### PR TITLE
fix(release): bump lastVersion on version-docs job so /docs/ flips to the new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -548,6 +548,18 @@ jobs:
       - name: Cut versioned docs snapshot
         run: npm --prefix website run version:cut -- "${{ steps.version.outputs.version }}"
 
+      - name: Update lastVersion in Docusaurus config
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s/lastVersion: '[^']*'/lastVersion: '$VERSION'/" website/docusaurus.config.js
+          if ! grep -q "lastVersion: '$VERSION'" website/docusaurus.config.js; then
+            echo "Failed to update lastVersion to $VERSION in docusaurus.config.js"
+            grep -n "lastVersion:" website/docusaurus.config.js
+            exit 1
+          fi
+          echo "Updated lastVersion to $VERSION"
+
       - name: Commit and push versioned docs
         env:
           GH_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
@@ -555,7 +567,7 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add website/src/data/siteData.json website/docs/rules/ website/versioned_docs/ website/versioned_sidebars/ website/versions.json
+          git add website/src/data/siteData.json website/docs/rules/ website/versioned_docs/ website/versioned_sidebars/ website/versions.json website/docusaurus.config.js
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Docs site versioning** - `/docs/` now serves the latest released version (0.18.0) instead of unreleased dev content, and dev docs moved to `/docs/next/` with an unreleased banner. Snapshotted `docs/` as `version-0.18.0` (lossless - no commits touched `docs/` after the v0.18.0 tag).
+- **Release automation** - the `version-docs` job in `release.yml` now bumps `lastVersion` in `docusaurus.config.js` and includes the config change in the auto-opened docs PR, so `/docs/` automatically flips to point at the newly released version. Previously the snapshot was created but `lastVersion` stayed stale, which caused the v0.18.0 drift.
 
 ## [0.18.0] - 2026-04-02
 


### PR DESCRIPTION
## Summary

The `version-docs` job in `release.yml` already snapshots docs on release via `docusaurus docs:version`, but it never updated `lastVersion` in `docusaurus.config.js`. That means when a new release ships, `/docs/` keeps serving the prior release because Docusaurus routes by `lastVersion`.

This was the root cause of the v0.18.0 site state - the snapshot was missed entirely, `lastVersion` was still pointing at `'current'`, and `/docs/` served dev content labeled "next". Fixed manually in #718.

## Change

One new step + one line appended:

- New step `Update lastVersion in Docusaurus config` runs `sed -i "s/lastVersion: '[^']*'/lastVersion: '$VERSION'/"` on `website/docusaurus.config.js`, with a guard grep that fails the job if the replacement didn't land.
- The subsequent `Commit and push` step now adds `website/docusaurus.config.js` to the PR's `git add` list, so the config change rides along in the auto-opened docs PR.

## Test plan

- [x] Manually ran the sed against the current config - replaces `lastVersion: '0.18.0'` with the new version
- [x] Verified the guard rejects a failed replacement
- [ ] Next release tag push creates a PR that updates all four surfaces: snapshot + sidebars + versions.json + lastVersion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow that auto-generates and pushes versioned docs; a bad `sed`/pattern mismatch could fail the job or publish docs pointing at the wrong version.
> 
> **Overview**
> Ensures the `version-docs` step in `.github/workflows/release.yml` also bumps Docusaurus `lastVersion` to the just-released tag version after cutting the versioned docs snapshot, with a guard that fails the job if the update doesn’t apply.
> 
> Updates the subsequent commit step to include `website/docusaurus.config.js` so the `lastVersion` change is pushed along with the generated `versioned_docs`/`versions.json` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1e5a62e801757eccda76d16e9cd77e17aabbb66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->