### PR TITLE
fix(rules): re-verify CUR-* rules against current Cursor docs

### DIFF
--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -55,7 +55,22 @@
       "cursor-rules": {
         "url": "https://cursor.com/docs/context/rules",
         "hash": "24529507938b37d3e3815e86b8c1c87cbaf78230c899854f0d74b2d5356c676a",
-        "rules": ["CUR-001", "CUR-002", "CUR-003", "CUR-004", "CUR-005", "CUR-006"]
+        "rules": ["CUR-001", "CUR-002", "CUR-003", "CUR-004", "CUR-005", "CUR-006", "CUR-007", "CUR-008", "CUR-009"]
+      },
+      "cursor-hooks": {
+        "url": "https://cursor.com/docs/agent/hooks",
+        "hash": "",
+        "rules": ["CUR-010", "CUR-011", "CUR-012", "CUR-013"]
+      },
+      "cursor-subagents": {
+        "url": "https://cursor.com/docs/context/subagents",
+        "hash": "",
+        "rules": ["CUR-014", "CUR-015"]
+      },
+      "cursor-environment": {
+        "url": "https://cursor.com/docs/cloud-agent/setup",
+        "hash": "",
+        "rules": ["CUR-016"]
       },
       "github-copilot": {
         "url": "https://docs.github.com/en/copilot/customizing-copilot",

--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -59,17 +59,17 @@
       },
       "cursor-hooks": {
         "url": "https://cursor.com/docs/agent/hooks",
-        "hash": "",
+        "hash": "4f55df64b01fe7d2c55a9d544eafdda070e35d7f84045c021f4a5ea9fcdd05d8",
         "rules": ["CUR-010", "CUR-011", "CUR-012", "CUR-013"]
       },
       "cursor-subagents": {
         "url": "https://cursor.com/docs/context/subagents",
-        "hash": "",
+        "hash": "f849221f0342190122e8411587e47f129c915902077da6995753f26c8a03cc9a",
         "rules": ["CUR-014", "CUR-015"]
       },
       "cursor-environment": {
         "url": "https://cursor.com/docs/cloud-agent/setup",
-        "hash": "",
+        "hash": "326a48176a4541dc5e1d94d7f1ef94c50a007dc4798b85e97e8ada5ec75e8a9e",
         "rules": ["CUR-016"]
       },
       "github-copilot": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CUR-016 environment.json validation rewritten**: Schema now matches the current Cursor Cloud Agent spec - `install` is required, `terminals` is optional (was previously required), and `build` (with `dockerfile` and `context`) and `update` fields are now validated. Snapshot-based approach replaced with field-level structural validation. Includes 12 new unit tests.
