### PR TITLE
[skip changelog] fix(ci): add User-Agent header to crates.io API requests

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -47,7 +47,7 @@ jobs:
           if cargo publish -p "$crate" 2>&1; then
             echo "$crate $version published successfully"
           else
-            status=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/$crate/$version")
+            status=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: agnix-ci (https://github.com/agent-sh/agnix)" "https://crates.io/api/v1/crates/$crate/$version")
             if [ "$status" = "200" ]; then
               echo "$crate $version already published, skipping"
             else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,7 @@ jobs:
             echo "$crate $version published successfully"
           else
             # Check if version already exists on crates.io (handles re-runs after partial failures)
-            status=$(curl -s -o /dev/null -w "%{http_code}" "https://crates.io/api/v1/crates/$crate/$version")
+            status=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: agnix-ci (https://github.com/agent-sh/agnix)" "https://crates.io/api/v1/crates/$crate/$version")
             if [ "$status" = "200" ]; then
               echo "$crate $version already published, skipping"
             else


### PR DESCRIPTION
## Summary
- crates.io returns HTTP 403 for API requests missing `User-Agent` header
- This broke the idempotent publish check - already-published crates were treated as failures
- Adds `User-Agent: agnix-ci` header to curl calls in both `publish-crates.yml` and `release.yml`

## Context
The `publish-crates` workflow dispatched for v0.14.0 failed because `agnix-rules` (already published) got HTTP 403 from the crates.io version check, instead of the expected 200.

## Test plan
- [ ] Re-dispatch `publish-crates` workflow after merge to verify fix