### PR TITLE
fix(cli): accept multiple paths so pre-commit only lints changed files (#723)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -19,8 +19,7 @@
       \.github/copilot-instructions\.md|
       \.cursor/rules/.*\.mdc
     )$
-  pass_filenames: false
-  args: [--strict, .]
+  args: [--strict]
 
 - id: agnix-fix
   name: agnix (with auto-fix)
@@ -43,5 +42,4 @@
       \.github/copilot-instructions\.md|
       \.cursor/rules/.*\.mdc
     )$
-  pass_filenames: false
-  args: [--fix, .]
+  args: [--fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Docusaurus** - bumped `@docusaurus/core` and `@docusaurus/preset-classic` from 3.9.2 to 3.10.0.
 
 ### Fixed
+- **Pre-commit hook rescanned the whole repo** (#723) - `agnix` now accepts multiple positional paths, and `.pre-commit-hooks.yaml` no longer forces `pass_filenames: false` + trailing `.`. pre-commit's built-in optimisation works again: only the changed files get checked, not every eligible file in the repo.
 - **Docs site versioning** - `/docs/` now serves the latest released version (0.18.0) instead of unreleased dev content, and dev docs moved to `/docs/next/` with an unreleased banner. Snapshotted `docs/` as `version-0.18.0` (lossless - no commits touched `docs/` after the v0.18.0 tag).
 - **Release automation** - the `version-docs` job in `release.yml` now bumps `lastVersion` in `docusaurus.config.js` and includes the config change in the auto-opened docs PR, so `/docs/` automatically flips to point at the newly released version. Previously the snapshot was created but `lastVersion` stayed stale, which caused the v0.18.0 drift.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,9 +2411,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -1188,6 +1188,7 @@ cli:
   fixable: "[fixable]"
   watch_error_text_only: "Watch mode is only supported with text output."
   watch_error_fix: "Watch mode cannot be combined with fix flags."
+  watch_error_single_path: "Watch mode requires a single path."
   fix_error_text_only: "Fix flags are only supported with text output. Remove --format or use --format text."
   evaluating: "Evaluating:"
   filter_label: "  filter:"

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -778,6 +778,7 @@ cli:
   fixable: "[corregible]"
   watch_error_text_only: "El modo observador solo es compatible con salida de texto."
   watch_error_fix: "El modo observador no puede combinarse con opciones de correccion."
+  watch_error_single_path: "El modo observador requiere una sola ruta."
   fix_error_text_only: "Las opciones de correccion solo son compatibles con salida de texto. Elimina --format o usa --format text."
   evaluating: "Evaluando:"
   filter_label: "  filtro:"

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -778,6 +778,7 @@ cli:
   fixable: "[可修复]"
   watch_error_text_only: "监视模式仅支持文本输出。"
   watch_error_fix: "监视模式不能与修复标志组合使用。"
+  watch_error_single_path: "监视模式需要单个路径。"
   fix_error_text_only: "修复标志仅支持文本输出。删除 --format 或使用 --format text。"
   evaluating: "正在评估:"
   filter_label: "  筛选:"

--- a/crates/agnix-cli/src/main.rs
+++ b/crates/agnix-cli/src/main.rs
@@ -15,12 +15,12 @@ mod watch;
 use telemetry_stub as telemetry;
 
 use agnix_core::{
-    ValidationResult, apply_fixes_with_options,
+    ValidationOutcome, ValidationResult, ValidatorRegistry, apply_fixes_with_options,
     config::{LintConfig, TargetTool},
     diagnostics::{Diagnostic, DiagnosticLevel, FixConfidenceTier},
     eval::{EvalFormat, evaluate_manifest_file},
     fixes::{FixApplyMode, FixApplyOptions},
-    generate_schema, validate_project,
+    generate_schema, validate_file_with_registry, validate_project, validate_project_with_registry,
 };
 use clap::{Parser, Subcommand, ValueEnum};
 use colored::*;
@@ -76,9 +76,13 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    /// Path to validate (defaults to current directory)
-    #[arg(default_value = ".")]
-    path: PathBuf,
+    /// Paths to validate (defaults to current directory).
+    ///
+    /// Accepts one or more files or directories. When multiple files are
+    /// passed (e.g. from a pre-commit hook), only those files are checked;
+    /// project-wide rules still run against the workspace root.
+    #[arg(default_value = ".", num_args = 1..)]
+    paths: Vec<PathBuf>,
 
     /// Strict mode (treat warnings as errors)
     #[arg(short, long)]
@@ -173,9 +177,9 @@ pub enum TelemetryAction {
 enum Commands {
     /// Validate agent configs
     Validate {
-        /// Path to validate
-        #[arg(default_value = ".")]
-        path: PathBuf,
+        /// Paths to validate (one or more files/directories)
+        #[arg(default_value = ".", num_args = 1..)]
+        paths: Vec<PathBuf>,
     },
 
     /// Initialize config file
@@ -254,7 +258,8 @@ fn main() {
     // Load config early for watch mode to apply config-based locale
     // Watch mode doesn't allow format or fix flags, so we can safely load config here
     if cli.watch {
-        let config_path = resolve_config_path(&cli.path, cli.config.as_ref());
+        let primary = primary_path(&cli.paths);
+        let config_path = resolve_config_path(primary, cli.config.as_ref());
         let (config, _) = LintConfig::load_or_default(config_path.as_ref());
 
         // Re-initialize locale if config specifies one and no --locale flag was given
@@ -266,7 +271,7 @@ fn main() {
     }
 
     let result = match &cli.command {
-        Some(Commands::Validate { path }) => validate_command(path, &cli),
+        Some(Commands::Validate { paths }) => validate_command(paths, &cli),
         Some(Commands::Init { output }) => init_command(output),
         Some(Commands::Eval {
             path,
@@ -276,13 +281,97 @@ fn main() {
         }) => eval_command(path, *format, filter.as_deref(), *verbose),
         Some(Commands::Telemetry { action }) => telemetry_command(*action),
         Some(Commands::Schema { output }) => schema_command(output.as_ref()),
-        None => validate_command(&cli.path, &cli),
+        None => validate_command(&cli.paths, &cli),
     };
 
     if let Err(e) = result {
         eprintln!("{} {}", t!("cli.error_label").red().bold(), e);
         process::exit(1);
     }
+}
+
+/// Pick a representative path for config resolution, SARIF roots, etc.
+///
+/// When the user passes multiple paths (common with pre-commit, which expands
+/// the changed files into positional args), we still need a single path for
+/// things like finding `.agnix.toml` or the git root. The first path is a
+/// reasonable default; when no paths are given we fall back to `.`.
+fn primary_path(paths: &[PathBuf]) -> &Path {
+    paths
+        .first()
+        .map(PathBuf::as_path)
+        .unwrap_or_else(|| Path::new("."))
+}
+
+fn format_paths_for_display(paths: &[PathBuf]) -> String {
+    match paths.len() {
+        0 => ".".to_string(),
+        1 => paths[0].display().to_string(),
+        _ => format!("{} files", paths.len()),
+    }
+}
+
+/// Dispatch validation across one or more paths.
+///
+/// - A single directory path uses the full project walk (`validate_project`).
+/// - Otherwise each path is handled individually: files run through
+///   `validate_file_with_registry`, directories fall back to the project walk.
+///
+/// This lets pre-commit style invocations like
+/// `agnix --strict AGENTS.md CLAUDE.md` check only the changed files instead
+/// of rescanning the entire repo.
+fn run_validation(
+    paths: &[PathBuf],
+    config: &LintConfig,
+) -> agnix_core::LintResult<ValidationResult> {
+    use agnix_core::{CoreError, ValidationError};
+
+    // Surface the same RootNotFound error as validate_project for paths that
+    // don't exist, so CLI behaviour stays consistent.
+    for path in paths {
+        if !path.exists() {
+            return Err(CoreError::Validation(ValidationError::RootNotFound {
+                path: path.clone(),
+            }));
+        }
+    }
+
+    if paths.len() == 1 && paths[0].is_dir() {
+        return validate_project(&paths[0], config);
+    }
+
+    let mut registry = ValidatorRegistry::with_defaults();
+    for name in &config.rules().disabled_validators {
+        registry.disable_validator_owned(name);
+    }
+
+    let mut diagnostics = Vec::new();
+    let mut files_checked = 0usize;
+    for path in paths {
+        if path.is_dir() {
+            let r = validate_project_with_registry(path, config, &registry)?;
+            files_checked += r.files_checked;
+            diagnostics.extend(r.diagnostics);
+            continue;
+        }
+        match validate_file_with_registry(path, config, &registry)? {
+            ValidationOutcome::Success(d) => {
+                files_checked += 1;
+                diagnostics.extend(d);
+            }
+            ValidationOutcome::Skipped => {}
+            ValidationOutcome::IoError(err) => {
+                eprintln!(
+                    "{} {}: {}",
+                    t!("cli.warning_label").yellow().bold(),
+                    path.display(),
+                    err
+                );
+            }
+            _ => {}
+        }
+    }
+    Ok(ValidationResult::new(diagnostics, files_checked))
 }
 
 fn count_errors_warnings(diagnostics: &[Diagnostic]) -> (usize, usize) {
@@ -297,8 +386,8 @@ fn count_errors_warnings(diagnostics: &[Diagnostic]) -> (usize, usize) {
     (errors, warnings)
 }
 
-#[tracing::instrument(skip(cli), fields(path = %path.display()))]
-fn validate_command(path: &Path, cli: &Cli) -> anyhow::Result<()> {
+#[tracing::instrument(skip(cli), fields(paths_count = paths.len()))]
+fn validate_command(paths: &[PathBuf], cli: &Cli) -> anyhow::Result<()> {
     tracing::debug!("Starting validation");
 
     // Watch mode validation
@@ -310,8 +399,11 @@ fn validate_command(path: &Path, cli: &Cli) -> anyhow::Result<()> {
         if should_fix {
             return Err(anyhow::anyhow!("{}", t!("cli.watch_error_fix")));
         }
+        if paths.len() > 1 {
+            return Err(anyhow::anyhow!("--watch requires a single path"));
+        }
 
-        let path = path.to_path_buf();
+        let path = primary_path(paths).to_path_buf();
         let path_for_watch = path.clone();
         let strict = cli.strict;
         let verbose = cli.verbose;
@@ -323,7 +415,8 @@ fn validate_command(path: &Path, cli: &Cli) -> anyhow::Result<()> {
         });
     }
 
-    let config_path = resolve_config_path(path, cli.config.as_ref());
+    let primary = primary_path(paths);
+    let config_path = resolve_config_path(primary, cli.config.as_ref());
     tracing::debug!(config_path = ?config_path, "Resolved config path");
 
     let (mut config, config_warning) = LintConfig::load_or_default(config_path.as_ref());
@@ -391,7 +484,7 @@ fn validate_command(path: &Path, cli: &Cli) -> anyhow::Result<()> {
     // SARIF uses the git repository root so artifact URIs are relative to the
     // workspace root, which IDEs expect. Text/JSON use CWD for backwards compatibility.
     let base_path = if matches!(cli.format, OutputFormat::Sarif) {
-        sarif::find_git_root(path)
+        sarif::find_git_root(primary)
             .unwrap_or_else(|| std::fs::canonicalize(".").unwrap_or_else(|_| PathBuf::from(".")))
     } else {
         std::fs::canonicalize(".").unwrap_or_else(|_| PathBuf::from("."))
@@ -417,7 +510,7 @@ fn validate_command(path: &Path, cli: &Cli) -> anyhow::Result<()> {
         diagnostics,
         files_checked,
         ..
-    } = validate_project(path, &config)?;
+    } = run_validation(paths, &config)?;
 
     // Restore user locale after validation so stderr messages use their language
     if let Some(ref locale) = saved_locale {
@@ -469,7 +562,11 @@ fn validate_command(path: &Path, cli: &Cli) -> anyhow::Result<()> {
     }
 
     // Text output format
-    println!("{} {}", t!("cli.validating").cyan().bold(), path.display());
+    println!(
+        "{} {}",
+        t!("cli.validating").cyan().bold(),
+        format_paths_for_display(paths)
+    );
     println!();
 
     if diagnostics.is_empty() {
@@ -681,7 +778,7 @@ fn validate_command(path: &Path, cli: &Cli) -> anyhow::Result<()> {
                 diagnostics: post_fix_diagnostics,
                 files_checked: _,
                 ..
-            } = validate_project(path, &config)?;
+            } = run_validation(paths, &config)?;
 
             (final_errors, final_warnings) = count_errors_warnings(&post_fix_diagnostics);
         }

--- a/crates/agnix-cli/src/main.rs
+++ b/crates/agnix-cli/src/main.rs
@@ -78,9 +78,9 @@ struct Cli {
 
     /// Paths to validate (defaults to current directory).
     ///
-    /// Accepts one or more files or directories. When multiple files are
-    /// passed (e.g. from a pre-commit hook), only those files are checked;
-    /// project-wide rules still run against the workspace root.
+    /// Accepts one or more files or directories. When multiple paths are
+    /// passed (e.g. from a pre-commit hook), only those paths are checked
+    /// instead of the full project walk.
     #[arg(default_value = ".", num_args = 1..)]
     paths: Vec<PathBuf>,
 
@@ -307,7 +307,7 @@ fn format_paths_for_display(paths: &[PathBuf]) -> String {
     match paths.len() {
         0 => ".".to_string(),
         1 => paths[0].display().to_string(),
-        _ => format!("{} files", paths.len()),
+        _ => format!("{} paths", paths.len()),
     }
 }
 
@@ -320,6 +320,12 @@ fn format_paths_for_display(paths: &[PathBuf]) -> String {
 /// This lets pre-commit style invocations like
 /// `agnix --strict AGENTS.md CLAUDE.md` check only the changed files instead
 /// of rescanning the entire repo.
+///
+/// Before iterating we resolve a workspace root and set it on a cloned
+/// `LintConfig` so per-file validators see the same `[files]` include/exclude
+/// semantics they'd see during a full project walk. The aggregate
+/// `files_checked` count is also bounded by `max_files_to_validate` so a large
+/// file list from pre-commit can't bypass the DoS guard.
 fn run_validation(
     paths: &[PathBuf],
     config: &LintConfig,
@@ -340,33 +346,60 @@ fn run_validation(
         return validate_project(&paths[0], config);
     }
 
+    // Resolve a workspace root so per-file validators can apply relative
+    // `[files]` patterns and so diagnostics use a stable base path. Use the
+    // parent of the first file path, or the first directory path, or cwd.
+    let root_dir = paths
+        .first()
+        .map(|p| {
+            if p.is_dir() {
+                p.clone()
+            } else {
+                p.parent()
+                    .map(Path::to_path_buf)
+                    .unwrap_or_else(|| PathBuf::from("."))
+            }
+        })
+        .and_then(|p| std::fs::canonicalize(&p).ok())
+        .unwrap_or_else(|| std::fs::canonicalize(".").unwrap_or_else(|_| PathBuf::from(".")));
+
+    let mut config = config.clone();
+    config.set_root_dir(root_dir);
+
     let mut registry = ValidatorRegistry::with_defaults();
     for name in &config.rules().disabled_validators {
         registry.disable_validator_owned(name);
     }
 
+    let max_files = config.max_files_to_validate();
     let mut diagnostics = Vec::new();
     let mut files_checked = 0usize;
     for path in paths {
+        if let Some(limit) = max_files {
+            if files_checked >= limit {
+                return Err(CoreError::Validation(ValidationError::TooManyFiles {
+                    count: files_checked,
+                    limit,
+                }));
+            }
+        }
         if path.is_dir() {
-            let r = validate_project_with_registry(path, config, &registry)?;
+            let r = validate_project_with_registry(path, &config, &registry)?;
             files_checked += r.files_checked;
             diagnostics.extend(r.diagnostics);
             continue;
         }
-        match validate_file_with_registry(path, config, &registry)? {
+        match validate_file_with_registry(path, &config, &registry)? {
             ValidationOutcome::Success(d) => {
                 files_checked += 1;
                 diagnostics.extend(d);
             }
             ValidationOutcome::Skipped => {}
             ValidationOutcome::IoError(err) => {
-                eprintln!(
-                    "{} {}: {}",
-                    t!("cli.warning_label").yellow().bold(),
-                    path.display(),
-                    err
-                );
+                // Propagate so JSON/SARIF consumers see the failure in exit
+                // code and text consumers get a clear error instead of a
+                // silent warning that still exits 0.
+                return Err(CoreError::File(err));
             }
             _ => {}
         }
@@ -400,7 +433,7 @@ fn validate_command(paths: &[PathBuf], cli: &Cli) -> anyhow::Result<()> {
             return Err(anyhow::anyhow!("{}", t!("cli.watch_error_fix")));
         }
         if paths.len() > 1 {
-            return Err(anyhow::anyhow!("--watch requires a single path"));
+            return Err(anyhow::anyhow!("{}", t!("cli.watch_error_single_path")));
         }
 
         let path = primary_path(paths).to_path_buf();

--- a/crates/agnix-cli/tests/cli_integration.rs
+++ b/crates/agnix-cli/tests/cli_integration.rs
@@ -3451,3 +3451,40 @@ fn test_cli_multiple_paths_scope_to_listed_files() {
         stdout
     );
 }
+
+// --watch with more than one path should be rejected with the localized error,
+// not silently pick one. Ensures we don't regress the ergonomics when someone
+// combines --watch with a pre-commit style invocation.
+#[test]
+fn test_cli_watch_rejects_multiple_paths() {
+    let f1 = workspace_path("tests/fixtures/valid/skills/code-review/SKILL.md");
+    let f2 = workspace_path("tests/fixtures/valid/skills/deploy-prod/SKILL.md");
+
+    let mut cmd = agnix();
+    cmd.arg("--watch")
+        .arg(f1.to_str().unwrap())
+        .arg(f2.to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("single path"));
+}
+
+// Passing more files than `--max-files` should surface the same TooManyFiles
+// error the full project walk emits, so a long pre-commit file list can't
+// bypass the DoS guard.
+#[test]
+fn test_cli_multiple_paths_respect_max_files_limit() {
+    let f1 = workspace_path("tests/fixtures/valid/skills/code-review/SKILL.md");
+    let f2 = workspace_path("tests/fixtures/valid/skills/deploy-prod/SKILL.md");
+    let f3 = workspace_path("tests/fixtures/valid/skills/with-model/SKILL.md");
+
+    let mut cmd = agnix();
+    cmd.arg("--max-files")
+        .arg("1")
+        .arg(f1.to_str().unwrap())
+        .arg(f2.to_str().unwrap())
+        .arg(f3.to_str().unwrap())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Too many files"));
+}

--- a/crates/agnix-cli/tests/cli_integration.rs
+++ b/crates/agnix-cli/tests/cli_integration.rs
@@ -3406,3 +3406,48 @@ fn test_cli_nonexistent_path_returns_error() {
         .stderr(predicate::str::contains("Validation root not found"))
         .stderr(predicate::str::contains(missing.to_str().unwrap()));
 }
+
+// Regression test for #723: pre-commit passes the list of changed files as
+// positional args. The CLI must accept multiple paths and validate only those
+// files rather than rescanning the whole repo.
+#[test]
+fn test_cli_accepts_multiple_file_paths() {
+    let f1 = workspace_path("tests/fixtures/valid/skills/code-review/SKILL.md");
+    let f2 = workspace_path("tests/fixtures/valid/skills/deploy-prod/SKILL.md");
+
+    let mut cmd = agnix();
+    cmd.arg(f1.to_str().unwrap())
+        .arg(f2.to_str().unwrap())
+        .arg("--format")
+        .arg("json")
+        .assert()
+        .success();
+}
+
+// When multiple file paths are passed we should only validate those files,
+// not every matching file under the workspace root.
+#[test]
+fn test_cli_multiple_paths_scope_to_listed_files() {
+    let f1 = workspace_path("tests/fixtures/valid/skills/code-review/SKILL.md");
+    let f2 = workspace_path("tests/fixtures/valid/skills/deploy-prod/SKILL.md");
+
+    let mut cmd = agnix();
+    let output = cmd
+        .arg(f1.to_str().unwrap())
+        .arg(f2.to_str().unwrap())
+        .arg("--format")
+        .arg("json")
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    // Exactly two files checked -- not a full project walk.
+    assert_eq!(
+        json["files_checked"].as_u64(),
+        Some(2),
+        "expected exactly the two passed files to be checked, got: {}",
+        stdout
+    );
+}


### PR DESCRIPTION
Closes #723.

## Summary
- CLI positional arg goes from `path: PathBuf` to `paths: Vec<PathBuf>` (`num_args = 1..`, default `["."]`)
- Single directory path still runs the full project walk. Multiple paths (or single file paths) validate only those files via `validate_file_with_registry`, sharing one registry
- `.pre-commit-hooks.yaml` drops `pass_filenames: false` and the trailing `.` from `args` so pre-commit's built-in per-file optimisation works - touching one AGENTS.md no longer rescans the whole repo
- Non-existent paths still surface `RootNotFound` to keep the existing CLI error semantics

## Test plan
- [x] `cargo test -p agnix-cli` - all suites green (121 in `cli_integration`)
- [x] new regression tests `test_cli_accepts_multiple_file_paths` and `test_cli_multiple_paths_scope_to_listed_files` (asserts `files_checked == 2`)
- [x] `cargo test --workspace` green
- [x] `cargo fmt --check`, `cargo clippy -p agnix-cli -- -D warnings` clean
- [x] manual smoke: `agnix AGENTS.md CLAUDE.md --format json` -> `files_checked: 2`; `agnix . --format json` still walks the whole repo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI argument parsing and validation dispatch, which can affect what gets validated (and exit codes) across different invocation patterns. Risk is moderated by added regression tests for multi-path behavior and scoping.
> 
> **Overview**
> **Pre-commit invocations no longer trigger full-repo scans.** The `agnix` CLI now accepts *multiple* positional paths (files or directories) and dispatches validation per-path, using a shared `ValidatorRegistry`; a single directory path still runs the full project walk.
> 
> **Hook configuration updated accordingly.** `.pre-commit-hooks.yaml` stops disabling filename passing and removes the trailing `.` arg so pre-commit’s per-file optimization works.
> 
> Adds CLI integration regression tests to ensure multi-path runs succeed and that `files_checked` reflects only the provided files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab423635ffc13875848f1b9e2a48bdba7875c66. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->