### PR TITLE
[skip changelog] ci: add workflow_dispatch for manual crate publishing

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 0.14.0)'
+        description: 'Version without v prefix (e.g. 0.14.0)'
         required: true
         type: string
 
@@ -37,6 +37,10 @@ jobs:
           cat > /tmp/publish-crate.sh << 'SCRIPT'
           #!/usr/bin/env bash
           set -euo pipefail
+          if [ "$#" -ne 2 ]; then
+            echo "Usage: publish-crate.sh <crate> <version>"
+            exit 2
+          fi
           crate="$1"
           version="$2"
           echo "Publishing $crate $version..."
@@ -57,6 +61,10 @@ jobs:
           cat > /tmp/wait-for-crate.sh << 'SCRIPT'
           #!/usr/bin/env bash
           set -euo pipefail
+          if [ "$#" -ne 2 ]; then
+            echo "Usage: wait-for-crate.sh <crate> <version>"
+            exit 2
+          fi
           crate="$1"
           version="$2"
           max_retries=30
@@ -69,6 +77,7 @@ jobs:
                 sleep "$interval"
                 continue
               fi
+              echo "Attempt $i/$max_retries: cargo search failed, no retries left"
               break
             }
             if echo "$output" | grep -qF "$crate = \"$version\""; then


### PR DESCRIPTION
## Summary
- Adds `publish-crates.yml` workflow_dispatch to manually publish crates to crates.io
- Uses idempotent publish helper (same pattern as release.yml) - safely skips already-published versions
- Publishes in dependency order: agnix-rules -> agnix-core -> agnix-cli/lsp/mcp

## Context
The v0.14.0 release workflow's crates.io step timed out waiting for index propagation. Only agnix-rules was published. This workflow lets us publish the remaining 4 crates on demand.

## Test plan
- [ ] Workflow file is valid YAML
- [ ] Dispatch with version 0.14.0 after merge to publish remaining crates