### PR TITLE
feat(tool-release-watch): LLM-assisted agnix triage (#802)

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0",
-  "last_updated": "2026-04-25",
-  "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.",
+  "version": "1.1",
+  "last_updated": "2026-04-26",
+  "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
       "tier": "s",
@@ -17,7 +17,39 @@
       ],
       "github_repo": "anthropics/claude-code",
       "last_known_version": "v2.1.119",
-      "tracked": true
+      "tracked": true,
+      "changes_of_interest": {
+        "config_surfaces": [
+          "CLAUDE.md",
+          ".claude/settings.json",
+          ".claude/settings.local.json",
+          ".claude/managed-settings.json",
+          ".claude/agents/*.md",
+          ".claude/skills/*/SKILL.md",
+          ".claude/hooks configuration",
+          ".mcp.json",
+          ".claude-plugin/plugin.json",
+          ".claude/rules.yaml"
+        ],
+        "relevant": [
+          "New or renamed top-level keys in settings.json / managed-settings.json",
+          "New hook event names, hook action types (command/http/prompt/agent/mcp_tool/...), or required fields per type",
+          "Changes to skill/agent frontmatter fields or validation rules",
+          "Changes to CLAUDE.md import syntax, directives, or size limits",
+          "Plugin manifest schema changes in .claude-plugin/plugin.json",
+          "MCP server config schema changes (fields, auth shapes, placeholders)",
+          "New built-in tool names (affecting the allow-list validator)",
+          "Output-style or rules-file schema changes"
+        ],
+        "irrelevant": [
+          "Model additions or model-selection UI",
+          "Performance improvements, bug fixes that don't change config schema",
+          "Telemetry / analytics / billing changes",
+          "CLI startup flags that don't touch files agnix reads",
+          "Thinking-block presentation and streaming UX",
+          "Error message wording changes"
+        ]
+      }
     },
     "codex": {
       "tier": "s",
@@ -29,7 +61,32 @@
       ],
       "github_repo": "openai/codex",
       "last_known_version": "rust-v0.125.0",
-      "tracked": true
+      "tracked": true,
+      "changes_of_interest": {
+        "config_surfaces": [
+          "AGENTS.md",
+          "codex-rs/core/config.toml (project + ~/.codex/config.toml)",
+          ".codex-plugin/plugin.json (plugin manifest)",
+          ".mcp.json or [mcp_servers.*] TOML blocks referenced from config.toml",
+          "requirements.toml (managed environment config)"
+        ],
+        "relevant": [
+          "New / renamed / removed keys in config.toml ([app], [agents], [features], [mcp_servers.*], [permissions], [sandbox], [windows], etc.)",
+          "Changes to MCP server schema (auth fields, bearer_token/env_var, allow-listed keys)",
+          "Feature toggles in [features] - new features, flag shapes (flat bool vs nested {enabled})",
+          "Plugin manifest schema changes in .codex-plugin/plugin.json",
+          "Apps config shape ([apps.*], tool-approval modes, default_tools_* keys)",
+          "Hook configuration schema (config.toml hooks block stabilized in 0.124)",
+          "AGENTS.md size limits, required sections, or directive grammar"
+        ],
+        "irrelevant": [
+          "Model additions, reasoning presets, context-length bumps",
+          "TUI keyboard shortcuts and display tweaks",
+          "App-server plumbing, Unix socket transport, remote thread config",
+          "Permission-profile UX",
+          "Dependency bumps without config-schema effects"
+        ]
+      }
     },
     "opencode": {
       "tier": "s",
@@ -40,7 +97,28 @@
       ],
       "github_repo": "sst/opencode",
       "last_known_version": "v1.14.25",
