### PR TITLE
fix: sync plugin.json version and rule count with npm package [skip changelog]

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
-  "version": "0.16.1",
-  "description": "Lint agent configurations before they break your workflow. 405 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "version": "0.20.0",
+  "description": "Lint agent configurations before they break your workflow. 414 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "[email protected]",


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugin/.claude-plugin/plugin.json` declares `"version": "0.16.1"` while `npm/package.json` is at `"0.20.0"` — 4 minor versions behind. The plugin description in that same file also cites "405 rules", while the current rule count (documented in `CLAUDE.md` and tracked by `scripts/sync-rule-bookkeeping.js`) is 414.

**Impact**: Any tooling that reads `plugin/.claude-plugin/plugin.json` to determine the plugin version (marketplace indexers, Claude Code's plugin install flow) will see a stale version number and an incorrect rule count.

## Fix

- Bumped `"version"` from `"0.16.1"` to `"0.20.0"` to match `npm/package.json`
- Updated the description from `"405 rules"` to `"414 rules"`

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"CC-stale-count","fingerprint":"sha256:039a69bf4b89f3c3870ada215f3e64ad1129439e652b03a561aa6f8f28652fe9"}]}
nlpm-metadata-end -->