### PR TITLE
fix: strengthen .txt test coverage and docs for #565

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ agnix --target claude-code .  # Target specific tool
 | [Cursor](https://cursor.com) | CUR-\* | 16 | .cursor/rules/\*.mdc, .cursorrules, .cursor/hooks.json, .cursor/agents/\*\*/\*.md, .cursor/environment.json |
 | [MCP](https://modelcontextprotocol.io) | MCP-\* | 12 | \*.mcp.json |
 | [AGENTS.md](https://agentsmd.org) | AGM-\*, XP-\* | 13 | AGENTS.md, AGENTS.local.md, AGENTS.override.md |
+| [Cline](https://docs.cline.bot) | CLN-\* | 4 | .clinerules, .clinerules/\*.md, .clinerules/\*.txt |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | GM-\* | 9 | GEMINI.md, GEMINI.local.md, .gemini/settings.json (hooks), gemini-extension.json (extensions), .geminiignore |
 
 ## Architecture

--- a/crates/agnix-core/src/file_types/detection.rs
+++ b/crates/agnix-core/src/file_types/detection.rs
@@ -848,17 +848,20 @@ mod tests {
 
     #[test]
     fn detect_cline_rules_folder_non_md_txt_rejected() {
-        assert_ne!(
+        assert_eq!(
             detect_file_type(Path::new(".clinerules/config.json")),
-            FileType::ClineRulesFolder
+            FileType::Unknown,
+            "Non-.md/.txt files in .clinerules/ should be Unknown"
         );
-        assert_ne!(
+        assert_eq!(
             detect_file_type(Path::new(".clinerules/config.yaml")),
-            FileType::ClineRulesFolder
+            FileType::Unknown,
+            "Non-.md/.txt files in .clinerules/ should be Unknown"
         );
-        assert_ne!(
+        assert_eq!(
             detect_file_type(Path::new(".clinerules/config.toml")),
-            FileType::ClineRulesFolder
+            FileType::Unknown,
+            "Non-.md/.txt files in .clinerules/ should be Unknown"
         );
     }
 

--- a/crates/agnix-core/src/rules/cline.rs
+++ b/crates/agnix-core/src/rules/cline.rs
@@ -109,7 +109,8 @@ impl Validator for ClineValidator {
             }
         }
 
-        // CLN-002, CLN-003, and CLN-004 only apply to folder files (.md/.txt) (they have frontmatter)
+        // CLN-002, CLN-003, and CLN-004 only apply to folder files (.md/.txt);
+        // frontmatter is optional but these rules check frontmatter content when present
         if !is_folder {
             return diagnostics;
         }
@@ -663,6 +664,31 @@ unknownKey: value
             "Fix should convert scalar to array format, got: {}",
             cln_004[0].fixes[0].replacement
         );
+    }
+
+    #[test]
+    fn test_cln_001_whitespace_only_txt() {
+        let diagnostics = validate_folder_txt("   \n\n\t  ");
+        let cln_001: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CLN-001").collect();
+        assert_eq!(cln_001.len(), 1);
+        assert_eq!(cln_001[0].level, DiagnosticLevel::Error);
+    }
+
+    #[test]
+    fn test_cln_001_empty_body_after_frontmatter_txt() {
+        let content = "---\npaths:\n  - \"**/*.py\"\n---\n";
+        let diagnostics = validate_folder_txt(content);
+        let cln_001: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CLN-001").collect();
+        assert_eq!(cln_001.len(), 1);
+        assert!(cln_001[0].message.contains("no content after frontmatter"));
+    }
+
+    #[test]
+    fn test_cln_001_folder_no_frontmatter_with_content_txt() {
+        let content = "# Rules without frontmatter\n\nSome instructions.";
+        let diagnostics = validate_folder_txt(content);
+        let cln_001: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CLN-001").collect();
+        assert!(cln_001.is_empty());
     }
 
     #[test]

--- a/crates/agnix-core/tests/lib_tests.rs
+++ b/crates/agnix-core/tests/lib_tests.rs
@@ -2165,6 +2165,85 @@ fn test_fixture_file_type_detection() {
         FileType::CopilotScoped,
         "typescript.instructions.md should be detected as CopilotScoped"
     );
+
+    // Cline .txt fixtures should be detected as FileType::ClineRulesFolder
+    assert_eq!(
+        detect_file_type(&fixtures_dir.join("cline/.clinerules/03-python.txt")),
+        FileType::ClineRulesFolder,
+        "03-python.txt should be detected as ClineRulesFolder"
+    );
+    assert_eq!(
+        detect_file_type(&fixtures_dir.join("cline-invalid/.clinerules/bad-glob.txt")),
+        FileType::ClineRulesFolder,
+        "bad-glob.txt should be detected as ClineRulesFolder"
+    );
+    assert_eq!(
+        detect_file_type(&fixtures_dir.join("cline-invalid/.clinerules/scalar-paths.txt")),
+        FileType::ClineRulesFolder,
+        "scalar-paths.txt should be detected as ClineRulesFolder"
+    );
+    assert_eq!(
+        detect_file_type(&fixtures_dir.join("cline-invalid/.clinerules/unknown-keys.txt")),
+        FileType::ClineRulesFolder,
+        "unknown-keys.txt should be detected as ClineRulesFolder"
+    );
+}
+
+// ===== Cline Validation Integration Tests =====
+
+#[test]
+fn test_validate_cline_fixtures() {
+    let fixtures_dir = get_fixtures_dir();
+    let config = LintConfig::default();
+
+    // Valid .txt file should produce no CLN-* diagnostics
+    let valid_txt = fixtures_dir.join("cline/.clinerules/03-python.txt");
+    let diagnostics = expect_success(validate_file(&valid_txt, &config).unwrap());
+    let cln_diagnostics: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule.starts_with("CLN-"))
+        .collect();
+    assert!(
+        cln_diagnostics.is_empty(),
+        "Expected no CLN-* diagnostics for valid 03-python.txt, got: {:?}",
+        cln_diagnostics
+    );
+}
+
+#[test]
+fn test_validate_cline_invalid_bad_glob_txt() {
+    let fixtures_dir = get_fixtures_dir();
+    let config = LintConfig::default();
+    let bad_glob = fixtures_dir.join("cline-invalid/.clinerules/bad-glob.txt");
+    let diagnostics = expect_success(validate_file(&bad_glob, &config).unwrap());
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CLN-002"),
+        "Expected CLN-002 from bad-glob.txt fixture"
+    );
+}
+
+#[test]
+fn test_validate_cline_invalid_scalar_paths_txt() {
+    let fixtures_dir = get_fixtures_dir();
+    let config = LintConfig::default();
+    let scalar_paths = fixtures_dir.join("cline-invalid/.clinerules/scalar-paths.txt");
+    let diagnostics = expect_success(validate_file(&scalar_paths, &config).unwrap());
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CLN-004"),
+        "Expected CLN-004 from scalar-paths.txt fixture"
+    );
+}
+
+#[test]
+fn test_validate_cline_invalid_unknown_keys_txt() {
+    let fixtures_dir = get_fixtures_dir();
+    let config = LintConfig::default();
+    let unknown_keys = fixtures_dir.join("cline-invalid/.clinerules/unknown-keys.txt");
+    let diagnostics = expect_success(validate_file(&unknown_keys, &config).unwrap());
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CLN-003"),
+        "Expected CLN-003 from unknown-keys.txt fixture"
+    );
 }
 
 // ===== GitHub Copilot Validation Integration Tests =====


### PR DESCRIPTION
## Summary

Follow-up to #572 (feat: support .clinerules/*.txt files). Addresses review findings from automated code review:

- Add integration tests for .txt fixtures through `validate_file()` end-to-end pipeline
- Add fixture file type detection assertions for all .txt fixtures
- Add missing .txt test parity with .md tests (whitespace-only, empty body, no-frontmatter)
- Strengthen detection rejection test with `assert_eq!(Unknown)` instead of `assert_ne!`
- Fix misleading comment about frontmatter requirement
- Add Cline row to README Supported Tools table

## Test Plan

- [x] 67 cline-related tests pass (11 new)
- [x] Full `cargo test -p agnix-core` suite passes (3000+ tests)
- [x] `cargo build` compiles without errors

## Related Issues

Part of #565