-      "tracked": true
+      "tracked": true,
+      "changes_of_interest": {
+        "config_surfaces": [
+          "AGENTS.md",
+          ".opencode/config.json",
+          "opencode agent definitions",
+          "opencode MCP config (inside .opencode/config.json or referenced .mcp.json)"
+        ],
+        "relevant": [
+          "New / renamed / removed top-level keys in .opencode/config.json",
+          "Permission config schema (including rule ordering semantics)",
+          "LSP config shape (request keys, permission-prompt payload)",
+          "MCP server definition shape / auth / env-var substitution rules",
+          "AGENTS.md grammar or size limits"
+        ],
+        "irrelevant": [
+          "Model additions, provider plumbing, OAuth flow UI",
+          "Desktop app icon/session UX",
+          "npmrc / build-tool fixes",
+          "Experimental HTTP API endpoints that don't change config files"
+        ]
+      }
     },
     "kiro": {
       "tier": "s",
@@ -58,7 +136,34 @@
       "notes_extractor": "glm",
       "last_known_version": "2.1.1",
       "tracked": true,
-      "notes": "Proprietary CLI; no GH releases. Tracked via HTML scrape of kiro.dev/changelog/cli/ - the first NN.NN.NN version on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). The CLI itself exposes `kiro-cli version --changelog`. IDE has a separate changelog at https://kiro.dev/changelog/ide/ (not tracked here; could be added as a separate kiro-ide entry if needed)."
+      "notes": "Proprietary CLI; no GH releases. Tracked via HTML scrape of kiro.dev/changelog/cli/ - the first NN.NN.NN version on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). The CLI itself exposes `kiro-cli version --changelog`. IDE has a separate changelog at https://kiro.dev/changelog/ide/ (not tracked here; could be added as a separate kiro-ide entry if needed).",
+      "changes_of_interest": {
+        "config_surfaces": [
+          ".kiro/steering/*.md",
+          ".kiro/agents/*.json",
+          ".kiro/hooks/*.kiro.hook",
+          ".kiro/settings/mcp.json",
+          ".kiro/settings.json (CLI preferences)",
+          ".kiro/powers/*/POWER.md",
+          ".kiro/skills/*/SKILL.md (surfaced as slash commands in 2.1)"
+        ],
+        "relevant": [
+          "New / renamed CLI settings keys (writable via `kiro-cli settings <k> <v>`)",
+          "Steering file inclusion-mode or format changes",
+          "Agent definition schema (tools, permissions, auth)",
+          "Hook event names, payload shapes, required fields",
+          "MCP server config shape (auth, env substitution, tool filtering)",
+          "Power manifest schema",
+          "Skills directory layout or slash-command naming rules"
+        ],
+        "irrelevant": [
+          "IDE UX (image-maps, previews, theming)",
+          "Model / inference changes",
+          "Device-flow auth UX",
+          "TUI keyboard shortcuts",
+          "Remote environment / devcontainer orchestration"
+        ]
+      }
     },
     "copilot": {
       "tier": "a",
@@ -69,7 +174,25 @@
       "github_repo": "microsoft/vscode-copilot-chat",
       "last_known_version": "v0.43.0",
       "tracked": true,
-      "notes": "Tracks the canonical VS Code Copilot Chat extension - the surface where new instruction-file features and schema changes typically land first. Note: the spec docs at https://docs.github.com/en/copilot/customizing-copilot can change independently of extension releases; spec-drift.yml covers that path. The intermediate v0.43.{timestamp} CI tags are not flagged because the GitHub releases API returns the marked-latest stable tag."
+      "notes": "Tracks the canonical VS Code Copilot Chat extension - the surface where new instruction-file features and schema changes typically land first. Note: the spec docs at https://docs.github.com/en/copilot/customizing-copilot can change independently of extension releases; spec-drift.yml covers that path. The intermediate v0.43.{timestamp} CI tags are not flagged because the GitHub releases API returns the marked-latest stable tag.",
+      "changes_of_interest": {
+        "config_surfaces": [
+          ".github/copilot-instructions.md",
+          ".github/instructions/*.instructions.md"
+        ],
+        "relevant": [
+          "Changes to instruction-file frontmatter, globs, or resolution order",
+          "New instruction-file naming conventions or scope rules",
+          "Additions to the supported instruction-file markdown directives"
+        ],
+        "irrelevant": [
+          "Chat UX / conversation history",
+          "Model picker and provider integrations",
+          "Inline-completion tuning",
+          "MCP / agent-mode features that don't touch the instruction-file surface",
+          "Workbench keybindings and UI"
+        ]
+      }
     },
     "cline": {
       "tier": "a",
@@ -79,7 +202,28 @@
       ],
       "github_repo": "cline/cline",
       "last_known_version": "v3.81.0",
-      "tracked": true
+      "tracked": true,
+      "changes_of_interest": {
+        "config_surfaces": [
+          ".clinerules (file or dir)",
+          ".clinerules/workflows/*.md",
+          ".clinerules/hooks/*",
+          ".clinerules/skills/*/SKILL.md",
+          ".cline/skills/*/SKILL.md"
+        ],
+        "relevant": [
+          "Changes to .clinerules parsing (file vs dir, precedence)",
+          "New workflow/hook/skill file layouts",
+          "Skill frontmatter schema changes",
+          "Memory-bank format changes"
+        ],
+        "irrelevant": [
+          "Model additions",
+          "Webview UI updates",
+          "cline-core internal diagnostics and memory tuning",
+          "Provider plumbing (OpenAI Codex subscription etc.)"
+        ]
+      }
     },
     "cursor": {
       "tier": "a",
@@ -92,7 +236,30 @@
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
       "last_known_version": "3.2.11",
       "tracked": true,
-      "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML)."
+      "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
+      "changes_of_interest": {
+        "config_surfaces": [
+          ".cursor/rules/*.mdc",
+          ".cursorrules (legacy)",
+          ".cursor/hooks.json",
+          ".cursor/agents/*.md",
+          ".cursor/environment.json",
+          ".cursor/mcp.json"
+        ],
+        "relevant": [
+          "Changes to .cursor/rules/*.mdc frontmatter (globs, description, alwaysApply)",
+          "New hook shapes in .cursor/hooks.json",
+          "Agent frontmatter schema in .cursor/agents/*.md",
+          "environment.json schema changes",
+          "MCP config shape inside .cursor/mcp.json"
+        ],
+        "irrelevant": [
+          "Agents Window UX (worktrees, multitask, subagents orchestration)",
+          "CLI /config panel behavior",
+          "Bugbot internal config",
+          "Model additions, editor UI tweaks"
+        ]
+      }
     },
     "roo-code": {
       "tier": "b",
@@ -103,7 +270,27 @@
       "github_repo": "RooCodeInc/Roo-Code",
       "last_known_version": "v3.53.0",
       "tracked": true,
-      "notes": "Repo moved from RooVetGit/Roo-Code (still referenced in some docs) to RooCodeInc/Roo-Code."
+      "notes": "Repo moved from RooVetGit/Roo-Code (still referenced in some docs) to RooCodeInc/Roo-Code.",
+      "changes_of_interest": {
+        "config_surfaces": [
+          ".roomodes",
+          ".rooignore",
+          ".roorules",
+          ".roo/rules/*.md",
+          ".roo/rules-{slug}/*.md",
+          ".roo/mcp.json"
+        ],
+        "relevant": [
+          "Schema changes in .roomodes (mode definitions, permissions, custom instructions)",
+          "Rules resolution order between .roorules and .roo/rules/*",
+          "MCP config shape changes"
+        ],
+        "irrelevant": [
+          "Model provider additions (GPT-5.5, Vertex, etc.)",
+          "Checkpoint navigation UI",
+          "Webview / activity bar tweaks"
+        ]
+      }
     },
     "amp": {
       "tier": "b",
@@ -130,7 +317,29 @@
       ],
       "github_repo": "google-gemini/gemini-cli",
       "last_known_version": "v0.39.1",
