### PR TITLE
perf(core): investigate streaming validation, add AGM-006 tests (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Investigated streaming validation with par_bridge() - current collect+par_iter approach found optimal for typical workloads (#83)
 
 ### Tests
-- Added AGM-006 validation pipeline tests for AGENTS.md path collection and files_checked counter (#83)
+- Added validation pipeline tests for AGENTS.md path collection and files_checked counter (#83)
 
 ### Changed
 - Narrowed agnix-core public API surface (#85)

--- a/crates/agnix-core/src/lib.rs
+++ b/crates/agnix-core/src/lib.rs
@@ -999,8 +999,8 @@ mod tests {
     }
 
     #[test]
-    fn test_streaming_validation_agents_md_collection() {
-        // Verify that streaming validation correctly collects AGENTS.md paths for AGM-006
+    fn test_validate_project_agents_md_collection() {
+        // Verify that validation correctly collects AGENTS.md paths for AGM-006
         let temp = tempfile::TempDir::new().unwrap();
 
         // Create multiple AGENTS.md files in different directories
@@ -1029,8 +1029,8 @@ mod tests {
     }
 
     #[test]
-    fn test_streaming_files_checked_count() {
-        // Verify that streaming validation correctly counts recognized file types
+    fn test_validate_project_files_checked_count() {
+        // Verify that validation correctly counts recognized file types
         let temp = tempfile::TempDir::new().unwrap();
 
         // Create recognized file types


### PR DESCRIPTION
## Summary

Investigation of streaming validation for issue #83:

- **Attempted**: Implemented `par_bridge()` streaming to avoid intermediate `Vec<PathBuf>` collection
- **Review finding**: Critical issues identified - Mutex contention, atomic overhead, worse work distribution than collect+par_iter
- **Decision**: Keep current collect+par_iter approach as it performs better for typical workloads (<10k files)

### Changes
- Minor code cleanup in AGM-006 path filtering logic
- Added `test_streaming_validation_agents_md_collection` - verifies correct AGENTS.md path collection
- Added `test_streaming_files_checked_count` - validates file counting accuracy
- Updated CHANGELOG with investigation results

### Technical Details

The original issue assumed that collecting all paths into a Vec before validation was a bottleneck. Investigation revealed:

1. Memory overhead of path Vec is negligible compared to I/O cost of file reads
2. `par_bridge()` has worse work distribution than `par_iter()` for rayon
3. Mutex contention in the parallel hot path defeats parallelization benefits
4. Atomic operations add unnecessary overhead for counters

## Test plan
- [x] All 855 tests pass
- [x] Clippy clean with `-D warnings`
- [x] Release build succeeds
- [x] New tests verify AGM-006 and files_checked behavior

Closes #83