### PR TITLE
test(imports): add concurrency and multi-file cycle tests for ImportsValidator (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Confidence-tiered autofix engine**: `Fix` metadata now supports confidence, alternative groups, and dependencies; CLI adds `--fix-unsafe` and `--show-fixes`; core exposes confidence-based `FixApplyMode`/`FixApplyOptions`
 - **CI crate graph parity test**: New workspace-level test validates that all `Cargo.toml` workspace members are documented in CLAUDE.md, AGENTS.md, README.md, SPEC.md, and CONTRIBUTING.md - prevents architecture-doc drift
 - **`resolve_validation_root` file-input tests**: 7 integration tests covering single-file validation mode - validates file-input path behavior, unknown file type handling, project-level rule scoping, and nonexistent file edge case (#450)
-- **`ImportsValidator` concurrency and multi-file cycle tests**: 11 new tests covering thread-safety under concurrent validation, multi-file import cycles (3- and 4-file chains), depth boundary conditions (at, below, and above `MAX_IMPORT_DEPTH`), diamond dependency graphs, and mixed valid/invalid import scenarios (#456)
+- **`ImportsValidator` concurrency and multi-file cycle tests**: 11 new tests covering thread-safety under concurrent validation, multi-file import cycles (3- and 4-file chains), depth boundary conditions at and below `MAX_IMPORT_DEPTH` (complementing existing above-boundary coverage), diamond dependency graphs, and mixed valid/invalid import scenarios (#456)
 
 ### Changed
 - **Docs**: Updated architecture references in README.md, SPEC.md, CLAUDE.md, and AGENTS.md to explicitly include the `agnix-wasm` workspace crate

--- a/crates/agnix-core/src/rules/imports.rs
+++ b/crates/agnix-core/src/rules/imports.rs
@@ -1889,13 +1889,14 @@ mod tests {
 
     #[test]
     fn test_depth_at_boundary_no_trigger() {
-        // 6 files, 5 hops deep - exactly at MAX_IMPORT_DEPTH = 5.
-        // Deepest point: depth=5, check 5+1=6 > 5 is true, so CC-MEM-003 WOULD fire...
-        // wait - at depth=4 we try to recurse into e (depth+1=5 <= 5, allowed).
-        // At depth=5 (visiting e) we try to recurse into leaf (depth+1=6 > 5, TRIGGERS).
-        // This test verifies the boundary: a chain reaching depth 5 (leaf at depth 5)
-        // is reachable but a further import from leaf would trigger CC-MEM-003.
-        // Since leaf has no further imports, CC-MEM-003 should NOT fire.
+        // 6 files in a linear chain: CLAUDE -> a -> b -> c -> d -> leaf.
+        // There are 5 import hops, so the deepest file (leaf) is at depth=5.
+        // With MAX_IMPORT_DEPTH = 5 and the check `depth + 1 > MAX_IMPORT_DEPTH`:
+        // - At depth=4 (file d), recursing into leaf uses 4+1=5 > 5 (false), so it is allowed.
+        // - If leaf tried to import another file, that recursion would use 5+1=6 > 5 (true),
+        //   and CC-MEM-003 would trigger.
+        // This test verifies the boundary: a chain that reaches depth 5 is allowed as long as
+        // the leaf file has no further imports, so CC-MEM-003 should NOT fire.
         let temp = TempDir::new().unwrap();
         let claude = temp.path().join("CLAUDE.md");
         let a = temp.path().join("a.md");
@@ -1928,8 +1929,9 @@ mod tests {
     #[test]
     fn test_concurrent_cycle_detection_no_deadlock() {
         use std::collections::HashMap;
-        use std::sync::{Arc, RwLock};
+        use std::sync::{Arc, RwLock, mpsc};
         use std::thread;
+        use std::time::Duration;
 
         let temp = TempDir::new().unwrap();
         let claude = temp.path().join("CLAUDE.md");
@@ -1939,26 +1941,28 @@ mod tests {
         fs::write(&b, "@CLAUDE.md").unwrap();
 
         let cache: crate::parsers::ImportCache = Arc::new(RwLock::new(HashMap::new()));
+        let (tx, rx) = mpsc::channel();
 
-        let handles: Vec<_> = (0..8)
-            .map(|_| {
-                let cache = cache.clone();
-                let path = claude.clone();
-                let content = fs::read_to_string(&path).unwrap();
-                thread::spawn(move || {
-                    let mut config = LintConfig::default();
-                    config.set_import_cache(cache);
-                    config.set_root_dir(path.parent().unwrap().to_path_buf());
-                    let validator = ImportsValidator;
-                    validator.validate(&path, &content, &config)
-                })
-            })
-            .collect();
+        for _ in 0..8 {
+            let cache = cache.clone();
+            let path = claude.clone();
+            let content = fs::read_to_string(&path).unwrap();
+            let tx = tx.clone();
+            thread::spawn(move || {
+                let mut config = LintConfig::default();
+                config.set_import_cache(cache);
+                config.set_root_dir(path.parent().unwrap().to_path_buf());
+                let validator = ImportsValidator;
+                let result = validator.validate(&path, &content, &config);
+                tx.send(result).ok();
+            });
+        }
+        drop(tx);
 
-        for handle in handles {
-            let diagnostics = handle
-                .join()
-                .expect("Thread panicked during cycle detection");
+        for _ in 0..8 {
+            let diagnostics = rx
+                .recv_timeout(Duration::from_secs(10))
+                .expect("Thread did not complete within 10s (possible deadlock)");
             assert!(
                 diagnostics.iter().any(|d| d.rule == "CC-MEM-002"),
                 "Each thread should detect CC-MEM-002 in two-file cycle"


### PR DESCRIPTION
## Summary

- Add 11 new tests to the `ImportsValidator` inline test module covering gaps identified in issue #456
- No production code changes - purely additive test coverage

### Tests Added

**Multi-file circular chains**
- `test_cycle_detection_three_file_chain` - A→B→C→A (3-node cycle), verifies CC-MEM-002 fires and message contains the full cycle path
- `test_cycle_detection_four_file_chain` - A→B→C→D→A (4-node cycle), verifies CC-MEM-002 and cycle detection short-circuits before depth check
- `test_cycle_detection_three_file_chain_with_non_claude_root` - same 3-file cycle with SKILL.md root, verifies CC-MEM-002/003 are suppressed

**Depth boundary conditions**
- `test_depth_below_boundary_no_trigger` - 5-file chain (depth 4), well below MAX_IMPORT_DEPTH=5
- `test_depth_at_boundary_no_trigger` - 6-file chain (depth 5), exactly at MAX_IMPORT_DEPTH, verifies CC-MEM-003 does NOT fire

**Concurrent cache access**
- `test_concurrent_cycle_detection_no_deadlock` - 8 threads sharing `Arc<RwLock<HashMap>>` on a 2-file cycle
- `test_concurrent_three_file_cycle_shared_cache` - 10 threads on 3-file cycle, verifies cache populated for all 3 files
- `test_concurrent_cycle_near_depth_limit` - 5 threads on 5-file cycle at depth 4, verifies CC-MEM-002 fires and CC-MEM-003 does not
- `test_concurrent_diamond_dependency_no_duplicate_diagnostics` - diamond dependency (CLAUDE→{b,c}→shared→missing), asserts exactly 1 missing-import diagnostic per thread
- `test_concurrent_different_roots_shared_cache` - interleaved CLAUDE.md and SKILL.md threads sharing one cache; CLAUDE threads get CC-MEM-002, SKILL threads do not

**Mid-chain traversal**
- `test_missing_transitive_import_stops_traversal` - missing b.md in chain a.md→b.md stops recursion, c.md never referenced

## Test Plan

- [x] `cargo test --lib -p agnix-core -- rules::imports::tests --quiet` → 65/65 pass
- [x] `cargo test -p agnix-core` → full suite passes (2916 tests)
- [x] `cargo build -p agnix-core` → zero warnings

## Related Issues

Closes #456