### PR TITLE
fix(zed): remove mdc language definition per upstream review

### DIFF
--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -8,9 +8,8 @@ repository = "https://github.com/avifenesh/agnix"
 
 [language_servers.agnix-lsp]
 name = "agnix"
-languages = ["Markdown", "JSON", "MDC"]
+languages = ["Markdown", "JSON"]
 
 [language_servers.agnix-lsp.language_ids]
 "Markdown" = "markdown"
 "JSON" = "json"
-"MDC" = "markdown"

--- a/editors/zed/languages/mdc/config.toml
+++ b/editors/zed/languages/mdc/config.toml
@@ -1,5 +1,0 @@
-name = "MDC"
-grammar = "markdown"
-path_suffixes = ["mdc"]
-tab_size = 2
-hard_tabs = false


### PR DESCRIPTION
## Summary

- Remove the custom MDC language definition from the Zed extension
- Remove MDC from the language server languages list and language_ids
- Requested by Zed maintainer @MrSubidubi in [zed-industries/extensions#4743](https://github.com/zed-industries/extensions/pull/4743)

The `.mdc` suffix should be added as a recognized Markdown suffix in Zed core instead.

## Test plan

- Verify Zed extension still builds without the `languages/` directory
- Verify agnix LSP still activates for Markdown and JSON files