### PR TITLE
fix(zed): bump extension version to 0.13.0 [skip changelog]

### DIFF
--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.12.1"
+version = "0.13.0"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"


### PR DESCRIPTION
## Summary
- Bumps `editors/zed/extension.toml` version from 0.12.1 to 0.13.0 to match the current release
- Required for the zed-industries/extensions PR (package-extensions CI check)

## Test plan
- [ ] CI passes
- [ ] zed-industries/extensions package-extensions check passes after submodule update