### PR TITLE
fix: repair spec-drift sentinel and update stale tracking data

### DIFF
--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -38,7 +38,7 @@
       "claude-code-subagents": {
         "url": "https://code.claude.com/docs/en/sub-agents",
         "hash": "b17ed99452ce65f18804fff1ed945414d9e42ae862d295ad49be6b13dd93210c",
-        "rules": ["CC-SA-001", "CC-SA-002", "CC-SA-003", "CC-SA-004", "CC-SA-005", "CC-SA-006", "CC-SA-007"]
+        "rules": ["CC-AG-001", "CC-AG-002", "CC-AG-003", "CC-AG-004", "CC-AG-005", "CC-AG-006", "CC-AG-007"]
       },
       "codex-cli-agents-md": {
         "url": "https://developers.openai.com/codex/guides/agents-md/",
@@ -75,12 +75,12 @@
       "github-copilot": {
         "url": "https://docs.github.com/en/copilot/customizing-copilot",
         "hash": "668c75acb7948484e1334aeb040332961836fbe187561fa830219afcde8ae289",
-        "rules": ["GH-001", "GH-002", "GH-003", "GH-004"]
+        "rules": ["COP-001", "COP-002", "COP-003", "COP-004"]
       },
       "cline-rules": {
         "url": "https://docs.cline.bot/features/cline-rules/overview",
         "hash": "3a42acacd88e62655c440c04214bed9e622793007489f1d9ef68a2ea85360063",
-        "rules": ["CLINE-001", "CLINE-002", "CLINE-003"]
+        "rules": ["CLN-001", "CLN-002", "CLN-003"]
       }
     }
   }

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -256,8 +256,12 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-          # Output drift sources JSON for downstream jobs
-          echo "drift_sources=$DRIFT_SOURCES_JSON" >> "$GITHUB_OUTPUT"
+          # Output drift sources JSON for downstream jobs (multiline-safe)
+          {
+            echo "drift_sources<<EOF"
+            echo "$DRIFT_SOURCES_JSON"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
           # Output new hashes if update requested
           if [[ "$UPDATE_BASELINES" == "true" ]]; then

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-02-05
+**Last Updated**: 2026-03-28
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -17,31 +17,31 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml) | Weekly | 2026-02-05 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
-| Codex CLI | `AGENTS.md`, `codex.toml` | https://developers.openai.com/codex/ | Automated (spec-drift.yml) | Weekly | 2026-02-05 | AGM, XP |
-| OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml) | Weekly | 2026-02-05 | AGM, XP |
+| Codex CLI | `AGENTS.md`, `codex.toml` | https://developers.openai.com/codex/ | Automated (spec-drift.yml) | Weekly | 2026-02-05 | AGM, CDX, CDX-AG, CDX-APP, CDX-CFG, CX-SK, XP |
+| OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml) | Weekly | 2026-02-05 | OC, OC-AG, OC-AGM, OC-CFG, OC-DEP, OC-LSP, OC-PM, OC-SK, OC-TUI, XP |
 
 ### A Tier (test on major changes)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml) | Monthly | 2026-02-05 | COP |