+- **CUR-001 to CUR-016 verified_on dates updated**: All 16 Cursor rules re-verified against current Cursor documentation on 2026-02-26.
+- **spec-baselines.json expanded**: Baseline entries added for CUR-007 through CUR-016 to enable cross-version regression detection.
+
 ### Changed
 - **Unified design system**: Import shared design tokens from agent-sh/design-system. Switch from Outfit to Inter font. Add font preconnect hints to Docusaurus config. Keeps teal accent and light/dark mode.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ agnix --target claude-code .  # Target specific tool
 | [Agent Skills](https://agentskills.io) | AS-\*, CC-SK-\* | 31 | SKILL.md |
 | [Claude Code](https://docs.anthropic.com/en/docs/build-with-claude/claude-code) | CC-\* | 53 | CLAUDE.md, hooks, agents, plugins |
 | [GitHub Copilot](https://docs.github.com/en/copilot) | COP-\* | 6 | .github/copilot-instructions.md, .github/instructions/\*.instructions.md |
-| [Cursor](https://cursor.com) | CUR-\* | 10 | .cursor/rules/\*.mdc, .cursorrules |
+| [Cursor](https://cursor.com) | CUR-\* | 16 | .cursor/rules/\*.mdc, .cursorrules, .cursor/hooks.json, .cursor/agents/\*\*/\*.md, .cursor/environment.json |
 | [MCP](https://modelcontextprotocol.io) | MCP-\* | 12 | \*.mcp.json |
 | [AGENTS.md](https://agentsmd.org) | AGM-\*, XP-\* | 13 | AGENTS.md, AGENTS.local.md, AGENTS.override.md |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | GM-\* | 9 | GEMINI.md, GEMINI.local.md, .gemini/settings.json (hooks), gemini-extension.json (extensions), .geminiignore |

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -530,15 +530,19 @@ rules:
     message: "Cursor subagent definition is empty after frontmatter"
     suggestion: "Add body instructions below the frontmatter section"
   cur_016:
-    message: ".cursor/environment.json must be an object with snapshot, install, and terminals"
+    message: ".cursor/environment.json must be an object with install (required) and optional start, update, build, terminals"
     parse_error: "Failed to parse .cursor/environment.json: %{error}"
-    snapshot: "Field 'snapshot' must be a string"
     install: "Field 'install' must be a string"
+    missing_install: "Field 'install' is required and must be a string"
     start: "Field 'start' must be a string when present"
-    missing_terminals: "Field 'terminals' is required and must be an array"
+    update: "Field 'update' must be a string when present"
+    invalid_build: "Field 'build' must be an object when present"
+    build_dockerfile: "Field 'build.dockerfile' must be a string when present"
+    build_context: "Field 'build.context' must be a string when present"
     invalid_terminals: "Field 'terminals' must be an array, got %{got}"
     terminal: "terminals[%{index}] must be an object with string fields 'name' and 'command'"
-    suggestion: "Use schema: {\"snapshot\":\"...\",\"install\":\"...\",\"start\":\"...\",\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
+    terminal_not_object: "terminals[%{index}] must be a JSON object"
+    suggestion: "Use schema: {\"install\":\"...\",\"start\":\"...\",\"build\":{\"dockerfile\":\"...\",\"context\":\"...\"},\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
 
   # --- Cline (cline.rs) ---
   cln_001:

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -530,21 +530,19 @@ rules:
     message: "Cursor subagent definition is empty after frontmatter"
     suggestion: "Add body instructions below the frontmatter section"
   cur_016:
-    message: ".cursor/environment.json must be an object with snapshot, install, and terminals"
+    message: ".cursor/environment.json must be an object with install (required) and optional start, update, build, terminals"
     parse_error: "Failed to parse .cursor/environment.json: %{error}"
-    snapshot: "Field 'snapshot' must be a string"
     install: "Field 'install' must be a string"
-    missing_install: "Field 'install' is required"
+    missing_install: "Field 'install' is required and must be a string"
     start: "Field 'start' must be a string when present"
     update: "Field 'update' must be a string when present"
+    invalid_build: "Field 'build' must be an object when present"
     build_dockerfile: "Field 'build.dockerfile' must be a string when present"
     build_context: "Field 'build.context' must be a string when present"
-    invalid_build: "Field 'build' must be an object when present"
-    missing_terminals: "Field 'terminals' is required and must be an array"
     invalid_terminals: "Field 'terminals' must be an array, got %{got}"
     terminal: "terminals[%{index}] must be an object with string fields 'name' and 'command'"
     terminal_not_object: "terminals[%{index}] must be a JSON object"
-    suggestion: "Use schema: {\"snapshot\":\"...\",\"install\":\"...\",\"start\":\"...\",\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
+    suggestion: "Use schema: {\"install\":\"...\",\"start\":\"...\",\"build\":{\"dockerfile\":\"...\",\"context\":\"...\"},\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
 
   # --- Cline (cline.rs) ---
   cln_001:

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -534,10 +534,16 @@ rules:
     parse_error: "Failed to parse .cursor/environment.json: %{error}"
     snapshot: "Field 'snapshot' must be a string"
     install: "Field 'install' must be a string"
+    missing_install: "Field 'install' is required"
     start: "Field 'start' must be a string when present"
+    update: "Field 'update' must be a string when present"
+    build_dockerfile: "Field 'build.dockerfile' must be a string when present"
+    build_context: "Field 'build.context' must be a string when present"
+    invalid_build: "Field 'build' must be an object when present"
     missing_terminals: "Field 'terminals' is required and must be an array"
     invalid_terminals: "Field 'terminals' must be an array, got %{got}"
     terminal: "terminals[%{index}] must be an object with string fields 'name' and 'command'"
+    terminal_not_object: "terminals[%{index}] must be a JSON object"
     suggestion: "Use schema: {\"snapshot\":\"...\",\"install\":\"...\",\"start\":\"...\",\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
 
   # --- Cline (cline.rs) ---

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -669,14 +669,8 @@ fn validate_cursor_environment_file(
         && start.as_str().is_none()
     {
         diagnostics.push(
-            Diagnostic::error(
-                path_buf.clone(),
-                1,
-                0,
-                "CUR-016",
-                t!("rules.cur_016.start"),
-            )
-            .with_suggestion(t!("rules.cur_016.suggestion")),
+            Diagnostic::error(path_buf.clone(), 1, 0, "CUR-016", t!("rules.cur_016.start"))
+                .with_suggestion(t!("rules.cur_016.suggestion")),
         );
     }
 
@@ -748,8 +742,7 @@ fn validate_cursor_environment_file(
                 for (index, terminal) in terminals.iter().enumerate() {
                     if let Some(obj) = terminal.as_object() {
                         let has_name = obj.get("name").and_then(JsonValue::as_str).is_some();
-                        let has_command =
-                            obj.get("command").and_then(JsonValue::as_str).is_some();
+                        let has_command = obj.get("command").and_then(JsonValue::as_str).is_some();
                         if !has_name || !has_command {
                             diagnostics.push(
                                 Diagnostic::error(
@@ -769,10 +762,7 @@ fn validate_cursor_environment_file(
                                 1,
                                 0,
                                 "CUR-016",
-                                t!(
-                                    "rules.cur_016.terminal_not_object",
-                                    index = index + 1
-                                ),
+                                t!("rules.cur_016.terminal_not_object", index = index + 1),
                             )
                             .with_suggestion(t!("rules.cur_016.suggestion")),
                         );
@@ -1593,9 +1583,8 @@ is_background: false
 
     #[test]
     fn test_cur_016_invalid_environment_schema() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":42,"terminals":[{"name":"main"}]}"#,
-        );
+        let diagnostics =
+            validate_cursor_environment(r#"{"install":42,"terminals":[{"name":"main"}]}"#);
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
@@ -1627,39 +1616,34 @@ is_background: false
         assert!(
             diagnostics.iter().all(|d| d.rule != "CUR-016"),
             "Missing terminals should not trigger CUR-016, got: {:?}",
-            diagnostics.iter().map(|d| (&d.rule, &d.message)).collect::<Vec<_>>()
+            diagnostics
+                .iter()
+                .map(|d| (&d.rule, &d.message))
+                .collect::<Vec<_>>()
         );
     }
 
     #[test]
     fn test_cur_016_environment_invalid_terminals_type() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":"npm ci","terminals":{}}"#,
-        );
+        let diagnostics = validate_cursor_environment(r#"{"install":"npm ci","terminals":{}}"#);
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
     #[test]
     fn test_cur_016_environment_start_must_be_string() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":"npm ci","start":42}"#,
-        );
+        let diagnostics = validate_cursor_environment(r#"{"install":"npm ci","start":42}"#);
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
     #[test]
     fn test_cur_016_environment_update_must_be_string() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":"npm ci","update":42}"#,
-        );
+        let diagnostics = validate_cursor_environment(r#"{"install":"npm ci","update":42}"#);
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
     #[test]
     fn test_cur_016_environment_build_must_be_object() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":"npm ci","build":"invalid"}"#,
-        );
+        let diagnostics = validate_cursor_environment(r#"{"install":"npm ci","build":"invalid"}"#);
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
@@ -1669,7 +1653,10 @@ is_background: false
             r#"{"install":"npm ci","build":{"dockerfile":42,"context":true}}"#,
         );
         let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
-        assert!(cur_016.len() >= 2, "Expected errors for both build.dockerfile and build.context");
+        assert!(
+            cur_016.len() >= 2,
+            "Expected errors for both build.dockerfile and build.context"
+        );
     }
 
     #[test]
@@ -1680,7 +1667,10 @@ is_background: false
         assert!(
             diagnostics.iter().all(|d| d.rule != "CUR-016"),
             "Valid build should not trigger CUR-016, got: {:?}",
-            diagnostics.iter().map(|d| (&d.rule, &d.message)).collect::<Vec<_>>()
+            diagnostics
+                .iter()
+                .map(|d| (&d.rule, &d.message))
+                .collect::<Vec<_>>()
         );
     }
 
@@ -1689,7 +1679,9 @@ is_background: false
         let diagnostics = validate_cursor_environment(r#"{"install":null}"#);
         let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
         assert!(
-            cur_016.iter().any(|d| d.message.contains("must be a string")),
+            cur_016
+                .iter()
+                .any(|d| d.message.contains("must be a string")),
             "install: null should trigger the install message, got: {:?}",
             cur_016.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
@@ -1697,21 +1689,22 @@ is_background: false
 
     #[test]
     fn test_cur_016_environment_valid_update() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":"npm ci","update":"apt-get update"}"#,
-        );
+        let diagnostics =
+            validate_cursor_environment(r#"{"install":"npm ci","update":"apt-get update"}"#);
         assert!(
             diagnostics.iter().all(|d| d.rule != "CUR-016"),
             "Valid update should not trigger CUR-016, got: {:?}",
-            diagnostics.iter().map(|d| (&d.rule, &d.message)).collect::<Vec<_>>()
+            diagnostics
+                .iter()
+                .map(|d| (&d.rule, &d.message))
+                .collect::<Vec<_>>()
         );
     }
 
     #[test]
     fn test_cur_016_environment_terminal_non_object() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":"npm ci","terminals":[42,"string"]}"#,
-        );
+        let diagnostics =
+            validate_cursor_environment(r#"{"install":"npm ci","terminals":[42,"string"]}"#);
         let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
         assert!(
             cur_016.len() >= 2,
@@ -1722,9 +1715,8 @@ is_background: false
 
     #[test]
     fn test_cur_016_environment_build_dockerfile_invalid() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":"npm ci","build":{"dockerfile":42}}"#,
-        );
+        let diagnostics =
+            validate_cursor_environment(r#"{"install":"npm ci","build":{"dockerfile":42}}"#);
         let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
         assert_eq!(
             cur_016.len(),
@@ -1736,9 +1728,8 @@ is_background: false
 
     #[test]
     fn test_cur_016_environment_build_context_invalid() {
-        let diagnostics = validate_cursor_environment(
-            r#"{"install":"npm ci","build":{"context":true}}"#,
-        );
+        let diagnostics =
+            validate_cursor_environment(r#"{"install":"npm ci","build":{"context":true}}"#);
         let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
         assert_eq!(
             cur_016.len(),
@@ -1752,8 +1743,7 @@ is_background: false
     fn test_cur_016_environment_snapshot_ignored() {
         // Snapshot is a UI concept, not part of the environment.json spec.
         // This regression test ensures we do not validate or reject it.
-        let diagnostics =
-            validate_cursor_environment(r#"{"install":"npm ci","snapshot":42}"#);
+        let diagnostics = validate_cursor_environment(r#"{"install":"npm ci","snapshot":42}"#);
         assert!(
             diagnostics.iter().all(|d| d.rule != "CUR-016"),
             "snapshot field should be silently ignored, got: {:?}",

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -601,12 +601,14 @@ fn validate_cursor_environment_file(
         return diagnostics;
     }
 
+    let path_buf = path.to_path_buf();
+
     let parsed = match serde_json::from_str::<JsonValue>(content) {
         Ok(value) => value,
         Err(error) => {
             diagnostics.push(
                 Diagnostic::error(
-                    path.to_path_buf(),
+                    path_buf.clone(),
                     1,
                     0,
                     "CUR-016",
@@ -623,7 +625,7 @@ fn validate_cursor_environment_file(
         None => {
             diagnostics.push(
                 Diagnostic::error(
-                    path.to_path_buf(),
+                    path_buf.clone(),
                     1,
                     0,
                     "CUR-016",
@@ -639,7 +641,7 @@ fn validate_cursor_environment_file(
         Some(v) if v.as_str().is_none() => {
             diagnostics.push(
                 Diagnostic::error(
-                    path.to_path_buf(),
+                    path_buf.clone(),
                     1,
                     0,
                     "CUR-016",
@@ -651,7 +653,7 @@ fn validate_cursor_environment_file(
         None => {
             diagnostics.push(
                 Diagnostic::error(
-                    path.to_path_buf(),
+                    path_buf.clone(),
                     1,
                     0,
                     "CUR-016",
@@ -668,7 +670,7 @@ fn validate_cursor_environment_file(
     {
         diagnostics.push(
             Diagnostic::error(
-                path.to_path_buf(),
+                path_buf.clone(),
                 1,
                 0,
                 "CUR-016",
@@ -683,7 +685,7 @@ fn validate_cursor_environment_file(
     {
         diagnostics.push(
             Diagnostic::error(
-                path.to_path_buf(),
+                path_buf.clone(),
                 1,
                 0,
                 "CUR-016",
@@ -701,7 +703,7 @@ fn validate_cursor_environment_file(
                 {
                     diagnostics.push(
                         Diagnostic::error(
-                            path.to_path_buf(),
+                            path_buf.clone(),
                             1,
                             0,
                             "CUR-016",
@@ -715,7 +717,7 @@ fn validate_cursor_environment_file(
                 {
                     diagnostics.push(
                         Diagnostic::error(
-                            path.to_path_buf(),
+                            path_buf.clone(),
                             1,
                             0,
                             "CUR-016",
@@ -728,7 +730,7 @@ fn validate_cursor_environment_file(
             None => {
                 diagnostics.push(
                     Diagnostic::error(
-                        path.to_path_buf(),
+                        path_buf.clone(),
                         1,
                         0,
                         "CUR-016",
@@ -751,7 +753,7 @@ fn validate_cursor_environment_file(
                         if !has_name || !has_command {
                             diagnostics.push(
                                 Diagnostic::error(
-                                    path.to_path_buf(),
+                                    path_buf.clone(),
                                     1,
                                     0,
                                     "CUR-016",
@@ -763,11 +765,14 @@ fn validate_cursor_environment_file(
                     } else {
                         diagnostics.push(
                             Diagnostic::error(
-                                path.to_path_buf(),
+                                path_buf.clone(),
                                 1,
                                 0,
                                 "CUR-016",
-                                t!("rules.cur_016.terminal", index = index + 1),
+                                t!(
+                                    "rules.cur_016.terminal_not_object",
+                                    index = index + 1
+                                ),
                             )
                             .with_suggestion(t!("rules.cur_016.suggestion")),
                         );
@@ -777,7 +782,7 @@ fn validate_cursor_environment_file(
             other => {
                 diagnostics.push(
                     Diagnostic::error(
-                        path.to_path_buf(),
+                        path_buf.clone(),
                         1,
                         0,
                         "CUR-016",
@@ -1676,6 +1681,70 @@ is_background: false
             diagnostics.iter().all(|d| d.rule != "CUR-016"),
             "Valid build should not trigger CUR-016, got: {:?}",
             diagnostics.iter().map(|d| (&d.rule, &d.message)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_cur_016_environment_install_null() {
+        let diagnostics = validate_cursor_environment(r#"{"install":null}"#);
+        let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
+        assert!(
+            cur_016.iter().any(|d| d.message.contains("must be a string")),
+            "install: null should trigger the install message, got: {:?}",
+            cur_016.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_cur_016_environment_valid_update() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","update":"apt-get update"}"#,
+        );
+        assert!(
+            diagnostics.iter().all(|d| d.rule != "CUR-016"),
+            "Valid update should not trigger CUR-016, got: {:?}",
+            diagnostics.iter().map(|d| (&d.rule, &d.message)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_cur_016_environment_terminal_non_object() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","terminals":[42,"string"]}"#,
+        );
+        let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
+        assert!(
+            cur_016.len() >= 2,
+            "Expected at least 2 CUR-016 errors for non-object terminal entries, got {}",
+            cur_016.len()
+        );
+    }
+
+    #[test]
+    fn test_cur_016_environment_build_dockerfile_invalid() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","build":{"dockerfile":42}}"#,
+        );
+        let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
+        assert_eq!(
+            cur_016.len(),
+            1,
+            "Expected exactly 1 CUR-016 error for invalid build.dockerfile, got: {:?}",
+            cur_016.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_cur_016_environment_build_context_invalid() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","build":{"context":true}}"#,
+        );
+        let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
+        assert_eq!(
+            cur_016.len(),
+            1,
+            "Expected exactly 1 CUR-016 error for invalid build.context, got: {:?}",
+            cur_016.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }
 

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -1749,6 +1749,23 @@ is_background: false
     }
 
     #[test]
+    fn test_cur_016_environment_snapshot_ignored() {
+        // Snapshot is a UI concept, not part of the environment.json spec.
+        // This regression test ensures we do not validate or reject it.
+        let diagnostics =
+            validate_cursor_environment(r#"{"install":"npm ci","snapshot":42}"#);
+        assert!(
+            diagnostics.iter().all(|d| d.rule != "CUR-016"),
+            "snapshot field should be silently ignored, got: {:?}",
+            diagnostics
+                .iter()
+                .filter(|d| d.rule == "CUR-016")
+                .map(|d| &d.message)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn test_cursor_hooks_agents_environment_valid() {
         let hooks =
             r#"{"version":1,"hooks":{"sessionStart":[{"type":"command","command":"echo start"}]}}"#;

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -635,32 +635,36 @@ fn validate_cursor_environment_file(
         }
     };
 
-    if root.get("snapshot").and_then(JsonValue::as_str).is_none() {
-        diagnostics.push(
-            Diagnostic::error(
-                path.to_path_buf(),
-                1,
-                0,
-                "CUR-016",
-                t!("rules.cur_016.snapshot"),
-            )
-            .with_suggestion(t!("rules.cur_016.suggestion")),
-        );
+    // install is required
+    match root.get("install") {
+        Some(v) if v.as_str().is_none() => {
+            diagnostics.push(
+                Diagnostic::error(
+                    path.to_path_buf(),
+                    1,
+                    0,
+                    "CUR-016",
+                    t!("rules.cur_016.install"),
+                )
+                .with_suggestion(t!("rules.cur_016.suggestion")),
+            );
+        }
+        None => {
+            diagnostics.push(
+                Diagnostic::error(
+                    path.to_path_buf(),
+                    1,
+                    0,
+                    "CUR-016",
+                    t!("rules.cur_016.missing_install"),
+                )
+                .with_suggestion(t!("rules.cur_016.suggestion")),
+            );
+        }
+        _ => {}
     }
 
-    if root.get("install").and_then(JsonValue::as_str).is_none() {
-        diagnostics.push(
-            Diagnostic::error(
-                path.to_path_buf(),
-                1,
-                0,
-                "CUR-016",
-                t!("rules.cur_016.install"),
-            )
-            .with_suggestion(t!("rules.cur_016.suggestion")),
-        );
-    }
-
+    // start is optional but must be a string when present
     if let Some(start) = root.get("start")
         && start.as_str().is_none()
     {
@@ -676,13 +680,92 @@ fn validate_cursor_environment_file(
         );
     }
 
-    match root.get("terminals") {
-        Some(JsonValue::Array(terminals)) => {
-            for (index, terminal) in terminals.iter().enumerate() {
-                if let Some(obj) = terminal.as_object() {
-                    let has_name = obj.get("name").and_then(JsonValue::as_str).is_some();
-                    let has_command = obj.get("command").and_then(JsonValue::as_str).is_some();
-                    if !has_name || !has_command {
+    // update is optional but must be a string when present
+    if let Some(update) = root.get("update")
+        && update.as_str().is_none()
+    {
+        diagnostics.push(
+            Diagnostic::error(
+                path.to_path_buf(),
+                1,
+                0,
+                "CUR-016",
+                t!("rules.cur_016.update"),
+            )
+            .with_suggestion(t!("rules.cur_016.suggestion")),
+        );
+    }
+
+    // build is optional but must be an object with string dockerfile and context when present
+    if let Some(build) = root.get("build") {
+        match build.as_object() {
+            Some(build_obj) => {
+                if let Some(dockerfile) = build_obj.get("dockerfile")
+                    && dockerfile.as_str().is_none()
+                {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            path.to_path_buf(),
+                            1,
+                            0,
+                            "CUR-016",
+                            t!("rules.cur_016.build_dockerfile"),
+                        )
+                        .with_suggestion(t!("rules.cur_016.suggestion")),
+                    );
+                }
+                if let Some(context) = build_obj.get("context")
+                    && context.as_str().is_none()
+                {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            path.to_path_buf(),
+                            1,
+                            0,
+                            "CUR-016",
+                            t!("rules.cur_016.build_context"),
+                        )
+                        .with_suggestion(t!("rules.cur_016.suggestion")),
+                    );
+                }
+            }
+            None => {
+                diagnostics.push(
+                    Diagnostic::error(
+                        path.to_path_buf(),
+                        1,
+                        0,
+                        "CUR-016",
+                        t!("rules.cur_016.invalid_build"),
+                    )
+                    .with_suggestion(t!("rules.cur_016.suggestion")),
+                );
+            }
+        }
+    }
+
+    // terminals is optional but must be an array of objects when present
+    if let Some(terminals_value) = root.get("terminals") {
+        match terminals_value {
+            JsonValue::Array(terminals) => {
+                for (index, terminal) in terminals.iter().enumerate() {
+                    if let Some(obj) = terminal.as_object() {
+                        let has_name = obj.get("name").and_then(JsonValue::as_str).is_some();
+                        let has_command =
+                            obj.get("command").and_then(JsonValue::as_str).is_some();
+                        if !has_name || !has_command {
+                            diagnostics.push(
+                                Diagnostic::error(
+                                    path.to_path_buf(),
+                                    1,
+                                    0,
+                                    "CUR-016",
+                                    t!("rules.cur_016.terminal", index = index + 1),
+                                )
+                                .with_suggestion(t!("rules.cur_016.suggestion")),
+                            );
+                        }
+                    } else {
                         diagnostics.push(
                             Diagnostic::error(
                                 path.to_path_buf(),
@@ -694,43 +777,24 @@ fn validate_cursor_environment_file(
                             .with_suggestion(t!("rules.cur_016.suggestion")),
                         );
                     }
-                } else {
-                    diagnostics.push(
-                        Diagnostic::error(
-                            path.to_path_buf(),
-                            1,
-                            0,
-                            "CUR-016",
-                            t!("rules.cur_016.terminal", index = index + 1),
-                        )
-                        .with_suggestion(t!("rules.cur_016.suggestion")),
-                    );
                 }
             }
+            other => {
+                diagnostics.push(
+                    Diagnostic::error(
+                        path.to_path_buf(),
+                        1,
+                        0,
+                        "CUR-016",
+                        t!(
+                            "rules.cur_016.invalid_terminals",
+                            got = json_type_name(other)
+                        ),
+                    )
+                    .with_suggestion(t!("rules.cur_016.suggestion")),
+                );
+            }
         }
-        Some(other) => diagnostics.push(
-            Diagnostic::error(
-                path.to_path_buf(),
-                1,
-                0,
-                "CUR-016",
-                t!(
-                    "rules.cur_016.invalid_terminals",
-                    got = json_type_name(other)
-                ),
-            )
-            .with_suggestion(t!("rules.cur_016.suggestion")),
-        ),
-        None => diagnostics.push(
-            Diagnostic::error(
-                path.to_path_buf(),
-                1,
-                0,
-                "CUR-016",
-                t!("rules.cur_016.missing_terminals"),
-            )
-            .with_suggestion(t!("rules.cur_016.suggestion")),
-        ),
     }
 
     diagnostics
@@ -1529,41 +1593,97 @@ is_background: false
 
     #[test]
     fn test_cur_016_invalid_environment_schema() {
+        // install must be a string, not a number
         let diagnostics = validate_cursor_environment(
-            r#"{"snapshot":42,"install":"npm ci","terminals":[{"name":"main"}]}"#,
+            r#"{"install":42,"terminals":[{"name":"main"}]}"#,
         );
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
     #[test]
     fn test_cur_016_environment_parse_error() {
-        let diagnostics = validate_cursor_environment(r#"{"snapshot":"ubuntu","install":}"#);
+        let diagnostics = validate_cursor_environment(r#"{"install":}"#);
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
     #[test]
     fn test_cur_016_environment_root_must_be_object() {
-        let diagnostics = validate_cursor_environment(r#"["snapshot","install","terminals"]"#);
+        let diagnostics = validate_cursor_environment(r#"["install","terminals"]"#);
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
     #[test]
-    fn test_cur_016_environment_missing_or_invalid_terminals() {
-        let missing = validate_cursor_environment(r#"{"snapshot":"ubuntu","install":"npm ci"}"#);
-        assert!(missing.iter().any(|d| d.rule == "CUR-016"));
-
-        let invalid_type = validate_cursor_environment(
-            r#"{"snapshot":"ubuntu","install":"npm ci","terminals":{}}"#,
+    fn test_cur_016_environment_missing_install() {
+        // install is required
+        let diagnostics = validate_cursor_environment(r#"{"start":"npm run dev"}"#);
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "CUR-016"),
+            "Missing install should trigger CUR-016"
         );
-        assert!(invalid_type.iter().any(|d| d.rule == "CUR-016"));
+    }
+
+    #[test]
+    fn test_cur_016_environment_terminals_optional() {
+        // terminals is now optional - no error without it
+        let diagnostics = validate_cursor_environment(r#"{"install":"npm ci"}"#);
+        assert!(
+            diagnostics.iter().all(|d| d.rule != "CUR-016"),
+            "Missing terminals should not trigger CUR-016, got: {:?}",
+            diagnostics.iter().map(|d| (&d.rule, &d.message)).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_cur_016_environment_invalid_terminals_type() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","terminals":{}}"#,
+        );
+        assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
     }
 
     #[test]
     fn test_cur_016_environment_start_must_be_string() {
         let diagnostics = validate_cursor_environment(
-            r#"{"snapshot":"ubuntu","install":"npm ci","start":42,"terminals":[{"name":"app","command":"npm run dev"}]}"#,
+            r#"{"install":"npm ci","start":42}"#,
         );
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
+    }
+
+    #[test]
+    fn test_cur_016_environment_update_must_be_string() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","update":42}"#,
+        );
+        assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
+    }
+
+    #[test]
+    fn test_cur_016_environment_build_must_be_object() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","build":"invalid"}"#,
+        );
+        assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
+    }
+
+    #[test]
+    fn test_cur_016_environment_build_fields_must_be_strings() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","build":{"dockerfile":42,"context":true}}"#,
+        );
+        let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
+        assert!(cur_016.len() >= 2, "Expected errors for both build.dockerfile and build.context");
+    }
+
+    #[test]
+    fn test_cur_016_environment_valid_build() {
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","build":{"dockerfile":"Dockerfile","context":".."}}"#,
+        );
+        assert!(
+            diagnostics.iter().all(|d| d.rule != "CUR-016"),
+            "Valid build should not trigger CUR-016, got: {:?}",
+            diagnostics.iter().map(|d| (&d.rule, &d.message)).collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -1579,9 +1699,9 @@ is_background: false
 ---
 Review the diff and suggest improvements."#;
         let environment = r#"{
-  "snapshot": "ubuntu-24.04",
   "install": "npm ci",
   "start": "npm run dev",
+  "build": {"dockerfile": "Dockerfile", "context": ".."},
   "terminals": [{"name": "app", "command": "npm run dev"}]
 }"#;
 

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -635,7 +635,6 @@ fn validate_cursor_environment_file(
         }
     };
 
-    // install is required
     match root.get("install") {
         Some(v) if v.as_str().is_none() => {
             diagnostics.push(
@@ -664,7 +663,6 @@ fn validate_cursor_environment_file(
         _ => {}
     }
 
-    // start is optional but must be a string when present
     if let Some(start) = root.get("start")
         && start.as_str().is_none()
     {
@@ -680,7 +678,6 @@ fn validate_cursor_environment_file(
         );
     }
 
-    // update is optional but must be a string when present
     if let Some(update) = root.get("update")
         && update.as_str().is_none()
     {
@@ -696,7 +693,6 @@ fn validate_cursor_environment_file(
         );
     }
 
-    // build is optional but must be an object with string dockerfile and context when present
     if let Some(build) = root.get("build") {
         match build.as_object() {
             Some(build_obj) => {
@@ -744,7 +740,6 @@ fn validate_cursor_environment_file(
         }
     }
 
-    // terminals is optional but must be an array of objects when present
     if let Some(terminals_value) = root.get("terminals") {
         match terminals_value {
             JsonValue::Array(terminals) => {
@@ -1593,7 +1588,6 @@ is_background: false
 
     #[test]
     fn test_cur_016_invalid_environment_schema() {
-        // install must be a string, not a number
         let diagnostics = validate_cursor_environment(
             r#"{"install":42,"terminals":[{"name":"main"}]}"#,
         );
@@ -1614,7 +1608,6 @@ is_background: false
 
     #[test]
     fn test_cur_016_environment_missing_install() {
-        // install is required
         let diagnostics = validate_cursor_environment(r#"{"start":"npm run dev"}"#);
         assert!(
             diagnostics.iter().any(|d| d.rule == "CUR-016"),

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -530,15 +530,19 @@ rules:
     message: "Cursor subagent definition is empty after frontmatter"
     suggestion: "Add body instructions below the frontmatter section"
   cur_016:
-    message: ".cursor/environment.json must be an object with snapshot, install, and terminals"
+    message: ".cursor/environment.json must be an object with install (required) and optional start, update, build, terminals"
     parse_error: "Failed to parse .cursor/environment.json: %{error}"
-    snapshot: "Field 'snapshot' must be a string"
     install: "Field 'install' must be a string"
+    missing_install: "Field 'install' is required and must be a string"
     start: "Field 'start' must be a string when present"
-    missing_terminals: "Field 'terminals' is required and must be an array"
+    update: "Field 'update' must be a string when present"
+    invalid_build: "Field 'build' must be an object when present"
+    build_dockerfile: "Field 'build.dockerfile' must be a string when present"
+    build_context: "Field 'build.context' must be a string when present"
     invalid_terminals: "Field 'terminals' must be an array, got %{got}"
     terminal: "terminals[%{index}] must be an object with string fields 'name' and 'command'"
-    suggestion: "Use schema: {\"snapshot\":\"...\",\"install\":\"...\",\"start\":\"...\",\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
+    terminal_not_object: "terminals[%{index}] must be a JSON object"
+    suggestion: "Use schema: {\"install\":\"...\",\"start\":\"...\",\"build\":{\"dockerfile\":\"...\",\"context\":\"...\"},\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
 
   # --- Cline (cline.rs) ---
   cln_001:

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -3642,7 +3642,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3669,7 +3669,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3697,7 +3697,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3724,7 +3724,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3751,7 +3751,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3779,7 +3779,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3806,7 +3806,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3834,7 +3834,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3862,7 +3862,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3889,7 +3889,7 @@
         "source_urls": [
           "https://cursor.com/docs/agent/hooks"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3916,7 +3916,7 @@
         "source_urls": [
           "https://cursor.com/docs/agent/hooks"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3944,7 +3944,7 @@
         "source_urls": [
           "https://cursor.com/docs/agent/hooks"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3971,7 +3971,7 @@
         "source_urls": [
           "https://cursor.com/docs/agent/hooks"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3999,7 +3999,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/subagents"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -4026,7 +4026,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/subagents"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -4051,9 +4051,9 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://cursor.com/docs/cloud-agent"
+          "https://cursor.com/docs/cloud-agent/setup"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -4067,8 +4067,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\"snapshot\":\"ubuntu-24.04\",\"install\":\"npm ci\",\"start\":\"npm run dev\",\"terminals\":[{\"name\":\"app\",\"command\":\"npm run dev\"}]}",
-      "bad_example": "{\"snapshot\":42,\"install\":\"npm ci\",\"terminals\":[{\"name\":\"app\"}]}"
+      "good_example": "{\"build\":{\"dockerfile\":\"Dockerfile\",\"context\":\"..\"},\"install\":\"npm ci\",\"start\":\"npm run dev\",\"terminals\":[{\"name\":\"app\",\"command\":\"npm run dev\"}]}",
+      "bad_example": "{\"install\":42,\"terminals\":[{\"name\":\"app\"}]}"
     },
     {
       "id": "CX-SK-001",

--- a/knowledge-base/MONTHLY-REVIEW.md
+++ b/knowledge-base/MONTHLY-REVIEW.md
@@ -50,6 +50,9 @@ These tools have automated monthly monitoring. Review confirms accuracy and chec
 - https://docs.github.com/en/copilot/customizing-copilot
 - https://docs.cline.bot/features/cline-rules/overview
 - https://cursor.com/docs/context/rules
+- https://cursor.com/docs/agent/hooks
+- https://cursor.com/docs/context/subagents
+- https://cursor.com/docs/cloud-agent/setup
 
 ### B/C Tier: Roo Code, Kiro CLI, amp, pi, gemini cli, continue, Antigravity
 
@@ -144,7 +147,7 @@ After completing the review:
 | Tool/Category | Rule Count | Coverage Status |
 |--------------|------------|-----------------|
 | Claude Code (CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL) | 50+ | Comprehensive |
-| Cursor (CUR-*) | 6 | Good - covers core validation |
+| Cursor (CUR-*) | 16 | Comprehensive - covers rules, hooks, subagents, environment |
 | GitHub Copilot (COP-*) | 6 | Good - covers instruction files and validation |
 | AGENTS.md (AGM-*) | 6 | Good - covers structure and cross-platform |
 | MCP (MCP-*) | 8 | Good - covers protocol compliance |
@@ -167,7 +170,7 @@ After completing the review:
 #### Findings
 
 1. **S-tier coverage is strong**: Claude Code has 50+ rules covering skills, hooks, memory, agents, and plugins. Codex CLI and OpenCode share AGM and XP rules.
-2. **A-tier has good baseline**: Cursor (6 rules), Copilot (4 rules), and Cline (monitored) provide adequate coverage for the most common config patterns.
+2. **A-tier has good baseline**: Cursor (16 rules), Copilot (4 rules), and Cline (monitored) provide adequate coverage for the most common config patterns.
 3. **B/C/D tier gaps exist**: Roo Code, Kiro CLI, amp, pi, Continue, and Aider have no tool-specific rules. These tools rely on generic rules (AS-*, XP-*, AGM-*) where applicable.
 4. **No spec drift detected**: All S-tier and A-tier baselines current as of February 2026.
 5. **Issue templates needed**: Added rule contribution and tool support request templates to streamline community contributions for uncovered tools.

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -26,7 +26,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml) | Monthly | 2026-02-05 | COP |
 | Cline | `.clinerules`, `.cline/rules/*.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml) | Monthly | 2026-02-05 | -- |
-| Cursor | `.cursor/rules/*.mdc`, `.cursorrules` | https://cursor.com/docs/context/rules | Automated (spec-drift.yml) | Monthly | 2026-02-05 | CUR |
+| Cursor | `.cursor/rules/*.mdc`, `.cursorrules` | https://cursor.com/docs/context/rules | Automated (spec-drift.yml) | Monthly | 2026-02-26 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 
@@ -85,7 +85,10 @@ Authoritative sources monitored for changes that may affect validation rules.
 | Claude Code - Sub-agents | https://code.claude.com/docs/en/sub-agents | spec-drift.yml (weekly) | CC-AG-001 through CC-AG-007 |
 | Codex CLI - AGENTS.md | https://developers.openai.com/codex/guides/agents-md/ | spec-drift.yml (weekly) | AGM-001 through AGM-006, XP-001 through XP-006 |
 | OpenCode - Rules | https://opencode.ai/docs/rules/ | spec-drift.yml (weekly) | XP-001 through XP-006 |
-| Cursor - Rules | https://cursor.com/docs/context/rules | spec-drift.yml (monthly) | CUR-001 through CUR-006 |
+| Cursor - Rules | https://cursor.com/docs/context/rules | spec-drift.yml (monthly) | CUR-001 through CUR-009 |
+| Cursor - Hooks | https://cursor.com/docs/agent/hooks | spec-drift.yml (monthly) | CUR-010 through CUR-013 |
+| Cursor - Subagents | https://cursor.com/docs/context/subagents | spec-drift.yml (monthly) | CUR-014, CUR-015 |
+| Cursor - Environment | https://cursor.com/docs/cloud-agent/setup | spec-drift.yml (monthly) | CUR-016 |
 | GitHub Copilot | https://docs.github.com/en/copilot/customizing-copilot | spec-drift.yml (monthly) | COP-001 through COP-006 |
 | Cline - Rules | https://docs.cline.bot/features/cline-rules/overview | spec-drift.yml (monthly) | -- |
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -2,7 +2,7 @@
 
 > Consolidated from 320KB knowledge base, 75+ sources, 5 research agents
 
-**Last Updated**: 2026-02-14
+**Last Updated**: 2026-02-26
 **Coverage**: Agent Skills • MCP • Claude Code • Cursor • Multi-Platform • Prompt Engineering
 
 ---

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -1202,63 +1202,63 @@ Rules with an empty `applies_to` object (`{}`) apply universally.
 **Requirement**: Cursor .mdc rule files MUST have non-empty content
 **Detection**: `content.trim().is_empty()` after stripping frontmatter
 **Fix**: Add meaningful rules content
-**Source**: docs.cursor.com/en/context
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-002"></a>
 ### CUR-002 [MEDIUM] Missing Frontmatter in .mdc File
 **Requirement**: Cursor .mdc files SHOULD have YAML frontmatter with metadata
 **Detection**: File doesn't start with `---` markers
-**Fix**: Auto-fix (unsafe) -- insert template frontmatter with description and globs fields
-**Source**: docs.cursor.com/en/context
+**Fix**: Auto-fix (unsafe) - insert template frontmatter with description and globs fields
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-003"></a>
 ### CUR-003 [HIGH] Invalid YAML Frontmatter
 **Requirement**: .mdc file frontmatter MUST be valid YAML
 **Detection**: YAML parse error on frontmatter content
 **Fix**: Fix YAML syntax errors in frontmatter
-**Source**: docs.cursor.com/en/context
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-004"></a>
 ### CUR-004 [HIGH] Invalid Glob Pattern in globs Field
 **Requirement**: `globs` field MUST contain valid glob patterns
 **Detection**: Attempt to parse as glob pattern
 **Fix**: Correct the glob syntax
-**Source**: docs.cursor.com/en/context
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-005"></a>
 ### CUR-005 [MEDIUM] Unknown Frontmatter Keys
 **Requirement**: .mdc frontmatter SHOULD only contain known keys (description, globs, alwaysApply)
 **Detection**: Check for keys other than known keys in frontmatter
 **Fix**: Remove unknown keys
-**Source**: docs.cursor.com/en/context
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-006"></a>
 ### CUR-006 [MEDIUM] Legacy .cursorrules File Detected
 **Requirement**: Projects SHOULD migrate from .cursorrules to .cursor/rules/*.mdc format
 **Detection**: File named `.cursorrules`
 **Fix**: Create `.cursor/rules/` directory and migrate rules to .mdc files
-**Source**: docs.cursor.com/en/context
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-007"></a>
 ### CUR-007 [MEDIUM] alwaysApply with Redundant globs
 **Requirement**: When `alwaysApply: true`, the `globs` field SHOULD NOT be set (it is redundant)
 **Detection**: Frontmatter has both `alwaysApply: true` and a `globs` field
 **Fix**: [AUTO-FIX] Remove the `globs` field (safe)
-**Source**: docs.cursor.com/en/context
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-008"></a>
 ### CUR-008 [HIGH] Invalid alwaysApply Type
 **Requirement**: `alwaysApply` MUST be a boolean (`true`/`false`), not a quoted string
 **Detection**: `alwaysApply` value is a string (e.g., `"true"` or `"false"`) instead of a boolean
-**Fix**: Auto-fix (safe) -- convert quoted string to unquoted boolean
-**Source**: docs.cursor.com/en/context
+**Fix**: Auto-fix (safe) - convert quoted string to unquoted boolean
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-009"></a>
 ### CUR-009 [MEDIUM] Missing Description for Agent-Requested Rule
 **Requirement**: Rules with no `alwaysApply` and no `globs` (agent-requested rules) SHOULD have a `description`
 **Detection**: Frontmatter has no `alwaysApply`, no `globs`, and no `description` (or empty description)
 **Fix**: Add a `description` field explaining when the rule should apply
-**Source**: docs.cursor.com/en/context
+**Source**: cursor.com/docs/context/rules
 
 <a id="cur-010"></a>
 ### CUR-010 [HIGH] Invalid .cursor/hooks.json Schema
@@ -1304,10 +1304,10 @@ Rules with an empty `applies_to` object (`{}`) apply universally.
 
 <a id="cur-016"></a>
 ### CUR-016 [HIGH] Invalid .cursor/environment.json Schema
-**Requirement**: `.cursor/environment.json` MUST be an object with string `snapshot`, string `install`, and array `terminals`
-**Detection**: Parse JSON and validate required fields plus terminal entry structure
+**Requirement**: `.cursor/environment.json` MUST be an object with string `install` (required), optional string `start`, optional array `terminals`, optional object `build` (with string `dockerfile` and `context`), and optional string `update`
+**Detection**: Parse JSON and validate required fields plus terminal entry and build object structure
 **Fix**: Provide required fields and valid terminal objects (`name`, `command`)
-**Source**: cursor.com/docs/cloud-agent
+**Source**: cursor.com/docs/cloud-agent/setup
 
 ---
 

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -3642,7 +3642,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3669,7 +3669,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3697,7 +3697,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3724,7 +3724,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3751,7 +3751,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3779,7 +3779,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3806,7 +3806,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3834,7 +3834,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3862,7 +3862,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/rules"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3889,7 +3889,7 @@
         "source_urls": [
           "https://cursor.com/docs/agent/hooks"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3916,7 +3916,7 @@
         "source_urls": [
           "https://cursor.com/docs/agent/hooks"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3944,7 +3944,7 @@
         "source_urls": [
           "https://cursor.com/docs/agent/hooks"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3971,7 +3971,7 @@
         "source_urls": [
           "https://cursor.com/docs/agent/hooks"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -3999,7 +3999,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/subagents"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -4026,7 +4026,7 @@
         "source_urls": [
           "https://cursor.com/docs/context/subagents"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -4051,9 +4051,9 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://cursor.com/docs/cloud-agent"
+          "https://cursor.com/docs/cloud-agent/setup"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-02-26",
         "applies_to": {
           "tool": "cursor"
         },
@@ -4067,8 +4067,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\"snapshot\":\"ubuntu-24.04\",\"install\":\"npm ci\",\"start\":\"npm run dev\",\"terminals\":[{\"name\":\"app\",\"command\":\"npm run dev\"}]}",
-      "bad_example": "{\"snapshot\":42,\"install\":\"npm ci\",\"terminals\":[{\"name\":\"app\"}]}"
+      "good_example": "{\"build\":{\"dockerfile\":\"Dockerfile\",\"context\":\"..\"},\"install\":\"npm ci\",\"start\":\"npm run dev\",\"terminals\":[{\"name\":\"app\",\"command\":\"npm run dev\"}]}",
+      "bad_example": "{\"install\":42,\"terminals\":[{\"name\":\"app\"}]}"
     },
     {
       "id": "CX-SK-001",

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -530,15 +530,18 @@ rules:
     message: "Cursor subagent definition is empty after frontmatter"
     suggestion: "Add body instructions below the frontmatter section"
   cur_016:
-    message: ".cursor/environment.json must be an object with snapshot, install, and terminals"
+    message: ".cursor/environment.json must be an object with install (required) and optional start, update, build, terminals"
     parse_error: "Failed to parse .cursor/environment.json: %{error}"
-    snapshot: "Field 'snapshot' must be a string"
     install: "Field 'install' must be a string"
+    missing_install: "Field 'install' is required and must be a string"
     start: "Field 'start' must be a string when present"
-    missing_terminals: "Field 'terminals' is required and must be an array"
+    update: "Field 'update' must be a string when present"
+    invalid_build: "Field 'build' must be an object when present"
+    build_dockerfile: "Field 'build.dockerfile' must be a string when present"
+    build_context: "Field 'build.context' must be a string when present"
     invalid_terminals: "Field 'terminals' must be an array, got %{got}"
     terminal: "terminals[%{index}] must be an object with string fields 'name' and 'command'"
-    suggestion: "Use schema: {\"snapshot\":\"...\",\"install\":\"...\",\"start\":\"...\",\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
+    suggestion: "Use schema: {\"install\":\"...\",\"start\":\"...\",\"build\":{\"dockerfile\":\"...\",\"context\":\"...\"},\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
 
   # --- Cline (cline.rs) ---
   cln_001:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -541,6 +541,7 @@ rules:
     build_context: "Field 'build.context' must be a string when present"
     invalid_terminals: "Field 'terminals' must be an array, got %{got}"
     terminal: "terminals[%{index}] must be an object with string fields 'name' and 'command'"
+    terminal_not_object: "terminals[%{index}] must be a JSON object"
     suggestion: "Use schema: {\"install\":\"...\",\"start\":\"...\",\"build\":{\"dockerfile\":\"...\",\"context\":\"...\"},\"terminals\":[{\"name\":\"...\",\"command\":\"...\"}]}"
 
   # --- Cline (cline.rs) ---

--- a/tests/fixtures/cursor-invalid/environment-cur016/.cursor/environment.json
+++ b/tests/fixtures/cursor-invalid/environment-cur016/.cursor/environment.json
@@ -1,6 +1,5 @@
 {
-  "snapshot": 42,
-  "install": "npm ci",
+  "install": 42,
   "terminals": [
     {
       "name": "app"

--- a/tests/fixtures/cursor/.cursor/environment.json
+++ b/tests/fixtures/cursor/.cursor/environment.json
@@ -1,5 +1,8 @@
 {
-  "snapshot": "ubuntu-24.04",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
   "install": "npm ci",
   "start": "npm run dev",
   "terminals": [


### PR DESCRIPTION
## Summary

- Re-verified all 16 CUR-* rules (CUR-001 to CUR-016) against current Cursor documentation
- Fixed CUR-016 environment.json validation: removed `snapshot` (UI-managed, not in JSON spec), made `terminals` optional, added `build` object and `update` string validation
- Updated all `verified_on` dates to 2026-02-26
- Fixed source URLs in VALIDATION-RULES.md (`docs.cursor.com/en/context` -> `cursor.com/docs/context/rules`)
- Expanded spec-baselines.json to track CUR-007 through CUR-016 (was only CUR-001 to CUR-006)
- Synced locale files, removed stale keys (`snapshot`, `missing_terminals`)
- Added 12 new unit tests for CUR-016 validation paths

## Test Plan

- `cargo test` passes all 3500+ tests across the full workspace
- New tests cover: install null, valid update, terminal non-object entries, individual build subfield validation, snapshot ignored regression
- Locale sync verified (byte-identical across all crate copies)
- rules.json parity verified (knowledge-base and agnix-rules copies identical)

## Related Issues

Closes #568