### PR TITLE
fix: add missing allowed-tools to plugin/skills/agnix/SKILL.md [skip changelog]

### DIFF
--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -2,6 +2,7 @@
 name: agnix
 description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 405 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
+allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 
 # agnix


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The two distributions of the agnix skill have diverged:

- `skills/agnix/SKILL.md` (root) declares `allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep`
- `plugin/skills/agnix/SKILL.md` (plugin) has no `allowed-tools` field at all

Without `allowed-tools`, the plugin skill runs with whatever permissions the invoking agent has — which may be broader than intended. The root skill explicitly restricts execution to `agnix` and `cargo` Bash commands plus read-only file operations.

**Impact**: Users who install agnix via the Claude Code plugin (`claude plugin install agnix`) get a skill that can execute arbitrary Bash commands, while users who load the root skill file get a properly scoped version. This is a security-relevant divergence.

## Fix

Added `allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep` to `plugin/skills/agnix/SKILL.md`, matching the existing declaration in `skills/agnix/SKILL.md`.

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"CC-orphan-component","fingerprint":"sha256:efa1ee83d78ac53a9e14b6d00a6c080e65a396f742aebf8a0079bdef0a9eaec9"}]}
nlpm-metadata-end -->