### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-24
+
 ### Changed
 - **Dependency bumps (dependabot queue drain)**: consolidated 8 open dependabot PRs (#783-#790) into a single verified branch:
   - Rust crates: `rayon 1.10 -> 1.12`, `toml 0.8 -> 1.x` (the clean `cargo update` resolved to the latest 1.x release at merge time; coexists with `rust-i18n-support`'s `0.8.x`), `rmcp 1.4 -> 1.5`, `similar 3.0 -> 3.1`, `uuid 1.23.0 -> 1.23.1`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -61,7 +61,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -93,14 +93,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -32,8 +32,8 @@ categories = ["development-tools", "command-line-utilities"]
 
 [workspace.dependencies]
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.19.0" }
-agnix-core = { path = "crates/agnix-core", version = "0.19.0" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.20.0" }
+agnix-core = { path = "crates/agnix-core", version = "0.20.0" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.19.0"
+version = "0.20.0"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",


### PR DESCRIPTION
Dep-bump release. Version bump from 0.19.0 to 0.20.0 across workspace Cargo.toml (root + inter-crate pin), editors/vscode, editors/zed, and npm/.

## Included (already on main via #791)
- 5 Rust crate bumps (rayon 1.10->1.12, toml 0.8->1.x, rmcp 1.4->1.5, similar 3.0->3.1, uuid 1.23.0->1.23.1)
- 3 CI action bumps (setup-node v4->v6.4, taiki-e 2.75.17->2.75.21, claude-code-action v1.0.101->v1.0.105)
- deny.toml skip list simplified to wildcards for windows_* and toml families
- 2 new transitive RUSTSEC advisories documented + ignored (libyml, serde_yml via rust-i18n)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a coordinated release/version bump plus dependency updates; risk comes from the `toml` major-version upgrade and newly ignored transitive RUSTSEC advisories that could mask future security issues if not revisited.
> 
> **Overview**
> Cuts the `v0.20.0` release by bumping the workspace/crate versions (and associated distribution packages for VS Code, Zed, and npm) from `0.19.0` to `0.20.0`.
> 
> Updates release documentation by adding a `0.20.0` changelog entry summarizing consolidated Dependabot dependency/action bumps and the related `cargo audit`/`deny.toml` adjustments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b69e7f8bf69f9e6401ba10b2b8734255ab86aa8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->