### PR TITLE
feat(codex): CDX-CFG-029 agents.max_threads + multi_agent_v2 conflict (#806)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 406 rules, 75+ sources, rules.json
+knowledge-base/     # 407 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-406 rules defined in `knowledge-base/rules.json` (source of truth)
+407 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.18.0 - Production-ready with full validation pipeline
-- 406 validation rules across 39 validators
+- 407 validation rules across 39 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **CDX-CFG-029: agents.max_threads incompatible with multi_agent_v2 (#806)**. In rust-v0.125.0 Codex rejects the config at load time with "agents.max_threads cannot be set when multi_agent_v2 is enabled" - the v2 agent lifecycle manages threading internally and accepting the legacy limit alongside creates conflicting semantics (openai/codex#19129). CDX-CFG-029 detects the feature in either shape Codex accepts (flat `[features] multi_agent_v2 = true` or table `[features.multi_agent_v2] enabled = true`) and errors when `[agents] max_threads` is also set. Closes #806.
 - **CDX-CFG-028: Reject unsupported inline MCP `bearer_token` field (#805)**. In rust-v0.125.0 Codex runtime rejects `mcp_servers.<name>.bearer_token` and requires `bearer_token_env_var` instead; schemars generation also dropped the field (openai/codex#19294). agnix now emits a HIGH-severity diagnostic pointing users at the correct replacement, with a specific suggestion that keeps secrets out of the config file. Removed `bearer_token` from `KNOWN_MCP_SERVER_KEYS` and suppressed it from the generic CDX-CFG-006 (nested unknown-key) path when CDX-CFG-028 is enabled, so users get one specific diagnostic rather than two. Disabling CDX-CFG-028 intentionally falls through to CDX-CFG-006 so the field is never silently accepted. Closes #805.
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 406 rules, 75+ sources, rules.json
+knowledge-base/     # 407 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-406 rules defined in `knowledge-base/rules.json` (source of truth)
+407 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.18.0 - Production-ready with full validation pipeline
-- 406 validation rules across 39 validators
+- 407 validation rules across 39 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>406 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>407 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 406 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 407 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -797,6 +797,9 @@ rules:
   cdx_cfg_028:
     message: "MCP server '%{server}' uses unsupported inline 'bearer_token' field. Codex runtime rejects this - use 'bearer_token_env_var' to reference an env var instead"
     suggestion: "Replace 'bearer_token = \"...\"' with 'bearer_token_env_var = \"YOUR_ENV_VAR_NAME\"' and set the token in that env var. Rationale: openai/codex#19294 - the field was removed from the config schema in rust-v0.125.0"
+  cdx_cfg_029:
+    message: "'agents.max_threads' cannot be set when 'multi_agent_v2' is enabled - these use different agent lifecycles and Codex will fail to load this config"
+    suggestion: "Remove 'agents.max_threads' (the v2 lifecycle manages threading internally), or disable 'multi_agent_v2' if you need the legacy thread limit. Rationale: openai/codex#19129 - Codex rejects this combination at config-load time in rust-v0.125.0"
   cdx_ag_001:
     message: "AGENTS.md is empty"
     suggestion: "Add concrete repository-specific operating instructions"

--- a/crates/agnix-core/src/rules/codex.rs
+++ b/crates/agnix-core/src/rules/codex.rs
@@ -88,6 +88,7 @@ const CODEX_CONFIG_RULE_IDS: &[&str] = &[
     "CDX-CFG-026",
     "CDX-CFG-027",
     "CDX-CFG-028",
+    "CDX-CFG-029",
     "CDX-APP-001",
     "CDX-APP-002",
     "CDX-APP-003",
@@ -1824,6 +1825,32 @@ fn validate_codex_config_rules(
         }
     }
 
+    // CDX-CFG-029: agents.max_threads cannot be set when multi_agent_v2 is
+    // enabled. Upstream: openai/codex#19129 - multi_agent_v2 uses the v2 agent
+    // lifecycle; accepting the legacy `agents.max_threads` limit alongside it
+    // creates conflicting configuration semantics. Codex now fails config
+    // load with "agents.max_threads cannot be set when multi_agent_v2 is
+    // enabled".
+    if config.is_rule_enabled("CDX-CFG-029")
+        && value_at_path(&root, &["agents", "max_threads"]).is_some()
+        && is_multi_agent_v2_enabled(&root)
+    {
+        let line = key_lines
+            .get("max_threads")
+            .copied()
+            .unwrap_or_else(|| key_lines.get("multi_agent_v2").copied().unwrap_or(1));
+        diagnostics.push(
+            Diagnostic::error(
+                path.to_path_buf(),
+                line,
+                0,
+                "CDX-CFG-029",
+                t!("rules.cdx_cfg_029.message"),
+            )
+            .with_suggestion(t!("rules.cdx_cfg_029.suggestion")),
+        );
+    }
+
     if config.is_rule_enabled("CDX-APP-001")
         && let Some(apps) = value_at_path(&root, &["apps"])
     {
@@ -2172,6 +2199,31 @@ fn is_windows_absolute_path(value: &str) -> bool {
         && bytes[0].is_ascii_alphabetic()
         && bytes[1] == b':'
         && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
+/// Return true when the `multi_agent_v2` feature is enabled in either shape
+/// that the Codex config parser accepts:
+///
+/// - `[features] multi_agent_v2 = true` - flat boolean form (FeatureToml::Enabled)
+/// - `[features.multi_agent_v2] enabled = true` - table form (FeatureToml::Config)
+///
+/// Returns false when the feature is missing, explicitly false, or set to any
+/// non-boolean value (which Codex would reject earlier during TOML deserialize,
+/// so we don't need to re-diagnose it here).
+fn is_multi_agent_v2_enabled(root: &Value) -> bool {
+    let Some(feature) = value_at_path(root, &["features", "multi_agent_v2"]) else {
+        return false;
+    };
+    // Flat form: features.multi_agent_v2 = true
+    if let Some(b) = feature.as_bool() {
+        return b;
+    }
+    // Table form: [features.multi_agent_v2] enabled = true
+    // The table may exist without `enabled`; upstream defaults that to false.
+    if let Some(obj) = feature.as_object() {
+        return obj.get("enabled").and_then(Value::as_bool).unwrap_or(false);
+    }
+    false
 }
 
 /// Find the 1-indexed line of `bearer_token =` under `[mcp_servers.<name>]`.
@@ -4053,6 +4105,138 @@ bearer_token = \"t2\"
             .expect("s2 diag");
         assert_eq!(s1.line, 3, "s1 bearer_token should be line 3");
         assert_eq!(s2.line, 7, "s2 bearer_token should be line 7");
+    }
+
+    // ===== CDX-CFG-029: agents.max_threads incompatible with multi_agent_v2 =====
+
+    #[test]
+    fn test_cdx_cfg_029_flat_form_flags_conflict() {
+        // [features] multi_agent_v2 = true + [agents] max_threads = N
+        let content = "\
+[agents]
+max_threads = 4
+
+[features]
+multi_agent_v2 = true
+";
+        let diagnostics = validate_config(content);
+        let cdx_029: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-029")
+            .collect();
+        assert_eq!(cdx_029.len(), 1);
+        assert_eq!(cdx_029[0].level, DiagnosticLevel::Error);
+        assert!(
+            cdx_029[0]
+                .message
+                .contains("'agents.max_threads' cannot be set when 'multi_agent_v2' is enabled")
+        );
+    }
+
+    #[test]
+    fn test_cdx_cfg_029_table_form_flags_conflict() {
+        // [features.multi_agent_v2] enabled = true + [agents] max_threads = N
+        let content = "\
+[agents]
+max_threads = 2
+
+[features.multi_agent_v2]
+enabled = true
+";
+        let diagnostics = validate_config(content);
+        let cdx_029: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-029")
+            .collect();
+        assert_eq!(
+            cdx_029.len(),
+            1,
+            "table form [features.multi_agent_v2] enabled=true must also trigger"
+        );
+    }
+
+    #[test]
+    fn test_cdx_cfg_029_table_form_without_enabled_does_not_flag() {
+        // [features.multi_agent_v2] exists but `enabled` is not set - upstream
+        // defaults that to false, so CDX-CFG-029 must not fire.
+        let content = "\
+[agents]
+max_threads = 2
+
+[features.multi_agent_v2]
+usage_hint_enabled = true
+";
+        let diagnostics = validate_config(content);
+        let cdx_029: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-029")
+            .collect();
+        assert!(
+            cdx_029.is_empty(),
+            "[features.multi_agent_v2] without explicit enabled=true must not flag, got {:?}",
+            cdx_029
+        );
+    }
+
+    #[test]
+    fn test_cdx_cfg_029_table_form_enabled_false_does_not_flag() {
+        let content = "\
+[agents]
+max_threads = 2
+
+[features.multi_agent_v2]
+enabled = false
+";
+        let diagnostics = validate_config(content);
+        let cdx_029: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-029")
+            .collect();
+        assert!(cdx_029.is_empty());
+    }
+
+    #[test]
+    fn test_cdx_cfg_029_max_threads_alone_is_fine() {
+        let content = "[agents]\nmax_threads = 4\n";
+        let diagnostics = validate_config(content);
+        let cdx_029: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-029")
+            .collect();
+        assert!(cdx_029.is_empty());
+    }
+
+    #[test]
+    fn test_cdx_cfg_029_multi_agent_v2_alone_is_fine() {
+        // Only multi_agent_v2, no agents.max_threads - perfectly valid
+        let content = "[features]\nmulti_agent_v2 = true\n";
+        let diagnostics = validate_config(content);
+        let cdx_029: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-029")
+            .collect();
+        assert!(cdx_029.is_empty());
+    }
+
+    #[test]
+    fn test_cdx_cfg_029_can_be_disabled() {
+        use crate::config::LintConfig;
+        let mut config = LintConfig::default();
+        config.rules_mut().disabled_rules = vec!["CDX-CFG-029".to_string()];
+        let content = "\
+[agents]
+max_threads = 4
+
+[features]
+multi_agent_v2 = true
+";
+        let validator = CodexConfigValidator;
+        let diagnostics = validator.validate(std::path::Path::new("config.toml"), content, &config);
+        let cdx_029: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-029")
+            .collect();
+        assert!(cdx_029.is_empty());
     }
 
     #[test]

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 406,
+  "total_rules": 407,
   "last_updated": "2026-04-01",
   "schema": {
     "evidence": {
@@ -5142,6 +5142,33 @@
       },
       "good_example": "[mcp_servers.myserver]\nurl = \"https://api.example.com\"\nbearer_token_env_var = \"MY_API_TOKEN\"",
       "bad_example": "[mcp_servers.myserver]\nurl = \"https://api.example.com\"\nbearer_token = \"sk-live-...\""
+    },
+    {
+      "id": "CDX-CFG-029",
+      "name": "Incompatible agents.max_threads with multi_agent_v2",
+      "severity": "HIGH",
+      "category": "codex",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/openai/codex/pull/19129"
+        ],
+        "verified_on": "2026-04-26",
+        "applies_to": {
+          "tool": "codex"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "[agents]\nmax_threads = 4\n\n[features]\n# multi_agent_v2 omitted or false",
+      "bad_example": "[agents]\nmax_threads = 4\n\n[features]\nmulti_agent_v2 = true"
     },
     {
       "id": "CL-SK-001",

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -2406,6 +2406,13 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 **Fix**: Manual - rewrite as `bearer_token_env_var = "MY_ENV_VAR"` and set the token in the named env var (keeps secret out of the config file)
 **Source**: openai/codex#19294 (removed from schema in rust-v0.125.0), openai/codex#19275 (original bug)
 
+<a id="cdx-cfg-029"></a>
+### CDX-CFG-029 [HIGH] Incompatible agents.max_threads with multi_agent_v2
+**Requirement**: `agents.max_threads` MUST NOT be set when `multi_agent_v2` is enabled - the v2 lifecycle manages threading internally, and Codex fails config load with "agents.max_threads cannot be set when multi_agent_v2 is enabled"
+**Detection**: Detect `multi_agent_v2` enabled in either the flat form (`[features] multi_agent_v2 = true`) or the table form (`[features.multi_agent_v2] enabled = true`); error when the feature is active AND `[agents] max_threads` is explicitly set
+**Fix**: Manual - remove `agents.max_threads` (v2 manages threading) or disable `multi_agent_v2` if the legacy limit is needed
+**Source**: openai/codex#19129 (rejected at config-load time in rust-v0.125.0)
+
 <a id="cdx-ag-004"></a>
 ### CDX-AG-004 [MEDIUM] AGENTS.md Exceeds Size Limit
 **Requirement**: AGENTS.md SHOULD not exceed 100,000 bytes

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 406,
+  "total_rules": 407,
   "last_updated": "2026-04-01",
   "schema": {
     "evidence": {
@@ -5142,6 +5142,33 @@
       },
       "good_example": "[mcp_servers.myserver]\nurl = \"https://api.example.com\"\nbearer_token_env_var = \"MY_API_TOKEN\"",
       "bad_example": "[mcp_servers.myserver]\nurl = \"https://api.example.com\"\nbearer_token = \"sk-live-...\""
+    },
+    {
+      "id": "CDX-CFG-029",
+      "name": "Incompatible agents.max_threads with multi_agent_v2",
+      "severity": "HIGH",
+      "category": "codex",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/openai/codex/pull/19129"
+        ],
+        "verified_on": "2026-04-26",
+        "applies_to": {
+          "tool": "codex"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "[agents]\nmax_threads = 4\n\n[features]\n# multi_agent_v2 omitted or false",
+      "bad_example": "[agents]\nmax_threads = 4\n\n[features]\nmulti_agent_v2 = true"
     },
     {
       "id": "CL-SK-001",

--- a/website/docs/rules/generated/cdx-cfg-029.md
+++ b/website/docs/rules/generated/cdx-cfg-029.md
@@ -1,0 +1,56 @@
+---
+id: cdx-cfg-029
+title: "CDX-CFG-029: Incompatible agents.max_threads with multi_agent_v2"
+sidebar_label: "CDX-CFG-029"
+description: "agnix rule CDX-CFG-029 checks for incompatible agents.max_threads with multi_agent_v2 in codex cli files. Severity: HIGH. See examples and fix guidance."
+keywords: ["CDX-CFG-029", "incompatible agents.max_threads with multi_agent_v2", "codex cli", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CDX-CFG-029`
+- **Severity**: `HIGH`
+- **Category**: `Codex CLI`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-04-26`
+
+## Applicability
+
+- **Tool**: `codex`
+- **Version Range**: `unspecified`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/openai/codex/pull/19129
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```toml
+[agents]
+max_threads = 4
+
+[features]
+multi_agent_v2 = true
+```
+
+### Valid
+
+```toml
+[agents]
+max_threads = 4
+
+[features]
+# multi_agent_v2 omitted or false
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `406` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `407` validation rules generated from `knowledge-base/rules.json`.
 `126` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -189,6 +189,7 @@ This section contains all `406` validation rules generated from `knowledge-base/
 | [CDX-CFG-026](./generated/cdx-cfg-026.md) | Invalid Network Permission Field | LOW | Codex CLI | Yes (safe) |
 | [CDX-CFG-027](./generated/cdx-cfg-027.md) | Invalid Windows Sandbox Value | LOW | Codex CLI | Yes (unsafe) |
 | [CDX-CFG-028](./generated/cdx-cfg-028.md) | Unsupported Inline MCP bearer_token Field | HIGH | Codex CLI | No |
+| [CDX-CFG-029](./generated/cdx-cfg-029.md) | Incompatible agents.max_threads with multi_agent_v2 | HIGH | Codex CLI | No |
 | [CL-SK-001](./generated/cl-sk-001.md) | Cline Skill Uses Unsupported Field | MEDIUM | Cline Skills | Yes (safe/unsafe) |
 | [CL-SK-002](./generated/cl-sk-002.md) | Missing Skill Name | HIGH | Cline Skills | Yes (safe) |
 | [CL-SK-003](./generated/cl-sk-003.md) | Missing Skill Description | HIGH | Cline Skills | No |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 406,
+  "totalRules": 407,
   "categoryCount": 37,
   "autofixCount": 126,
   "uniqueTools": [


### PR DESCRIPTION
## Summary

Adds **CDX-CFG-029** which flags the incompatible combo of \`agents.max_threads\` and \`multi_agent_v2\` in Codex config. Upstream rejects this at config-load time in rust-v0.125.0.

## Closes

- #806

## Upstream evidence

- openai/codex#19129 - \"Reject agents.max_threads with multi_agent_v2\"
- Error Codex returns: \`agents.max_threads cannot be set when multi_agent_v2 is enabled\`
- Rationale: multi_agent_v2 uses the v2 agent lifecycle; accepting the legacy \`agents.max_threads\` limit alongside creates conflicting semantics.

## Behavior

**Invalid** (both forms upstream accepts are flagged):
\`\`\`toml
# Flat form
[agents]
max_threads = 4

[features]
multi_agent_v2 = true
\`\`\`

\`\`\`toml
# Table form
[agents]
max_threads = 4

[features.multi_agent_v2]
enabled = true
\`\`\`

**Valid** (either alone is fine):
\`\`\`toml
[features.multi_agent_v2]
usage_hint_enabled = true   # not enabled - no conflict
\`\`\`

## Implementation notes

- \`is_multi_agent_v2_enabled\` helper checks both flat-bool and table-with-\`enabled\` shapes that Codex's FeatureToml deserializer accepts.
- Table-form without explicit \`enabled = true\` does NOT flag (upstream defaults \`enabled\` to false in that shape), covered by a dedicated test.
- \`autofix=false\` - the fix is semantic (pick which mode you want), not mechanical.

## Test plan

- [x] 7 new unit tests covering both config shapes, negative cases, and disable behavior
- [x] \`cargo test --workspace --all-targets\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] Docs site regenerated; parity tests green

## Follow-ups

2/7 of the rule-candidate series for v0.21.0 done. Remaining: #807, #803, #804, #808, #809.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new Codex config lint rule with unit tests and docs, without changing existing rule behavior beyond emitting one additional error in a specific invalid config combination.
> 
> **Overview**
> Adds a new Codex CLI validation rule, `CDX-CFG-029`, that errors when `[agents] max_threads` is set while `multi_agent_v2` is enabled (supports both the flat `[features] multi_agent_v2 = true` form and the table `[features.multi_agent_v2] enabled = true` form).
> 
> Updates rule metadata/i18n/docs to include the new rule (rule counts bumped to `407` across docs/site data), and adds unit tests covering both enablement shapes, negative cases, and rule-disable behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3431479579b4cb2c7dbfae5925f5f49704cd7b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->