### PR TITLE
docs: update Zed links to marketplace [skip changelog]

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>230 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
-<p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://github.com/agent-sh/agnix/tree/main/editors/zed">Zed</a></strong></p>
+<p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
 <p align="center">
   <a href="https://agent-sh.github.io/agnix/"><img src="https://img.shields.io/badge/Docs-Website-2563EB?style=for-the-badge" alt="Website"></a>

--- a/website/docs/editor-integration.md
+++ b/website/docs/editor-integration.md
@@ -52,7 +52,8 @@ The plugin auto-detects and downloads the `agnix-lsp` binary. For full setup ins
 
 ## Zed
 
-Install the agnix extension from the Zed extension marketplace, or see the
+Install the agnix extension from the
+[Zed extension marketplace](https://zed.dev/extensions?query=agnix), or see the
 [Zed extension README](https://github.com/avifenesh/agnix/tree/main/editors/zed).
 
 ## Other editors

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -50,6 +50,6 @@ agnix ships editor integrations powered by the `agnix-lsp` server:
 | VS Code | [Marketplace](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix) |
 | JetBrains | [Plugin](https://plugins.jetbrains.com/plugin/30087-agnix) |
 | Neovim | [Plugin](https://github.com/avifenesh/agnix.nvim) |
-| Zed | [Extension](https://github.com/avifenesh/agnix/tree/main/editors/zed) |
+| Zed | [Extension](https://zed.dev/extensions?query=agnix) |
 
 See [Editor Integration](./editor-integration.md) for setup details.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -175,7 +175,7 @@ const config = {
             },
             {
               label: 'Zed',
-              href: 'https://github.com/avifenesh/agnix/tree/main/editors/zed',
+              href: 'https://zed.dev/extensions?query=agnix',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- Updates Zed extension links across README, website docs, and navbar to point to the official Zed marketplace (`zed.dev/extensions?query=agnix`) now that the extension has been published via zed-industries/extensions#4743

## Changed files
- `README.md` - header extension link
- `website/docs/installation.md` - editor extensions table
- `website/docs/editor-integration.md` - added direct marketplace link
- `website/docusaurus.config.js` - navbar link

## Test plan
- [x] All links point to `https://zed.dev/extensions?query=agnix`
- [x] Versioned docs left unchanged (historical snapshots)