### PR TITLE
ci: add self-validation to CI [skip changelog]

### DIFF
--- a/.agnix.toml
+++ b/.agnix.toml
@@ -40,5 +40,4 @@ disabled_rules = [
     "CDX-AG-005",  # AGENTS.md uses structured code blocks for API documentation
     "CC-MEM-009",  # CLAUDE.md is intentionally detailed - it's the project memory
     "CC-SK-017",   # Intentional - version is a client-specific frontmatter field
-    "XML-001",     # <ValidationOutcome> is a Rust type reference, not unclosed XML
 ]

--- a/.agnix.toml
+++ b/.agnix.toml
@@ -29,4 +29,16 @@ import_references = true
 # - VER-001: Version pinning not needed for the linter itself
 # - CC-MEM-006: Negative instructions are sometimes necessary in CLAUDE.md
 # - PE-003: Weak language in docs is acceptable
-disabled_rules = ["XP-001", "XP-002", "XP-003", "XP-006", "VER-001", "CC-MEM-006", "PE-003"]
+disabled_rules = [
+    "XP-001",      # We document tool paths, mentioning them is expected
+    "XP-002",      # Same as XP-001
+    "XP-003",      # Same as XP-001
+    "XP-006",      # Intentionally have both CLAUDE.md and AGENTS.md (kept identical)
+    "VER-001",     # Version pinning not needed for the linter itself
+    "CC-MEM-006",  # Negative instructions are sometimes necessary
+    "PE-003",      # Weak language in docs is acceptable
+    "CDX-AG-005",  # AGENTS.md uses structured code blocks for API documentation
+    "CC-MEM-009",  # CLAUDE.md is intentionally detailed - it's the project memory
+    "CC-SK-017",   # Intentional - version is a client-specific frontmatter field
+    "XML-001",     # <ValidationOutcome> is a Rust type reference, not unclosed XML
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,16 @@ jobs:
 
       - name: Kiro S-tier Gate
         run: cargo test -p agnix-cli --test kiro_ci_gate -- --include-ignored
+
+  agnix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Validate agent configurations
+        uses: ./
+        with:
+          config: '.agnix.toml'
+          fail-on-error: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,13 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+
       - name: Validate agent configurations
         uses: ./
         with:
           config: '.agnix.toml'
           fail-on-error: 'true'
+          build-from-source: 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ tests/fixtures/     # Test cases by category
 - `file_utils.rs` - Safe file I/O (symlink rejection, size limits)
 - `fixes.rs` - Auto-fix application engine
 - `fs.rs` - FileSystem trait abstraction (RealFileSystem, MockFileSystem)
-- `pipeline.rs` - ValidationResult, validate_project(), validate_file() -> LintResult<ValidationOutcome>
+- `pipeline.rs` - `ValidationResult`, `validate_project()`, `validate_file()` -> `LintResult<ValidationOutcome>`
 - `registry.rs` - ValidatorRegistry, ValidatorRegistryBuilder, ValidatorProvider, factory functions
 
 ### Key Abstractions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ tests/fixtures/     # Test cases by category
 - `file_utils.rs` - Safe file I/O (symlink rejection, size limits)
 - `fixes.rs` - Auto-fix application engine
 - `fs.rs` - FileSystem trait abstraction (RealFileSystem, MockFileSystem)
-- `pipeline.rs` - ValidationResult, validate_project(), validate_file() -> LintResult<ValidationOutcome>
+- `pipeline.rs` - `ValidationResult`, `validate_project()`, `validate_file()` -> `LintResult<ValidationOutcome>`
 - `registry.rs` - ValidatorRegistry, ValidatorRegistryBuilder, ValidatorProvider, factory functions
 
 ### Key Abstractions


### PR DESCRIPTION
## Summary

- Update `.agnix.toml` config with additional rule suppressions
- Add agnix self-validation job to CI using `./` action reference
- Validates the repo's own agent configurations on push and PR

## Test plan

- [ ] CI passes with agnix self-validation step
- [ ] No false positive warnings in agnix output