-      "tracked": true
+      "tracked": true,
+      "changes_of_interest": {
+        "config_surfaces": [
+          "GEMINI.md",
+          ".gemini/settings.json",
+          ".geminiignore",
+          "gemini-extension.json",
+          ".gemini/agents/*.md (local agent definitions, validated by GeminiAgentValidator)"
+        ],
+        "relevant": [
+          "Changes to .gemini/settings.json top-level keys",
+          "Agent markdown frontmatter schema (kind, mcp_servers block, auth variants, system_prompt)",
+          "gemini-extension.json manifest shape",
+          "GEMINI.md grammar / size limits / import syntax",
+          "Hook env vars and plan-mode directives that affect agent files"
+        ],
+        "irrelevant": [
+          "Model additions / Gemini 2.x version bumps",
+          "Tool call performance and caching",
+          "/memory inbox UX and skill-extraction ergonomics",
+          "Provider plumbing"
+        ]
+      }
     },
     "windsurf": {
       "tier": "d",
@@ -144,7 +353,25 @@
       "notes_extractor": "glm",
       "last_known_version": "Wave 14",
       "tracked": true,
-      "notes": "Proprietary IDE (Codeium/Exafunction); no GH releases. Tracked via HTML scrape of windsurf.com/changelog - the first 'Wave NN' marker on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). Wave is the marketing release event; underlying VS Code-fork build version (e.g., 1.9544.24) bumps more often but is not the agnix-relevant signal. Separate /vscode, /jetbrains, /windsurf-next channels are not tracked."
+      "notes": "Proprietary IDE (Codeium/Exafunction); no GH releases. Tracked via HTML scrape of windsurf.com/changelog - the first 'Wave NN' marker on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). Wave is the marketing release event; underlying VS Code-fork build version (e.g., 1.9544.24) bumps more often but is not the agnix-relevant signal. Separate /vscode, /jetbrains, /windsurf-next channels are not tracked.",
+      "changes_of_interest": {
+        "config_surfaces": [
+          ".windsurf/rules/*.md",
+          ".windsurf/workflows/*.md",
+          ".windsurfrules (legacy)"
+        ],
+        "relevant": [
+          "New rules or workflows file layout / frontmatter",
+          "Legacy .windsurfrules deprecation status",
+          "Any new per-project config file under .windsurf/"
+        ],
+        "irrelevant": [
+          "Cascade / agent UX",
+          "Model additions and context-management policy",
+          "IDE base version bumps",
+          "Billing / credits"
+        ]
+      }
     }
   }
 }

