### PR TITLE
chore: bump tool-release baselines for OpenCode v1.14.28 + amp opus-4.7

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-04-26",
+  "last_updated": "2026-04-28",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.14.25",
+      "last_known_version": "v1.14.28",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -302,7 +302,7 @@
       "html_url": "https://ampcode.com/news.rss",
       "version_regex": "https://ampcode\\.com/news/[a-zA-Z0-9._-]+",
       "notes_extractor": "rss_cdata",
-      "last_known_version": "amp-free-is-ad-free",
+      "last_known_version": "opus-4.7",
       "tracked": true,
       "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed)."
     },

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -18,7 +18,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-25 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
 | Codex CLI | `AGENTS.md`, `codex.toml` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-25 | AGM, XP |
-| OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-25 | AGM, XP, OC |
+| OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-28 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/powers/*/POWER.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-04-25 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK |
 
 ### A Tier (test on major changes)
@@ -34,7 +34,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Roo Code | `.roomodes`, `.rooignore`, `.roorules`, `.roo/rules/*.md`, `.roo/rules-{slug}/*.md`, `.roo/mcp.json` | https://github.com/RooCodeInc/Roo-Code | Automated (tool-release-watch.yml) | Quarterly | 2026-04-25 | ROO |
-| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-04-23 | AMP, AMP-SK |
+| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-04-28 | AMP, AMP-SK |
 
 ### C Tier (community reports fixes only)
 


### PR DESCRIPTION
## Summary

Closes two auto-opened tool-release tracker issues; both releases are agnix-irrelevant per the workflow's auto-triage.

- **OpenCode v1.14.25 → v1.14.28** (tier `s`, #833). Only fix in the release is `opencode upgrade` failing for bun installs without a `package.json`. No change to `AGENTS.md` / `.opencode/config.json` schema, permissions, LSP, or MCP config shape.
- **amp `amp-free-is-ad-free` → `opus-4.7`** (tier `b`, #825). Model swap to Opus 4.7 in `smart` mode, removal of built-in `grep`/`glob`/`mermaid` tools, new `Opt+D` thinking-effort toggle. None of these change `.amp/settings.json` or `.agents/checks/*.md` shape.

## Changes

- `.github/tool-release-baselines.json` — bump `last_known_version` for both tools; bump `last_updated` to `2026-04-28`.
- `knowledge-base/RESEARCH-TRACKING.md` — bump "Last Reviewed" to `2026-04-28` for OpenCode and amp rows.

## Test plan

- [x] `jq -e . .github/tool-release-baselines.json` passes.
- [ ] CI green.
- [ ] Closes #833 and #825 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only update: bumps tracked release markers and review dates without changing any validation logic or runtime behavior.
> 
> **Overview**
> Updates tool-release tracking baselines by bumping `last_updated` and advancing `last_known_version` for **OpenCode** to `v1.14.28` and **amp** to `opus-4.7` in `.github/tool-release-baselines.json`.
> 
> Refreshes the corresponding **"Last Reviewed"** dates for OpenCode and amp to `2026-04-28` in `knowledge-base/RESEARCH-TRACKING.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19d3da8f64b5b76d4745b32b094029e5ef30f7c4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->