### PR TITLE
[skip changelog] fix(ci): use crates.io API for indexing wait

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -72,7 +72,7 @@ jobs:
           ua="User-Agent: agnix-ci (https://github.com/agent-sh/agnix)"
           echo "Waiting for $crate $version to appear on crates.io..."
           for i in $(seq 1 $max_retries); do
-            status=$(curl -s -o /dev/null -w "%{http_code}" -H "$ua" "https://crates.io/api/v1/crates/$crate/$version")
+            status=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 --max-time 30 -H "$ua" "https://crates.io/api/v1/crates/$crate/$version" || printf '000')
             if [ "$status" = "200" ]; then
               echo "$crate $version available after $(((i - 1) * interval))s"
               exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
           ua="User-Agent: agnix-ci (https://github.com/agent-sh/agnix)"
           echo "Waiting for $crate $version to appear on crates.io..."
           for i in $(seq 1 $max_retries); do
-            status=$(curl -s -o /dev/null -w "%{http_code}" -H "$ua" "https://crates.io/api/v1/crates/$crate/$version")
+            status=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 10 --max-time 30 -H "$ua" "https://crates.io/api/v1/crates/$crate/$version" || printf '000')
             if [ "$status" = "200" ]; then
               echo "$crate $version available after $(((i - 1) * interval))s"
               exit 0


### PR DESCRIPTION
## Summary
- Replace `cargo search` with crates.io HTTP API in `wait-for-crate.sh` (both `publish-crates.yml` and `release.yml`)
- `cargo search` is unreliable on CI - consistently fails to find published versions
- The HTTP API (`/api/v1/crates/<name>/<version>`) returns 200 immediately after publish

## Context
The publish-crates workflow failed twice because `cargo search agnix-rules --limit 1` couldn't find `agnix-rules = "0.14.0"` even though it was published days ago. The crates.io HTTP API is more reliable for version existence checks.

## Test plan
- [ ] Re-dispatch `publish-crates` workflow after merge