--- a/.github/workflows/tool-release-watch.yml
+++ b/.github/workflows/tool-release-watch.yml
@@ -62,8 +62,12 @@ jobs:
           UPDATE_BASELINES: ${{ inputs.update_baselines || 'false' }}
           TOOL_FILTER: ${{ inputs.tool || '' }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          # Optional - when set, scripts/glm-extract.js upgrades the stub
-          # release-notes body for tools with notes_extractor=glm (kiro,
-          # windsurf). Other tools are unaffected.
+          # Optional - when set, scripts/glm-extract.js:
+          # 1. Upgrades the stub release-notes body for tools with
+          #    notes_extractor=glm (kiro, windsurf). Other tools are unaffected.
+          # 2. Runs --mode=agnix-triage on tools that declare
+          #    `changes_of_interest` in tool-release-baselines.json to
+          #    prepend an agnix-focused summary to the issue body. Falls back
+          #    to the raw changelog if the call fails.
           GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
         run: bash scripts/check-tool-releases.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **LLM-assisted changelog triage in tool-release-watch (#802)**. When `GLM_API_KEY` is set and a tool declares `changes_of_interest` in `.github/tool-release-baselines.json`, the watcher now runs `scripts/glm-extract.js --mode=agnix-triage` after fetching the release notes. The LLM filters the notes down to validator-relevant items + rule candidates using the per-tool descriptor (`config_surfaces`, `relevant`, `irrelevant`). The filtered summary is posted as `## Agnix Triage (auto-filtered)` at the top of the issue body, with the full upstream changelog preserved in a `<details>` block below. Gracefully falls back to raw changelog on any LLM failure (missing key, empty response, HTTP error, node unavailable) - zero regressions vs. prior behavior. `changes_of_interest` descriptors authored for 10 of 11 tracked tools (all except amp, which is already filtered via RSS CDATA). Closes #802.
+
 ## [0.21.0] - 2026-04-26
 
 Shipped via PRs #810-#819 (v0.21 rule-candidates sprint: 9 new rules, 3 new validators, rule-bookkeeping automation, safe auto-fixes for Kiro toolSearch).

--- a/scripts/check-tool-releases.sh
+++ b/scripts/check-tool-releases.sh
@@ -152,13 +152,16 @@ for raw_id in "${TOOL_IDS[@]}"; do
   echo "  [NEW] $latest_version (was $baseline_version)"
   NEW_COUNT=$((NEW_COUNT+1))
 
+  # Script directory - used by notes_extractor=glm (to find glm-extract.js)
+  # and by the later agnix-triage step. Hoisted here so both branches share it.
+  script_dir=$(dirname "$0")
+
   # Optional release-notes upgrade: replace the stub release_body with extracted
   # content when the tool defines a notes_extractor (glm | rss_cdata). Failures
   # log a warning and fall back to whatever release_body was already set to.
   notes_extractor=$(jq -r --arg id "$tool_id" '.tools[$id].notes_extractor // "stub"' "$BASELINES_FILE")
   case "$notes_extractor" in
     glm)
-      script_dir=$(dirname "$0")
       if ! command -v node >/dev/null 2>&1; then
         echo "  WARN: notes_extractor=glm but node is not on PATH - using stub"
       elif [[ -z "${GLM_API_KEY:-}" ]]; then
@@ -213,6 +216,41 @@ sys.stdout.write(m.group(1).strip() if m else "")
     release_body="${release_body:0:$ISSUE_BODY_LIMIT}"$'\n\n'"_(release notes truncated at ${ISSUE_BODY_LIMIT} characters; see ${release_url} for the full text)_"
   fi
 
+  # Optional agnix-focused triage: when the tool declares changes_of_interest
+  # and GLM_API_KEY is available, run glm-extract.js --mode=agnix-triage on
+  # the release notes. The LLM filters changes down to validator-relevant
+  # items + rule candidates. Result is prepended as ## Agnix Triage so a
+  # human reviewer sees the filtered summary first and the full changelog
+  # below. On any failure (missing key, empty result, HTTP error), behavior
+  # is identical to before this flag existed.
+  agnix_triage=""
+  interests_json=$(jq -c --arg id "$tool_id" '.tools[$id].changes_of_interest // empty' "$BASELINES_FILE")
+  if [[ -n "$interests_json" ]]; then
+    if ! command -v node >/dev/null 2>&1; then
+      echo "  [triage] changes_of_interest set but node is not on PATH - skipping LLM triage"
+    elif [[ -z "${GLM_API_KEY:-}" ]]; then
+      echo "  [triage] changes_of_interest set but GLM_API_KEY env var is unset - skipping LLM triage"
+    elif [[ -z "${release_body:-}" ]]; then
+      echo "  [triage] no release_body to triage - skipping"
+    else
+      interests_tmp=$(mktemp)
+      printf '%s' "$interests_json" > "$interests_tmp"
+      triage_stderr=$(mktemp)
+      triage_out=$(node "$script_dir/glm-extract.js" \
+        "--mode=agnix-triage" \
+        "--interests-json=$interests_tmp" \
+        "$display_name" "$latest_version" "$release_url" \
+        2>"$triage_stderr" <<< "$release_body" || true)
+      if [[ -n "$triage_out" ]]; then
+        agnix_triage="$triage_out"
+        echo "  [triage] produced $(echo "$triage_out" | wc -c) chars of agnix-focused summary"
+      else
+        echo "  WARN: GLM triage returned empty (stderr: $(head -1 "$triage_stderr" 2>/dev/null)) - posting raw changelog only"
+      fi
+      rm -f "$interests_tmp" "$triage_stderr"
+    fi
+  fi
+
   # Compose issue body. Use absolute file links keyed off GITHUB_REPOSITORY so
   # they resolve correctly inside an issue (relative `../blob/main/...` resolves
   # against the issue URL and 404s).
@@ -226,6 +264,33 @@ sys.stdout.write(m.group(1).strip() if m else "")
   if [[ -n "$repo" ]]; then
     source_line="$source_line"$'\n'"**Repository**: https://github.com/$repo"
   fi
+  if [[ -n "$agnix_triage" ]]; then
+    # Triage succeeded: show the LLM summary first, collapse the raw
+    # changelog under <details> so maintainers read filtered items up top
+    # but still have the full text one click away for verification.
+    release_section=$(cat <<RELEASE_NOTES
+### Agnix Triage (auto-filtered)
+
+$agnix_triage
+
+<details><summary>Full upstream release notes</summary>
+
+$release_body
+
+</details>
+RELEASE_NOTES
+)
+  else
+    # No triage (tool has no changes_of_interest, or LLM failed). Keep
+    # the original layout.
+    release_section=$(cat <<RELEASE_NOTES
+### Release notes
+
+$release_body
+RELEASE_NOTES
+)
+  fi
+
   issue_body=$(cat <<BODY
 ## $display_name $latest_version
 
@@ -234,9 +299,7 @@ $source_line
 
 ---
 
-### Release notes
-
-$release_body
+$release_section
 
 ---
 

--- a/scripts/check-tool-releases.sh
+++ b/scripts/check-tool-releases.sh
@@ -153,8 +153,10 @@ for raw_id in "${TOOL_IDS[@]}"; do
   NEW_COUNT=$((NEW_COUNT+1))
 
   # Script directory - used by notes_extractor=glm (to find glm-extract.js)
-  # and by the later agnix-triage step. Hoisted here so both branches share it.
-  script_dir=$(dirname "$0")
+  # and by the later agnix-triage step. Resolve to an absolute path so
+  # `node "$script_dir/glm-extract.js"` works even when this script is
+  # invoked via a relative path from another working directory.
+  script_dir=$(cd "$(dirname "$0")" && pwd)
 
   # Optional release-notes upgrade: replace the stub release_body with extracted
   # content when the tool defines a notes_extractor (glm | rss_cdata). Failures
@@ -211,11 +213,6 @@ sys.stdout.write(m.group(1).strip() if m else "")
       ;;
   esac
 
-  # Truncate release notes if too long
-  if [[ ${#release_body} -gt $ISSUE_BODY_LIMIT ]]; then
-    release_body="${release_body:0:$ISSUE_BODY_LIMIT}"$'\n\n'"_(release notes truncated at ${ISSUE_BODY_LIMIT} characters; see ${release_url} for the full text)_"
-  fi
-
   # Optional agnix-focused triage: when the tool declares changes_of_interest
   # and GLM_API_KEY is available, run glm-extract.js --mode=agnix-triage on
   # the release notes. The LLM filters changes down to validator-relevant
@@ -223,19 +220,38 @@ sys.stdout.write(m.group(1).strip() if m else "")
   # human reviewer sees the filtered summary first and the full changelog
   # below. On any failure (missing key, empty result, HTTP error), behavior
   # is identical to before this flag existed.
+  #
+  # Runs BEFORE truncation so the LLM sees the complete changelog, not a
+  # half-sentence stub. Skips when release_body is itself a stub link (no
+  # meaningful content to classify) to avoid wasting GLM quota.
   agnix_triage=""
   interests_json=$(jq -c --arg id "$tool_id" '.tools[$id].changes_of_interest // empty' "$BASELINES_FILE")
   if [[ -n "$interests_json" ]]; then
+    # Skip triage on stub-shaped bodies (the fallback shapes in the
+    # html_url branch and the tags-fallback branch both produce
+    # marker-only text that LLM has nothing to filter).
+    is_stub_body=false
+    if [[ "$release_body" == *"This source provides a version marker only"* ]] \
+       || [[ "$release_body" == *"No release notes available"* ]]; then
+      is_stub_body=true
+    fi
+
     if ! command -v node >/dev/null 2>&1; then
       echo "  [triage] changes_of_interest set but node is not on PATH - skipping LLM triage"
     elif [[ -z "${GLM_API_KEY:-}" ]]; then
       echo "  [triage] changes_of_interest set but GLM_API_KEY env var is unset - skipping LLM triage"
     elif [[ -z "${release_body:-}" ]]; then
       echo "  [triage] no release_body to triage - skipping"
+    elif [[ "$is_stub_body" == "true" ]]; then
+      echo "  [triage] release_body is a stub marker - nothing to classify, skipping LLM call"
     else
+      # Use a trap to guarantee cleanup of temp files even if the command
+      # below fails mid-way (CI interruption, SIGTERM, etc.).
       interests_tmp=$(mktemp)
-      printf '%s' "$interests_json" > "$interests_tmp"
       triage_stderr=$(mktemp)
+      # shellcheck disable=SC2064  # intentional early expansion of tmp paths
+      trap "rm -f '$interests_tmp' '$triage_stderr'" EXIT INT TERM
+      printf '%s' "$interests_json" > "$interests_tmp"
       triage_out=$(node "$script_dir/glm-extract.js" \
         "--mode=agnix-triage" \
         "--interests-json=$interests_tmp" \
@@ -248,7 +264,26 @@ sys.stdout.write(m.group(1).strip() if m else "")
         echo "  WARN: GLM triage returned empty (stderr: $(head -1 "$triage_stderr" 2>/dev/null)) - posting raw changelog only"
       fi
       rm -f "$interests_tmp" "$triage_stderr"
+      trap - EXIT INT TERM
     fi
+  fi
+
+  # Truncate release notes if too long. When triage produced content, share
+  # the ISSUE_BODY_LIMIT budget between triage and raw body so the composed
+  # issue fits under GitHub's ~65KB issue-body cap. The triage summary is
+  # the more important view; budget it first and fit raw body into the
+  # remainder.
+  if [[ -n "$agnix_triage" ]]; then
+    triage_limit=$((ISSUE_BODY_LIMIT / 2))
+    if [[ ${#agnix_triage} -gt $triage_limit ]]; then
+      agnix_triage="${agnix_triage:0:$triage_limit}"$'\n\n'"_(triage truncated)_"
+    fi
+    remaining=$((ISSUE_BODY_LIMIT - ${#agnix_triage}))
+    if [[ ${#release_body} -gt $remaining ]]; then
+      release_body="${release_body:0:$remaining}"$'\n\n'"_(release notes truncated to fit; see ${release_url} for the full text)_"
+    fi
+  elif [[ ${#release_body} -gt $ISSUE_BODY_LIMIT ]]; then
+    release_body="${release_body:0:$ISSUE_BODY_LIMIT}"$'\n\n'"_(release notes truncated at ${ISSUE_BODY_LIMIT} characters; see ${release_url} for the full text)_"
   fi
 
   # Compose issue body. Use absolute file links keyed off GITHUB_REPOSITORY so

--- a/scripts/glm-extract.js
+++ b/scripts/glm-extract.js
@@ -53,7 +53,9 @@
 
 const fs = require('fs');
 
-const HTML_BUDGET = 80_000; // chars of input HTML to send to GLM
+// Char budget for stdin payload sent to GLM - applies to both HTML
+// (extract mode) and markdown release notes (agnix-triage mode).
+const INPUT_BUDGET = 80_000;
 const MAX_TOKENS = 4096;
 const TEMPERATURE = 0.3; // extraction task, prefer determinism
 
@@ -105,14 +107,18 @@ const baseUrl = (process.env.GLM_BASE_URL || 'https://api.z.ai/api/coding/paas/v
  * tool without editing this script.
  */
 function loadInterests() {
-  if (!flags['interests-json']) {
-    console.error('--mode=agnix-triage requires --interests-json=<path>');
+  const raw = flags['interests-json'];
+  // Must be a non-empty string path. Bare `--interests-json` with no `=`
+  // would parse to boolean `true`; reject that so we fail loudly instead
+  // of letting `fs.readFileSync(true)` crash with an obscure error.
+  if (!raw || typeof raw !== 'string') {
+    console.error('--mode=agnix-triage requires --interests-json=<path> with a file path value');
     process.exit(2);
   }
   try {
-    return JSON.parse(fs.readFileSync(flags['interests-json'], 'utf8'));
+    return JSON.parse(fs.readFileSync(raw, 'utf8'));
   } catch (err) {
-    console.error(`failed to read ${flags['interests-json']}: ${err.message}`);
+    console.error(`failed to read ${raw}: ${err.message}`);
     process.exit(2);
   }
 }
@@ -161,15 +167,15 @@ function buildAgnixTriagePrompt(notes, interests) {
     'Items that do NOT matter to agnix (safe to ignore):',
     irrelevant,
     '',
-    'Read the release notes below and classify each bullet point. Reply as concise markdown with these sections in order:',
+    'Read the release notes below and classify each bullet point. Reply as concise markdown with these sections in order. Use #### (four hashes) for section headers so they nest under the outer ### Agnix Triage section that wraps this output in the GitHub issue body:',
     '',
-    '## Agnix-relevant changes',
+    '#### Agnix-relevant changes',
     'List each change-type relevant item as a single bullet. Quote the exact phrase from the notes in backticks. If none, write `_None - this release is agnix-irrelevant._`.',
     '',
-    '## Rule candidates',
+    '#### Rule candidates',
     'If any relevant change suggests a new validation rule, propose it as `- <rule name>: <one-line description>`. If none, write `_None._`.',
     '',
-    '## Irrelevant changes (not reviewed)',
+    '#### Irrelevant changes (not reviewed)',
     'One-line summary like `5 items: model additions, UI polish, bug fixes`. Do not enumerate.',
     '',
     'Rules: no preamble, no commentary about extraction, be strict about relevance - when in doubt, classify as irrelevant. Do not fabricate items that are not in the notes.',
@@ -182,7 +188,7 @@ function buildAgnixTriagePrompt(notes, interests) {
 }
 
 (async () => {
-  const stdin = (await readStdin()).slice(0, HTML_BUDGET);
+  const stdin = (await readStdin()).slice(0, INPUT_BUDGET);
   if (!stdin.trim()) {
     console.error('stdin was empty - nothing to process');
     process.exit(2);

--- a/scripts/glm-extract.js
+++ b/scripts/glm-extract.js
@@ -2,10 +2,27 @@
 /*
  * Thin GLM chat-completion client for the tool-release watcher.
  *
- * Reads HTML/text from stdin, asks GLM to extract release notes, writes
- * markdown to stdout. Designed for one-shot extraction - no streaming,
- * no tool calls, no SSE, no retries (the watcher falls back to a stub
- * link if this fails, and tomorrow's run tries again).
+ * Two modes, selected via --mode=<name>:
+ *
+ *   --mode=extract (default)
+ *     Reads HTML/text from stdin, asks GLM to extract release notes for
+ *     the named tool + version. Output is markdown with:
+ *       ## What changed
+ *       ## Likely impact on agnix rules
+ *     Used by kiro/windsurf where upstream provides an HTML changelog
+ *     page rather than a structured GitHub release body.
+ *
+ *   --mode=agnix-triage
+ *     Reads release-notes markdown from stdin (already extracted), plus
+ *     a `--interests-json=<file>` that describes what agnix cares about
+ *     for this tool (which config files, which change-types matter).
+ *     Asks GLM to filter the notes down to just validator-relevant items
+ *     + rule candidates. Output is markdown with:
+ *       ## Agnix-relevant changes
+ *       ## Rule candidates (if any)
+ *       ## Irrelevant (UI, perf, telemetry, etc.)
+ *     Used by tool-release-watch.yml to pre-triage the per-tool issue so
+ *     a human reads a summary instead of the full changelog.
  *
  * Surface and defaults distilled from github.com/avifenesh/cairn
  * internal/llm/glm.go (z.ai coding-paas endpoint, Bearer auth, OpenAI-
@@ -13,6 +30,7 @@
  *
  * Usage:
  *   echo "<html>" | node scripts/glm-extract.js <tool_display_name> <version> <source_url>
+ *   echo "<notes>" | node scripts/glm-extract.js --mode=agnix-triage --interests-json=/tmp/interests.json <tool_display_name> <version> <source_url>
  *
  * Env:
  *   GLM_API_KEY  required - z.ai key in "id.secret" format
@@ -26,20 +44,44 @@
  * Exit codes:
  *   0 - success, markdown on stdout
  *   1 - GLM HTTP error (message on stderr)
- *   2 - missing GLM_API_KEY or required argv
+ *   2 - missing GLM_API_KEY, required argv, or --interests-json when mode=agnix-triage
  *
  * The watcher treats any non-zero exit OR empty stdout as "fall back to stub".
  */
 
 'use strict';
 
+const fs = require('fs');
+
 const HTML_BUDGET = 80_000; // chars of input HTML to send to GLM
 const MAX_TOKENS = 4096;
 const TEMPERATURE = 0.3; // extraction task, prefer determinism
 
-const [, , toolDisplay, version, sourceUrl] = process.argv;
+// Parse argv: collect flags into an options object + leave positional args.
+const argv = process.argv.slice(2);
+const flags = {};
+const positional = [];
+for (const arg of argv) {
+  if (arg.startsWith('--')) {
+    const eq = arg.indexOf('=');
+    if (eq >= 0) {
+      flags[arg.slice(2, eq)] = arg.slice(eq + 1);
+    } else {
+      flags[arg.slice(2)] = true;
+    }
+  } else {
+    positional.push(arg);
+  }
+}
+
+const mode = flags.mode || 'extract';
+const [toolDisplay, version, sourceUrl] = positional;
 if (!toolDisplay || !version || !sourceUrl) {
-  console.error('usage: glm-extract.js <tool_display_name> <version> <source_url>');
+  console.error('usage: glm-extract.js [--mode=extract|agnix-triage] [--interests-json=<path>] <tool_display_name> <version> <source_url>');
+  process.exit(2);
+}
+if (!['extract', 'agnix-triage'].includes(mode)) {
+  console.error(`unknown --mode=${mode}; expected 'extract' or 'agnix-triage'`);
   process.exit(2);
 }
 
@@ -52,24 +94,41 @@ if (!apiKey) {
 const model = process.env.GLM_MODEL || 'glm-5';
 const baseUrl = (process.env.GLM_BASE_URL || 'https://api.z.ai/api/coding/paas/v4').replace(/\/$/, '');
 
+/**
+ * Load the changes_of_interest descriptor for the target tool. Schema:
+ *   {
+ *     "config_surfaces": ["path/to/config.toml", ".tool/settings.json"],
+ *     "relevant": ["new/renamed config keys", "hook event names", ...],
+ *     "irrelevant": ["UI polish", "model additions", ...]
+ *   }
+ * The prompt builder passes these verbatim so the operator can tune per
+ * tool without editing this script.
+ */
+function loadInterests() {
+  if (!flags['interests-json']) {
+    console.error('--mode=agnix-triage requires --interests-json=<path>');
+    process.exit(2);
+  }
+  try {
+    return JSON.parse(fs.readFileSync(flags['interests-json'], 'utf8'));
+  } catch (err) {
+    console.error(`failed to read ${flags['interests-json']}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
 async function readStdin() {
   return new Promise((resolve, reject) => {
     let buf = '';
     process.stdin.setEncoding('utf8');
-    process.stdin.on('data', chunk => { buf += chunk; });
+    process.stdin.on('data', (chunk) => { buf += chunk; });
     process.stdin.on('end', () => resolve(buf));
     process.stdin.on('error', reject);
   });
 }
 
-(async () => {
-  const html = (await readStdin()).slice(0, HTML_BUDGET);
-  if (!html.trim()) {
-    console.error('stdin was empty - nothing to extract');
-    process.exit(2);
-  }
-
-  const prompt = [
+function buildExtractPrompt(html) {
+  return [
     `Extract the release notes for ${toolDisplay} ${version} from the page below.`,
     '',
     'Reply as concise markdown with these sections:',
@@ -84,13 +143,65 @@ async function readStdin() {
     'Page content:',
     html,
   ].join('\n');
+}
+
+function buildAgnixTriagePrompt(notes, interests) {
+  const surfaces = (interests.config_surfaces || []).map((s) => `- \`${s}\``).join('\n') || '- (none declared)';
+  const relevant = (interests.relevant || []).map((s) => `- ${s}`).join('\n') || '- (none declared)';
+  const irrelevant = (interests.irrelevant || []).map((s) => `- ${s}`).join('\n') || '- (none declared)';
+  return [
+    `You are triaging release notes for ${toolDisplay} ${version} from the perspective of agnix, a linter for AI coding-tool config files.`,
+    '',
+    `Agnix validates these ${toolDisplay} config surfaces:`,
+    surfaces,
+    '',
+    'Items that matter to agnix (would likely require a validator update):',
+    relevant,
+    '',
+    'Items that do NOT matter to agnix (safe to ignore):',
+    irrelevant,
+    '',
+    'Read the release notes below and classify each bullet point. Reply as concise markdown with these sections in order:',
+    '',
+    '## Agnix-relevant changes',
+    'List each change-type relevant item as a single bullet. Quote the exact phrase from the notes in backticks. If none, write `_None - this release is agnix-irrelevant._`.',
+    '',
+    '## Rule candidates',
+    'If any relevant change suggests a new validation rule, propose it as `- <rule name>: <one-line description>`. If none, write `_None._`.',
+    '',
+    '## Irrelevant changes (not reviewed)',
+    'One-line summary like `5 items: model additions, UI polish, bug fixes`. Do not enumerate.',
+    '',
+    'Rules: no preamble, no commentary about extraction, be strict about relevance - when in doubt, classify as irrelevant. Do not fabricate items that are not in the notes.',
+    '',
+    `Source URL: ${sourceUrl}`,
+    '',
+    'Release notes:',
+    notes,
+  ].join('\n');
+}
+
+(async () => {
+  const stdin = (await readStdin()).slice(0, HTML_BUDGET);
+  if (!stdin.trim()) {
+    console.error('stdin was empty - nothing to process');
+    process.exit(2);
+  }
+
+  let prompt;
+  if (mode === 'extract') {
+    prompt = buildExtractPrompt(stdin);
+  } else {
+    const interests = loadInterests();
+    prompt = buildAgnixTriagePrompt(stdin, interests);
+  }
 
   let res;
   try {
     res = await fetch(`${baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${apiKey}`,
+        Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary

When \`GLM_API_KEY\` is available and a tool declares \`changes_of_interest\` in the baselines file, the watcher now filters release notes down to validator-relevant items + rule candidates before opening the per-tool issue. Saves a human from scanning the full upstream changelog for schema impact.

## Closes

- #802

## Why

During the 2026-04-25 triage batch (#810):
- 4 of 8 tools (OpenCode, Cline, Cursor, Roo) had **zero** schema impact but still required reading full release notes
- The 4 with impact had 2-5 relevant items buried in 15-50 bullet points
- GLM takes ~22s per call; a human triage read was ~5-15 min per tool

## Design

### \`glm-extract.js\` gains \`--mode=agnix-triage\`

The existing \`extract\` mode (default, used by kiro/windsurf HTML scraping) keeps its behavior. The new mode:
- Reads already-extracted release notes from stdin
- Takes \`--interests-json=<path>\` pointing at a \`{config_surfaces, relevant, irrelevant}\` descriptor
- Prompts GLM to classify each change and emit:
  - \`## Agnix-relevant changes\` (quoted bullets from the notes)
  - \`## Rule candidates\` (if any)
  - \`## Irrelevant changes (not reviewed)\` (one-line summary)

### \`check-tool-releases.sh\` post-processing

Runs after \`release_body\` is determined (regardless of source: GitHub release body, glm extract, rss_cdata, or stub). If the triage returns non-empty output:
- Issue body shows \`## Agnix Triage (auto-filtered)\` at the top
- Full upstream changelog goes inside \`<details><summary>Full upstream release notes</summary>...\` below

If anything fails (no key, empty response, HTTP error, node missing), behavior is **identical** to before this PR - original \`### Release notes\` layout with full changelog inline.

### \`tool-release-baselines.json\` v1.1

Adds \`changes_of_interest\` per tool. 10 of 11 tracked tools have descriptors:

| Tool | Covered surfaces |
|---|---|
| claude-code | CLAUDE.md, settings.json variants, hooks, skills/agents, .claude-plugin, .mcp.json |
| codex | AGENTS.md, config.toml, codex-plugin, mcp_servers blocks |
| opencode | AGENTS.md, .opencode/config.json, MCP config |
| kiro | steering/agents/hooks/mcp/powers/settings (incl. 2.1 skills) |
| copilot | copilot-instructions.md + instructions/*.md |
| cline | .clinerules + workflows/hooks/skills |
| cursor | .cursor/rules/*.mdc + hooks/agents/environment/mcp |
| roo-code | .roomodes + .roorules + .roo/* |
| gemini-cli | GEMINI.md, .gemini/settings.json, .gemini/agents/*.md, gemini-extension.json |
| windsurf | .windsurf/rules + workflows, .windsurfrules legacy |

amp is skipped - its rss_cdata extractor already pre-filters to the first news post.

## Test plan

- [x] \`bash -n scripts/check-tool-releases.sh\` syntax-clean
- [x] \`node scripts/glm-extract.js --mode=invalid ...\` exits 2 with clear error
- [x] \`node scripts/glm-extract.js --mode=agnix-triage\` without \`--interests-json\` exits 2
- [x] Prompt construction verified end-to-end against a dummy GLM_API_KEY (hits API, returns 401, proving the fetch path + prompt shape are correct)
- [x] \`cargo test --workspace --all-targets\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`node scripts/sync-rule-bookkeeping.js --check\` clean
- [x] JSON validity of baselines file verified

## Zero-regression contract

Every failure mode falls through to the prior behavior:
- \`GLM_API_KEY\` unset -> log \`[triage]\` warning, post raw changelog (as today)
- \`node\` not on PATH -> same
- Tool lacks \`changes_of_interest\` -> skip triage entirely, post raw changelog
- LLM returns empty / HTTP error -> log WARN, post raw changelog

## Follow-ups

After this lands: the next watcher run (daily 7am UTC) will produce pre-filtered issues for any new upstream release. Can also be triggered manually via workflow_dispatch to re-triage an existing release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new optional LLM call in the release-watcher pipeline and changes issue-body formatting, which could affect monitoring noise/issue content if the triage prompt or GLM behavior is off, but it falls back to the prior raw-changelog behavior on failure.
> 
> **Overview**
> When `GLM_API_KEY` is set and a tool declares `changes_of_interest`, tool-release issues now start with an **LLM-generated “Agnix Triage”** section that filters upstream release notes down to validator-relevant items and potential rule candidates, with the full changelog preserved under a `<details>` block.
> 
> This updates `scripts/glm-extract.js` to support a new `--mode=agnix-triage` (in addition to the existing extraction mode), extends `scripts/check-tool-releases.sh` to invoke it opportunistically with robust fallback, and bumps `.github/tool-release-baselines.json` to `v1.1` adding per-tool triage descriptors for most tracked tools (plus minor workflow/docs updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0143a1e0526f1a8cf5eb24f7b36caa6777e6cb82. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->