### PR TITLE
fix: update stale rule count from 405 to 414 in plugin and skill files [skip changelog]

### DIFF
--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 405 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 414 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 405 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 414 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 ---
 

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 405 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 414 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three production files cite `405 rules` in their descriptions, but `CLAUDE.md` documents 414 rules and the npm package is at `v0.20.0`. The `scripts/sync-rule-bookkeeping.js` script exists to keep these counts in sync, but was not run on the plugin/skill distribution files.

**Affected files:**
- `plugin/commands/agnix.md` — `codex-description` field
- `plugin/skills/agnix/SKILL.md` — `description` frontmatter field
- `skills/agnix/SKILL.md` — `description` frontmatter field

**Impact**: Users see an incorrect rule count in tool trigger phrases and skill descriptions. This reduces trust in the tool's documentation accuracy.

## Fix

Updated all three occurrences of `405 rules` → `414 rules` to match the actual count tracked in `CLAUDE.md` and `VALIDATION-RULES.md`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"CC-stale-count","fingerprint":"sha256:17a15f4663964c5b99248ee3ec99e2e6752239bb65de9fae862630077829e60e"},{"rule_id":"CC-stale-count","fingerprint":"sha256:2936ce241191d0834e2443a2c76895a07bb3de3c64b3cb1c973e209f9f970a98"},{"rule_id":"CC-stale-count","fingerprint":"sha256:c125b644c2d53270450c67dd0f6cf9c29388d961bbfa79ca84e0e0f33c7846e7"}]}
nlpm-metadata-end -->