### PR TITLE
fix: create draft release before uploading assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,16 +169,33 @@ jobs:
             echo "Release $VERSION" > release_notes.md
           fi
 
-      - name: Create GitHub Release
+      - name: Create draft release with assets
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           name: ${{ steps.notes.outputs.version }}
           body_path: release_notes.md
           files: artifacts/*
-          draft: false
+          draft: true
           prerelease: ${{ contains(github.ref, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish release
+        run: |
+          set -euo pipefail
+          RELEASE_ID=$(gh api "repos/${REPO}/releases" \
+            --jq ".[] | select(.tag_name == \"${TAG}\" and .draft == true) | .id")
+          if [ -z "$RELEASE_ID" ]; then
+            echo "Error: Draft release for ${TAG} not found"
+            exit 1
+          fi
+          gh api "repos/${REPO}/releases/${RELEASE_ID}" \
+            --method PATCH --field draft=false
+          echo "Published release ${TAG} (id: ${RELEASE_ID})"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ steps.notes.outputs.version }}
 
   publish:
     name: Publish to crates.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Release workflow**: Create GitHub release as draft before uploading assets, then publish - fixes immutable release protection blocking asset uploads (caused v0.16.3 to ship with zero binaries)
+
 ## [0.16.3] - 2026-03-19
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Creates the GitHub release as a **draft** first, uploads all binary assets, then publishes
- Fixes the race condition where GitHub's immutable release protection locked the release before assets could be uploaded
- Root cause of v0.16.3 shipping with zero binaries (all 5 builds succeeded but asset upload was blocked)

## Test Plan

- [ ] CI passes
- [ ] Next tag push creates a draft release, uploads assets, then publishes