### PR TITLE
fix(rules): align CC-HK-010 timeout thresholds with official docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Config structure enhanced with category-based toggles (legacy flags still supported)
 - Knowledge base docs refreshed (rule counts, AGENTS.md support tiers, Cursor rules)
 - Fixture layout aligned with detector paths to ensure validators exercise fixtures directly
-- CC-HK-010 now treats timeouts above the default limit as a soft warning
+- CC-HK-010 timeout thresholds now align with official Claude Code documentation
+  - Command hooks: warn when timeout > 600s (10-minute default)
+  - Prompt hooks: warn when timeout > 30s (30-second default)
 
 ### Performance
 - Significant speed improvements on projects with many files

--- a/knowledge-base/PATTERNS-CATALOG.md
+++ b/knowledge-base/PATTERNS-CATALOG.md
@@ -236,13 +236,20 @@ if !script_path.exists() {
 }
 ```
 
-### 6. No Timeout [MEDIUM]
+### 6. Timeout Policy [MEDIUM]
 
-**Pattern**: Long-running hook without timeout
+**Pattern**: Missing timeout or timeout exceeds type-specific defaults
 **Detection**:
 ```rust
-if hook.timeout.is_none() || hook.timeout.unwrap() > 60 {
-    warning!("Consider adding timeout (default 60s)");
+// Missing timeout
+if hook.timeout.is_none() {
+    warning!("Consider adding explicit timeout");
+}
+// Per-type threshold checks (only supported hook types)
+match hook.r#type.as_str() {
+    "command" => if timeout > 600 { warning!("Exceeds 10-min default"); }
+    "prompt" => if timeout > 30 { warning!("Exceeds 30s default"); }
+    _ => { /* timeout policy not defined for other hook types */ }
 }
 ```
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -238,12 +238,14 @@
 **Fix**: Warn, suggest safer alternative
 **Source**: awesome-slash/enhance-hooks
 
-### CC-HK-010 [MEDIUM] No Timeout Specified
-**Requirement**: Timeout is optional, but long-running hooks SHOULD set one
-**Detection**: `hook.timeout.is_none()`
-**Policy**: Soft warning if `hook.timeout > 60` (exceeds default limit; may be intentional)
-**Fix**: Add `"timeout": 30` (or reduce to <= 60 if unintentionally long)
-**Source**: docs.claude.com/en/docs/claude-code/hooks
+### CC-HK-010 [MEDIUM] Timeout Policy
+**Requirement**: Hooks SHOULD have explicit timeout; excessive timeouts warn
+**Detection**:
+  - `hook.timeout.is_none()` - missing timeout
+  - Command: `timeout > 600` exceeds 10-min default
+  - Prompt: `timeout > 30` exceeds 30s default
+**Fix**: Add explicit timeout within default limits (600s for commands, 30s for prompts)
+**Source**: code.claude.com/docs/en/hooks
 
 ### CC-HK-011 [HIGH] Invalid Timeout Value
 **Requirement**: timeout MUST be positive integer


### PR DESCRIPTION
## Summary
- Update CC-HK-010 timeout validation to use per-type thresholds based on official Claude Code hooks documentation
- Command hooks: warn when timeout > 600s (10-minute default)
- Prompt hooks: warn when timeout > 30s (30-second default)

## Changes
- Updated `crates/agnix-core/src/rules/hooks.rs` with per-type threshold checks
- Updated `knowledge-base/VALIDATION-RULES.md` with correct thresholds
- Updated `knowledge-base/PATTERNS-CATALOG.md` pattern description
- Added 4 new tests for threshold validation
- Added CHANGELOG entry

## Test plan
- [x] `cargo test` - all 418 tests pass
- [x] `cargo build --release` - builds successfully
- [x] CC-HK-010 tests validate both missing timeout and excessive timeout cases

Closes #77