### PR TITLE
fix: make release workflow resilient to re-runs [skip changelog]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
           if cargo publish -p "$crate" 2>&1; then
             echo "$crate $version published successfully"
           else
-            # Check crates.io API for the specific version (handles older tags, indexing lag)
+            # Check if version already exists on crates.io (handles re-runs after partial failures)
             status=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/$crate/$version")
             if [ "$status" = "200" ]; then
               echo "$crate $version already published, skipping"
@@ -485,16 +485,26 @@ jobs:
             BRANCH="docs/version-${{ steps.version.outputs.version }}"
             git checkout -B "$BRANCH"
             git commit -m "docs: version ${{ steps.version.outputs.version }} docs and update site data"
+            # Force-push to update the auto-generated docs branch on workflow re-runs
             git push --force-with-lease origin "$BRANCH"
             # Create PR only if one doesn't already exist for this branch
-            if gh pr view --head "$BRANCH" --json number --jq '.number' 2>/dev/null; then
+            PR_CHECK_ERR="$(mktemp)"
+            if gh pr view --head "$BRANCH" --json number --jq '.number' >/dev/null 2>"$PR_CHECK_ERR"; then
               echo "PR already exists for $BRANCH, updated with force push"
             else
-              gh pr create \
-                --base main \
-                --head "$BRANCH" \
-                --title "docs: version ${{ steps.version.outputs.version }} docs" \
-                --body "Auto-generated versioned docs snapshot for v${{ steps.version.outputs.version }}." \
-                --label "documentation"
+              if grep -qiE 'not[[:space:]]+found|could not find pull request|no pull requests' "$PR_CHECK_ERR"; then
+                gh pr create \
+                  --base main \
+                  --head "$BRANCH" \
+                  --title "docs: version ${{ steps.version.outputs.version }} docs" \
+                  --body "Auto-generated versioned docs snapshot for v${{ steps.version.outputs.version }}, including updated rule docs and site data." \
+                  --label "documentation"
+              else
+                echo "Error checking for existing PR:"
+                cat "$PR_CHECK_ERR"
+                rm -f "$PR_CHECK_ERR"
+                exit 1
+              fi
             fi
+            rm -f "$PR_CHECK_ERR"
           fi


### PR DESCRIPTION
## Summary
- crates.io publish steps now tolerate "already exists" errors, allowing failed workflow re-runs to skip already-published crates and continue with remaining ones
- Version docs job creates a PR instead of pushing directly to main, respecting branch protection rules

## Context
v0.14.0 release workflow had 4 failures:
1. **crates.io**: `agnix-rules` published but indexing timed out, re-run failed because `agnix-rules` was "already exists"
2. **Version Docs**: Branch protection blocked direct push to main
3. **JetBrains**: Plugin Developer agreement not accepted (separate issue)
4. **Zed**: Extension action compatibility issue (separate issue)

This PR fixes issues 1 and 2. Issues 3 and 4 will be tracked separately.

## Test plan
- Re-run the v0.14.0 release workflow failed jobs after this is merged
- Verify crates.io publish skips already-published crates and publishes remaining ones
- Verify version docs creates a PR instead of pushing directly