### PR TITLE
fix(ci): enable GitHub Pages setup in docs workflow

### DIFF
--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - name: Configure Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        with:
+          enablement: true
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary
- add `enablement: true` to `actions/configure-pages` in docs deployment workflow
- prevents `Get Pages site failed ... Not Found` when Pages has not been enabled yet

## Validation
- workflow YAML updated in `.github/workflows/docs-site.yml`
- branch pushed for CI validation