-| Cline | `.clinerules`, `.cline/rules/*.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml) | Monthly | 2026-02-05 | -- |
-| Cursor | `.cursor/rules/*.mdc`, `.cursorrules` | https://cursor.com/docs/context/rules | Automated (spec-drift.yml) | Monthly | 2026-02-26 | CUR |
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml) | Monthly | 2026-02-05 | COP, CP-SK |
+| Cline | `.clinerules`, `.cline/rules/*.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml) | Monthly | 2026-02-05 | CLN, CL-SK |
+| Cursor | `.cursor/rules/*.mdc`, `.cursorrules` | https://cursor.com/docs/context/rules | Automated (spec-drift.yml) | Monthly | 2026-02-26 | CUR, CR-SK |
 
 ### B Tier (test on significant changes if time permits)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Roo Code | `.roo/rules/*.md` | https://github.com/RooVetGit/Roo-Code | Manual | Quarterly | 2026-02-05 | -- |
-| Kiro CLI | `kiro.md` | https://kiro.dev/ | Manual | Quarterly | 2026-02-05 | -- |
-| amp | `.amp/rules.md` | https://amp.dev/ | Manual | Quarterly | 2026-02-05 | -- |
+| Roo Code | `.roo/rules/*.md` | https://github.com/RooVetGit/Roo-Code | Manual | Quarterly | 2026-02-05 | ROO, RC-SK |
+| Kiro CLI | `kiro.md`, `.kiro/` | https://kiro.dev/ | Manual | Quarterly | 2026-02-05 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK |
+| amp | `.amp/rules.md` | https://ampcode.com | Manual | Quarterly | 2026-02-05 | AMP, AMP-SK |
 | pi | `.pi/config.json` | TBD | Manual | Quarterly | 2026-02-05 | -- |
 
 ### C Tier (community reports fixes only)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md` | https://github.com/google-gemini/gemini-cli | Manual | As reported | 2026-02-05 | GM- |
+| gemini cli | `GEMINI.md` | https://github.com/google-gemini/gemini-cli | Manual | As reported | 2026-02-05 | GM |
 | continue | `.continue/config.json` | https://docs.continue.dev/ | Manual | As reported | 2026-02-05 | -- |
 | Antigravity | `.antigravity/config.yml` | TBD | Manual | As reported | 2026-02-05 | -- |
 
@@ -52,7 +52,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tabnine | `.tabnine.json` | https://docs.tabnine.com/ | None | Ad hoc | -- | -- |
 | Codeium | `.codeium/config.json` | https://codeium.com/docs/ | None | Ad hoc | -- | -- |
 | Amazon Q | `.aws/q/config.json` | https://docs.aws.amazon.com/q/ | None | Ad hoc | -- | -- |
-| Windsurf | `.windsurfrules` | https://windsurf.com/docs/ | None | Ad hoc | -- | -- |
+| Windsurf | `.windsurfrules` | https://docs.windsurf.com | None | Ad hoc | -- | WS, WS-SK |
 | Aider | `.aider.conf.yml` | https://aider.chat/docs/ | None | Ad hoc | -- | -- |
 | SourceGraph Cody | `.sourcegraph/config.json` | https://sourcegraph.com/docs/cody/ | None | Ad hoc | -- | -- |
 
@@ -70,33 +70,33 @@ Authoritative sources monitored for changes that may affect validation rules.
 
 | Source | URL | Watch Method | Rules Affected |
 |--------|-----|-------------|----------------|
-| Agent Skills Spec | https://agentskills.io/specification | spec-drift.yml (weekly) | AS-001 through AS-016 |
-| MCP Spec | https://modelcontextprotocol.io/specification/2025-11-25 | spec-drift.yml (weekly) | MCP-001 through MCP-008 |
-| MCP GitHub Repo | https://github.com/modelcontextprotocol/specification | mcp-release-watch.yml | MCP-001 through MCP-008 |
+| Agent Skills Spec | https://agentskills.io/specification | spec-drift.yml (weekly) | AS-001 through AS-019 |
+| MCP Spec | https://modelcontextprotocol.io/specification/2025-11-25 | spec-drift.yml (weekly) | MCP-001 through MCP-024 |
+| MCP GitHub Repo | https://github.com/modelcontextprotocol/specification | mcp-release-watch.yml | MCP-001 through MCP-024 |
 
 ### Vendor Documentation (Secondary)
 
 | Source | URL | Watch Method | Rules Affected |
 |--------|-----|-------------|----------------|
-| Claude Code - Memory | https://code.claude.com/docs/en/memory | spec-drift.yml (weekly) | CC-MEM-001 through CC-MEM-010 |
-| Claude Code - Hooks | https://code.claude.com/docs/en/hooks | spec-drift.yml (weekly) | CC-HK-001 through CC-HK-012 |
-| Claude Code - Skills | https://code.claude.com/docs/en/skills | spec-drift.yml (weekly) | CC-SK-001 through CC-SK-009 |
-| Claude Code - Plugins | https://code.claude.com/docs/en/plugins-reference | spec-drift.yml (weekly) | CC-PL-001 through CC-PL-006 |
-| Claude Code - Sub-agents | https://code.claude.com/docs/en/sub-agents | spec-drift.yml (weekly) | CC-AG-001 through CC-AG-007 |
-| Codex CLI - AGENTS.md | https://developers.openai.com/codex/guides/agents-md/ | spec-drift.yml (weekly) | AGM-001 through AGM-006, XP-001 through XP-006 |
-| OpenCode - Rules | https://opencode.ai/docs/rules/ | spec-drift.yml (weekly) | XP-001 through XP-006 |
+| Claude Code - Memory | https://code.claude.com/docs/en/memory | spec-drift.yml (weekly) | CC-MEM-001 through CC-MEM-012 |
+| Claude Code - Hooks | https://code.claude.com/docs/en/hooks | spec-drift.yml (weekly) | CC-HK-001 through CC-HK-019 |
+| Claude Code - Skills | https://code.claude.com/docs/en/skills | spec-drift.yml (weekly) | CC-SK-001 through CC-SK-017 |
+| Claude Code - Plugins | https://code.claude.com/docs/en/plugins-reference | spec-drift.yml (weekly) | CC-PL-001 through CC-PL-010 |
+| Claude Code - Sub-agents | https://code.claude.com/docs/en/sub-agents | spec-drift.yml (weekly) | CC-AG-001 through CC-AG-013 |
+| Codex CLI - AGENTS.md | https://developers.openai.com/codex/guides/agents-md/ | spec-drift.yml (weekly) | AGM-001 through AGM-006, CDX-*, CDX-AG-*, CDX-APP-*, CDX-CFG-*, XP-001 through XP-008 |
+| OpenCode - Rules | https://opencode.ai/docs/rules/ | spec-drift.yml (weekly) | OC-*, OC-AG-*, OC-AGM-*, OC-CFG-*, OC-DEP-*, OC-LSP-*, OC-PM-*, OC-TUI-*, XP-001 through XP-008 |
 | Cursor - Rules | https://cursor.com/docs/context/rules | spec-drift.yml (monthly) | CUR-001 through CUR-009 |
 | Cursor - Hooks | https://cursor.com/docs/agent/hooks | spec-drift.yml (monthly) | CUR-010 through CUR-013 |
 | Cursor - Subagents | https://cursor.com/docs/context/subagents | spec-drift.yml (monthly) | CUR-014, CUR-015 |
 | Cursor - Environment | https://cursor.com/docs/cloud-agent/setup | spec-drift.yml (monthly) | CUR-016 |
-| GitHub Copilot | https://docs.github.com/en/copilot/customizing-copilot | spec-drift.yml (monthly) | COP-001 through COP-006 |
-| Cline - Rules | https://docs.cline.bot/features/cline-rules/overview | spec-drift.yml (monthly) | -- |
+| GitHub Copilot | https://docs.github.com/en/copilot/customizing-copilot | spec-drift.yml (monthly) | COP-001 through COP-018 |
+| Cline - Rules | https://docs.cline.bot/features/cline-rules/overview | spec-drift.yml (monthly) | CLN-001 through CLN-004 |
 
 ### Community Sources
 
 | Source | URL | What to Watch |
 |--------|-----|---------------|
-| agentsys | https://github.com/anthropics/agentsys | Pattern updates, new enhance plugins |
+| agentsys | https://github.com/agent-sh/agentsys | Pattern updates, new enhance plugins |
 | MCP Servers Registry | https://github.com/modelcontextprotocol/servers | New server patterns, security advisories |
 | Stack Overflow AI Survey | https://survey.stackoverflow.co/2025/ai | Developer pain points, tool adoption trends |
 
@@ -139,7 +139,7 @@ New developments that may require future rule additions or tool tier changes.
 
 - **Status**: MCP ecosystem rapidly expanding
 - **Watch**: New transport types, authentication patterns, tool annotation schemas
-- **Impact**: May require updates to MCP-001 through MCP-008, new rules for auth/transport
+- **Impact**: May require updates to MCP-001 through MCP-024, new rules for auth/transport
 - **Sources**: https://modelcontextprotocol.io, mcp-release-watch.yml workflow
 
 ### AGENTS.md Ecosystem
@@ -165,7 +165,7 @@ The Model Context Protocol ecosystem is tracked separately due to its rapid evol
 ### Current MCP Coverage
 
 - **Protocol version monitored**: 2025-11-25
-- **Rules**: MCP-001 through MCP-008
+- **Rules**: MCP-001 through MCP-024
 - **Automated monitoring**: mcp-release-watch.yml (GitHub releases), spec-drift.yml (spec content)
 - **Baseline hash**: See `.github/spec-baselines.json` for current hash
 
@@ -173,7 +173,7 @@ The Model Context Protocol ecosystem is tracked separately due to its rapid evol
 
 | Area | Current Status | Potential Rule Impact |
 |------|---------------|---------------------|
-| Authentication patterns | No standard yet | New MCP-009+ rules for auth validation |
+| Authentication patterns | No standard yet | New MCP-025+ rules for auth validation |
 | Remote transport (SSE/WebSocket) | Supported in spec | Transport-specific validation rules |
 | Tool annotations | annotations field in spec | MCP-006 may need expansion |
 | Resource subscriptions | In spec, limited adoption | New rules for subscription patterns |
@@ -199,8 +199,8 @@ Tracking community input that influences rule development, tool support decision
 
 | Date | Source | Feedback | Status |
 |------|--------|----------|--------|
-| 2026-02-05 | Tool inventory audit | B/C/D tier tools lack rule coverage | Awaiting community contributions; issue templates now available |
-| 2026-02-05 | Cross-tool compatibility | Users mixing Cursor + Claude Code + Copilot report silent failures | XP-004/005/006 rules address some cases; more patterns needed |
+| 2026-02-05 | Tool inventory audit | B/C/D tier tools lack rule coverage | Partially resolved: Kiro (51 rules), Roo Code (7 rules), Cline (5 rules) now have coverage. Aider, Continue, Antigravity still at 0. |
+| 2026-02-05 | Cross-tool compatibility | Users mixing Cursor + Claude Code + Copilot report silent failures | XP-004/005/006/007/008 rules address some cases; more patterns needed |
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix spec-drift workflow that has been failing since Feb 25 (10+ consecutive runs) - multiline JSON was written to `$GITHUB_OUTPUT` with single-line syntax, causing `Invalid format '  {'` error
- Fix stale rule prefixes in `spec-baselines.json` (CC-SA->CC-AG, GH->COP, CLINE->CLN)
- Update `RESEARCH-TRACKING.md` with current rule inventory (342 rules across 47 prefixes), fix broken URLs, add missing tool entries

## Test plan

- [x] All 4076 workspace tests pass
- [ ] Verify spec-drift workflow succeeds on next scheduled/manual run
- [ ] Confirm drift issue gets auto-filed when sources have changed