### PR TITLE
chore: release v0.13.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 
 ## Current State
 
-- v0.12.4 - Production-ready with full validation pipeline
+- v0.13.0 - Production-ready with full validation pipeline
 - 230 validation rules across 25 validators
 
 - 3400+ passing tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-02-21
+
 ### Added
 - **XP-008 rule**: New MEDIUM-severity cross-platform rule that warns when CLAUDE.md contains Claude-specific directives (context:fork, agent fields, allowed-tools, hooks, @import) outside a guarded `## Claude Code` section, helping users targeting Cursor avoid silently-ignored configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 
 ## Current State
 
-- v0.12.4 - Production-ready with full validation pipeline
+- v0.13.0 - Production-ready with full validation pipeline
 - 230 validation rules across 25 validators
 
 - 3400+ passing tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -60,7 +60,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -92,14 +92,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.12.4"
+version = "0.13.0"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.12.4"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -31,8 +31,8 @@ categories = ["development-tools", "command-line-utilities"]
 
 [workspace.dependencies]
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.12.4" }
-agnix-core = { path = "crates/agnix-core", version = "0.12.4" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.13.0" }
+agnix-core = { path = "crates/agnix-core", version = "0.13.0" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
-  "version": "0.12.4",
-  "description": "Lint agent configurations before they break your workflow. 229 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "version": "0.13.0",
+  "description": "Lint agent configurations before they break your workflow. 230 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "[email protected]",

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agnix
 description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 230 rules across 10+ AI tools."
-version: 0.12.4
+version: 0.13.0
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 ---
 


### PR DESCRIPTION
## Summary
- Bump version from 0.12.4 to 0.13.0 (minor release)
- Move XP-008 changelog entry from Unreleased to 0.13.0 section

## Release Notes

### Added
- **XP-008 rule**: New cross-platform rule that warns when CLAUDE.md contains Claude-specific directives outside a guarded `## Claude Code` section when targeting Cursor, helping Cursor users avoid silently-ignored configuration

## Test Plan
- [x] All workspace tests pass
- [x] Version bumped in Cargo.toml, plugin.json, SKILL.md, CLAUDE.md, AGENTS.md
- [x] CHANGELOG.md updated with 0.13.0 section