### PR TITLE
feat(mcp): add MCP-025 for non-boolean alwaysLoad values (closes #835)

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.119",
+      "last_known_version": "v2.1.121",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Install website dependencies
         run: npm --prefix website ci
       - name: Generate rule docs and build site
+        # 415+ generated rule pages push webpack's server-side compile past
+        # Node's default ~4 GB heap; raise it to 6 GB (GitHub runners have
+        # ~7 GB). Pre-existing OOM observed on main's 2026-04-26 run.
+        env:
+          NODE_OPTIONS: '--max-old-space-size=6144'
         run: npm --prefix website run build
       - name: Run docs parity test
         run: cargo test -p agnix-cli --test docs_website_parity

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 414 rules, 75+ sources, rules.json
+knowledge-base/     # 415 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-414 rules defined in `knowledge-base/rules.json` (source of truth)
+415 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.18.0 - Production-ready with full validation pipeline
-- 414 validation rules across 42 validators
+- 415 validation rules across 42 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **MCP-025: non-boolean `alwaysLoad` in MCP server config** (#836). Claude Code 2.1.121 introduced an `alwaysLoad: boolean` field on MCP server entries - when `true`, every tool from that server skips tool-search deferral and is always available. A typo like `"alwaysLoad": "true"` (quoted string) is a silent footgun: Claude Code treats it as truthy in some code paths and ignores it in others, so the user's intent silently fails. MCP-025 (MEDIUM) flags non-boolean values before they reach Claude Code. Also teaches MCP-024 that `{ "alwaysLoad": true }` is a deliberate field, not an "empty server" false positive.
+- **Tool baseline**: `claude-code` bumped from v2.1.119 to v2.1.121 in `.github/tool-release-baselines.json` and `knowledge-base/RESEARCH-TRACKING.md`.
+- **Rule count**: 414 -> 415 across all derived locations (rules.json, CLAUDE.md, AGENTS.md, README.md, website docs) via `scripts/sync-rule-bookkeeping.js`.
+
 ## [0.22.1] - 2026-04-26
 
 Security-only patch release shipped via PR #826. No user-visible feature changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 414 rules, 75+ sources, rules.json
+knowledge-base/     # 415 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-414 rules defined in `knowledge-base/rules.json` (source of truth)
+415 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.18.0 - Production-ready with full validation pipeline
-- 414 validation rules across 42 validators
+- 415 validation rules across 42 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>414 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>415 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 414 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 415 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/crates/agnix-core/src/rules/mcp.rs
+++ b/crates/agnix-core/src/rules/mcp.rs
@@ -508,7 +508,15 @@ fn parse_mcp_server_lenient(value: &serde_json::Value) -> McpServerConfig {
             .get("url")
             .and_then(|v| v.as_str())
             .map(ToOwned::to_owned),
-        always_load: obj.get("alwaysLoad").cloned(),
+        // Map explicit `null` to absent so the lenient path matches the
+        // strict serde path, where `#[serde(default)]` collapses `null`
+        // into `None` for `Option<Value>`. Without this, MCP-025 would
+        // false-positive on `alwaysLoad: null` whenever some other field
+        // forces the fallback.
+        always_load: obj
+            .get("alwaysLoad")
+            .filter(|v| !v.is_null())
+            .cloned(),
     }
 }
 
@@ -1322,7 +1330,13 @@ fn has_meaningful_server_config(server: &McpServerConfig) -> bool {
         .as_deref()
         .is_some_and(|value| !value.trim().is_empty());
     let has_env = server.env.as_ref().is_some_and(|env| !env.is_empty());
-    let has_always_load = server.always_load.is_some();
+    // Explicit JSON `null` is conventionally "field absent" - match that for
+    // alwaysLoad so `{ "alwaysLoad": null }` is still flagged as an empty
+    // server by MCP-024 instead of masquerading as meaningful config.
+    let has_always_load = server
+        .always_load
+        .as_ref()
+        .is_some_and(|value| !value.is_null());
     has_type || has_command || has_args || has_url || has_env || has_always_load
 }
 
@@ -1618,32 +1632,45 @@ fn validate_server(
     // field. When `true`, every tool from that server skips tool-search
     // deferral. The key is declared as boolean; a string like "true" is a
     // silent footgun - Claude Code treats it as truthy in some code paths
-    // and ignores it in others. Flag any non-boolean value so the typo is
+    // and ignores it in others. Flag non-boolean values so the typo is
     // caught before it silently disables the intended always-available
     // behavior.
+    //
+    // Severity is MEDIUM and we emit `Diagnostic::warning` to match
+    // MCP-021 and the other MEDIUM MCP rules. An incorrect alwaysLoad
+    // value fails safe-by-default - Claude Code just uses on-demand
+    // tool search - so this is a config smell, not a breakage.
+    //
+    // Explicit JSON `null` is treated as field-absent, matching JSON
+    // convention and `has_meaningful_server_config` above. The strict
+    // serde path collapses `null` into `None` via `#[serde(default)]`;
+    // `parse_mcp_server_lenient` now mirrors that. The `!value.is_null()`
+    // guard here is defense-in-depth against a future caller that
+    // constructs `McpServerConfig` with `Some(Value::Null)` directly.
+    //
+    // The diagnostic points at the server-header `(line, col)` used by
+    // all other per-server rules. A precise per-field location would
+    // require a server-span collector (like `collect_tools_array_object_spans`
+    // for tools); left as a future enhancement so every per-server rule
+    // can benefit together rather than MCP-025 inventing its own.
     if config.is_rule_enabled("MCP-025")
         && let Some(value) = &server.always_load
         && !value.is_boolean()
+        && !value.is_null()
     {
         let actual_type = match value {
             serde_json::Value::String(_) => "string",
             serde_json::Value::Number(_) => "number",
-            serde_json::Value::Null => "null",
             serde_json::Value::Array(_) => "array",
             serde_json::Value::Object(_) => "object",
-            serde_json::Value::Bool(_) => unreachable!(),
-        };
-        let (al_line, al_col) = find_json_field_location(content, "alwaysLoad");
-        let (diag_line, diag_col) = if al_line > 0 {
-            (al_line, al_col)
-        } else {
-            (line, col)
+            // Bool and Null are excluded by the guards above.
+            serde_json::Value::Bool(_) | serde_json::Value::Null => unreachable!(),
         };
         diagnostics.push(
-            Diagnostic::error(
+            Diagnostic::warning(
                 path.to_path_buf(),
-                diag_line,
-                diag_col,
+                line,
+                col,
                 "MCP-025",
                 format!(
                     "Server '{}' has non-boolean 'alwaysLoad' value (got {})",
@@ -3348,6 +3375,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_mcp_024_triggers_when_only_field_is_null_always_load() {
+        // An explicit JSON `null` for alwaysLoad is conventionally "absent";
+        // it should NOT save the server from MCP-024. This guards against
+        // Some(Value::Null) masquerading as a meaningful field.
+        let content = r#"{
+            "mcpServers": {
+                "empty-ish": { "alwaysLoad": null }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "MCP-024"),
+            "MCP-024 should fire when alwaysLoad is the only field and it's null"
+        );
+    }
+
     // ===== MCP-025 Tests =====
 
     #[test]
@@ -3442,6 +3486,50 @@ mod tests {
         let mcp_025: Vec<_> = diagnostics.iter().filter(|d| d.rule == "MCP-025").collect();
         assert_eq!(mcp_025.len(), 1);
         assert!(mcp_025[0].message.contains("array"));
+    }
+
+    #[test]
+    fn test_mcp_025_emits_warning_not_error() {
+        // Severity is MEDIUM, so the diagnostic level must match the
+        // MEDIUM convention used by MCP-021 and other MEDIUM MCP rules.
+        use crate::diagnostics::DiagnosticLevel;
+        let content = r#"{
+            "mcpServers": {
+                "fs": { "type": "stdio", "command": "node", "alwaysLoad": "true" }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        let mcp_025: Vec<_> = diagnostics.iter().filter(|d| d.rule == "MCP-025").collect();
+        assert_eq!(mcp_025.len(), 1);
+        assert_eq!(
+            mcp_025[0].level,
+            DiagnosticLevel::Warning,
+            "MCP-025 is MEDIUM severity; diagnostic level must be Warning (not Error)"
+        );
+    }
+
+    #[test]
+    fn test_mcp_025_null_ignored_via_lenient_parser_fallback() {
+        // This exercises `parse_mcp_server_lenient` - when a sibling field
+        // forces the fallback (here `args: "oops"` breaks strict parsing),
+        // `alwaysLoad: null` must still be treated as absent rather than
+        // flagged as a non-boolean. Regression guard for Copilot's finding
+        // that the lenient parser was cloning null into Some(Value::Null).
+        let content = r#"{
+            "mcpServers": {
+                "fs": {
+                    "type": "stdio",
+                    "command": "node",
+                    "args": "not-an-array-so-strict-parse-fails",
+                    "alwaysLoad": null
+                }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        assert!(
+            !diagnostics.iter().any(|d| d.rule == "MCP-025"),
+            "MCP-025 must not fire on alwaysLoad: null even through the lenient parser"
+        );
     }
 
     // ===== Multiple servers test =====

--- a/crates/agnix-core/src/rules/mcp.rs
+++ b/crates/agnix-core/src/rules/mcp.rs
@@ -1634,7 +1634,11 @@ fn validate_server(
             serde_json::Value::Bool(_) => unreachable!(),
         };
         let (al_line, al_col) = find_json_field_location(content, "alwaysLoad");
-        let (diag_line, diag_col) = if al_line > 0 { (al_line, al_col) } else { (line, col) };
+        let (diag_line, diag_col) = if al_line > 0 {
+            (al_line, al_col)
+        } else {
+            (line, col)
+        };
         diagnostics.push(
             Diagnostic::error(
                 path.to_path_buf(),

--- a/crates/agnix-core/src/rules/mcp.rs
+++ b/crates/agnix-core/src/rules/mcp.rs
@@ -509,10 +509,12 @@ fn parse_mcp_server_lenient(value: &serde_json::Value) -> McpServerConfig {
             .and_then(|v| v.as_str())
             .map(ToOwned::to_owned),
         // Map explicit `null` to absent so the lenient path matches the
-        // strict serde path, where `#[serde(default)]` collapses `null`
-        // into `None` for `Option<Value>`. Without this, MCP-025 would
-        // false-positive on `alwaysLoad: null` whenever some other field
-        // forces the fallback.
+        // strict serde path. For `Option<Value>`, serde's `Option` impl
+        // already treats explicit `null` as `None` (independent of
+        // `#[serde(default)]`, which only affects missing keys). Without
+        // this filter the lenient branch would clone `Value::Null` and
+        // MCP-025 would false-positive on `alwaysLoad: null` whenever
+        // some sibling field forces the fallback.
         always_load: obj.get("alwaysLoad").filter(|v| !v.is_null()).cloned(),
     }
 }
@@ -1639,11 +1641,14 @@ fn validate_server(
     // tool search - so this is a config smell, not a breakage.
     //
     // Explicit JSON `null` is treated as field-absent, matching JSON
-    // convention and `has_meaningful_server_config` above. The strict
-    // serde path collapses `null` into `None` via `#[serde(default)]`;
-    // `parse_mcp_server_lenient` now mirrors that. The `!value.is_null()`
-    // guard here is defense-in-depth against a future caller that
-    // constructs `McpServerConfig` with `Some(Value::Null)` directly.
+    // convention and `has_meaningful_server_config` above. For
+    // `Option<Value>`, serde's own `Option` impl collapses an explicit
+    // `null` into `None` (independent of `#[serde(default)]`, which
+    // only affects missing keys). `parse_mcp_server_lenient` filters
+    // `null` before cloning so the two paths agree. The
+    // `!value.is_null()` guard here is defense-in-depth against a
+    // future caller that constructs `McpServerConfig` with
+    // `Some(Value::Null)` directly.
     //
     // The diagnostic points at the server-header `(line, col)` used by
     // all other per-server rules. A precise per-field location would
@@ -3358,8 +3363,9 @@ mod tests {
         // MCP-024 flags "empty" servers. An `alwaysLoad` boolean alone is
         // still meaningless without a type/command/url, but it IS a
         // deliberate field so we should NOT report MCP-024 here. MCP-009
-        // (missing command for the default stdio transport) is the right
-        // diagnostic for this case.
+        // (missing command for the default stdio transport) IS the right
+        // diagnostic for this case - assert it fires so the test doesn't
+        // silently become vacuous if validation behavior changes.
         let content = r#"{
             "mcpServers": {
                 "partial": { "alwaysLoad": true }
@@ -3369,6 +3375,10 @@ mod tests {
         assert!(
             !diagnostics.iter().any(|d| d.rule == "MCP-024"),
             "MCP-024 should not fire when alwaysLoad is set"
+        );
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "MCP-009"),
+            "MCP-009 (missing command for stdio) should fire instead"
         );
     }
 
@@ -3483,6 +3493,30 @@ mod tests {
         let mcp_025: Vec<_> = diagnostics.iter().filter(|d| d.rule == "MCP-025").collect();
         assert_eq!(mcp_025.len(), 1);
         assert!(mcp_025[0].message.contains("array"));
+    }
+
+    #[test]
+    fn test_mcp_025_flags_object_value() {
+        // Covers the `object` branch of the type-name match arm so no
+        // arm is silently untested - a user might imagine alwaysLoad as
+        // a structured config like `{ "enabled": true, "scope": "all" }`.
+        let content = r#"{
+            "mcpServers": {
+                "fs": {
+                    "type": "stdio",
+                    "command": "node",
+                    "alwaysLoad": { "enabled": true }
+                }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        let mcp_025: Vec<_> = diagnostics.iter().filter(|d| d.rule == "MCP-025").collect();
+        assert_eq!(mcp_025.len(), 1);
+        assert!(
+            mcp_025[0].message.contains("object"),
+            "diagnostic should name the object type, got: {}",
+            mcp_025[0].message
+        );
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/mcp.rs
+++ b/crates/agnix-core/src/rules/mcp.rs
@@ -1,4 +1,4 @@
-//! MCP (Model Context Protocol) validation (MCP-001 to MCP-024)
+//! MCP (Model Context Protocol) validation (MCP-001 to MCP-025)
 
 use crate::{
     config::LintConfig,
@@ -233,6 +233,7 @@ const RULE_IDS: &[&str] = &[
     "MCP-001", "MCP-002", "MCP-003", "MCP-004", "MCP-005", "MCP-006", "MCP-007", "MCP-008",
     "MCP-009", "MCP-010", "MCP-011", "MCP-012", "MCP-013", "MCP-014", "MCP-015", "MCP-016",
     "MCP-017", "MCP-018", "MCP-019", "MCP-020", "MCP-021", "MCP-022", "MCP-023", "MCP-024",
+    "MCP-025",
 ];
 
 pub struct McpValidator;
@@ -491,6 +492,7 @@ fn parse_mcp_server_lenient(value: &serde_json::Value) -> McpServerConfig {
             args: None,
             env: None,
             url: None,
+            always_load: None,
         };
     };
 
@@ -506,6 +508,7 @@ fn parse_mcp_server_lenient(value: &serde_json::Value) -> McpServerConfig {
             .get("url")
             .and_then(|v| v.as_str())
             .map(ToOwned::to_owned),
+        always_load: obj.get("alwaysLoad").cloned(),
     }
 }
 
@@ -1319,10 +1322,11 @@ fn has_meaningful_server_config(server: &McpServerConfig) -> bool {
         .as_deref()
         .is_some_and(|value| !value.trim().is_empty());
     let has_env = server.env.as_ref().is_some_and(|env| !env.is_empty());
-    has_type || has_command || has_args || has_url || has_env
+    let has_always_load = server.always_load.is_some();
+    has_type || has_command || has_args || has_url || has_env || has_always_load
 }
 
-/// Validate a single MCP server configuration entry (MCP-009 to MCP-012, MCP-017 to MCP-022, MCP-024)
+/// Validate a single MCP server configuration entry (MCP-009 to MCP-012, MCP-017 to MCP-022, MCP-024, MCP-025)
 fn validate_server(
     name: &str,
     server: &McpServerConfig,
@@ -1606,6 +1610,44 @@ fn validate_server(
             )
             .with_suggestion(
                 "Define at least one meaningful field such as type, command, url, args, or env",
+            ),
+        );
+    }
+
+    // MCP-025: Claude Code 2.1.121+ introduced an `alwaysLoad` MCP server
+    // field. When `true`, every tool from that server skips tool-search
+    // deferral. The key is declared as boolean; a string like "true" is a
+    // silent footgun - Claude Code treats it as truthy in some code paths
+    // and ignores it in others. Flag any non-boolean value so the typo is
+    // caught before it silently disables the intended always-available
+    // behavior.
+    if config.is_rule_enabled("MCP-025")
+        && let Some(value) = &server.always_load
+        && !value.is_boolean()
+    {
+        let actual_type = match value {
+            serde_json::Value::String(_) => "string",
+            serde_json::Value::Number(_) => "number",
+            serde_json::Value::Null => "null",
+            serde_json::Value::Array(_) => "array",
+            serde_json::Value::Object(_) => "object",
+            serde_json::Value::Bool(_) => unreachable!(),
+        };
+        let (al_line, al_col) = find_json_field_location(content, "alwaysLoad");
+        let (diag_line, diag_col) = if al_line > 0 { (al_line, al_col) } else { (line, col) };
+        diagnostics.push(
+            Diagnostic::error(
+                path.to_path_buf(),
+                diag_line,
+                diag_col,
+                "MCP-025",
+                format!(
+                    "Server '{}' has non-boolean 'alwaysLoad' value (got {})",
+                    name, actual_type
+                ),
+            )
+            .with_suggestion(
+                "Set alwaysLoad to true or false (unquoted). Strings like \"true\" are silently ignored by Claude Code.",
             ),
         );
     }
@@ -2521,6 +2563,7 @@ mod tests {
             "MCP-001", "MCP-002", "MCP-003", "MCP-004", "MCP-005", "MCP-006", "MCP-007", "MCP-008",
             "MCP-009", "MCP-010", "MCP-011", "MCP-012", "MCP-013", "MCP-014", "MCP-015", "MCP-016",
             "MCP-017", "MCP-018", "MCP-019", "MCP-020", "MCP-021", "MCP-022", "MCP-023", "MCP-024",
+            "MCP-025",
         ];
 
         for rule in rules {
@@ -2563,6 +2606,9 @@ mod tests {
                     r#"{"mcpServers":{"dup":{"type":"stdio","command":"node"},"dup":{"type":"stdio","command":"node"}}}"#
                 }
                 "MCP-024" => r#"{"mcpServers":{"empty":{}}}"#,
+                "MCP-025" => {
+                    r#"{"mcpServers":{"s":{"type":"stdio","command":"node","alwaysLoad":"true"}}}"#
+                }
                 _ => r#"{"tools": [{"name": "t"}]}"#,
             };
 
@@ -3277,6 +3323,121 @@ mod tests {
         }"#;
         let diagnostics = validate(content);
         assert!(diagnostics.iter().any(|d| d.rule == "MCP-024"));
+    }
+
+    #[test]
+    fn test_mcp_024_not_triggered_by_always_load_only() {
+        // MCP-024 flags "empty" servers. An `alwaysLoad` boolean alone is
+        // still meaningless without a type/command/url, but it IS a
+        // deliberate field so we should NOT report MCP-024 here. MCP-009
+        // (missing command for the default stdio transport) is the right
+        // diagnostic for this case.
+        let content = r#"{
+            "mcpServers": {
+                "partial": { "alwaysLoad": true }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        assert!(
+            !diagnostics.iter().any(|d| d.rule == "MCP-024"),
+            "MCP-024 should not fire when alwaysLoad is set"
+        );
+    }
+
+    // ===== MCP-025 Tests =====
+
+    #[test]
+    fn test_mcp_025_accepts_boolean_true() {
+        let content = r#"{
+            "mcpServers": {
+                "fs": { "type": "stdio", "command": "node", "alwaysLoad": true }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        assert!(
+            !diagnostics.iter().any(|d| d.rule == "MCP-025"),
+            "MCP-025 should not fire on a real boolean"
+        );
+    }
+
+    #[test]
+    fn test_mcp_025_accepts_boolean_false() {
+        let content = r#"{
+            "mcpServers": {
+                "fs": { "type": "stdio", "command": "node", "alwaysLoad": false }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        assert!(!diagnostics.iter().any(|d| d.rule == "MCP-025"));
+    }
+
+    #[test]
+    fn test_mcp_025_accepts_missing_field() {
+        let content = r#"{
+            "mcpServers": {
+                "fs": { "type": "stdio", "command": "node" }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        assert!(!diagnostics.iter().any(|d| d.rule == "MCP-025"));
+    }
+
+    #[test]
+    fn test_mcp_025_flags_string_value() {
+        let content = r#"{
+            "mcpServers": {
+                "fs": { "type": "stdio", "command": "node", "alwaysLoad": "true" }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        let mcp_025: Vec<_> = diagnostics.iter().filter(|d| d.rule == "MCP-025").collect();
+        assert_eq!(mcp_025.len(), 1);
+        assert!(
+            mcp_025[0].message.contains("string"),
+            "diagnostic should mention the actual type, got: {}",
+            mcp_025[0].message
+        );
+    }
+
+    #[test]
+    fn test_mcp_025_flags_number_value() {
+        let content = r#"{
+            "mcpServers": {
+                "fs": { "type": "stdio", "command": "node", "alwaysLoad": 1 }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        let mcp_025: Vec<_> = diagnostics.iter().filter(|d| d.rule == "MCP-025").collect();
+        assert_eq!(mcp_025.len(), 1);
+        assert!(mcp_025[0].message.contains("number"));
+    }
+
+    #[test]
+    fn test_mcp_025_null_is_treated_as_absent() {
+        // serde collapses an explicit JSON `null` into "field absent" when
+        // the target is `Option<Value>`, matching the usual JSON convention.
+        // MCP-025 should therefore NOT fire on `alwaysLoad: null` - the
+        // user clearly didn't intend to enable always-load.
+        let content = r#"{
+            "mcpServers": {
+                "fs": { "type": "stdio", "command": "node", "alwaysLoad": null }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        assert!(!diagnostics.iter().any(|d| d.rule == "MCP-025"));
+    }
+
+    #[test]
+    fn test_mcp_025_flags_array_value() {
+        let content = r#"{
+            "mcpServers": {
+                "fs": { "type": "stdio", "command": "node", "alwaysLoad": [true] }
+            }
+        }"#;
+        let diagnostics = validate(content);
+        let mcp_025: Vec<_> = diagnostics.iter().filter(|d| d.rule == "MCP-025").collect();
+        assert_eq!(mcp_025.len(), 1);
+        assert!(mcp_025[0].message.contains("array"));
     }
 
     // ===== Multiple servers test =====

--- a/crates/agnix-core/src/rules/mcp.rs
+++ b/crates/agnix-core/src/rules/mcp.rs
@@ -1680,7 +1680,7 @@ fn validate_server(
                 ),
             )
             .with_suggestion(
-                "Set alwaysLoad to true or false (unquoted). Strings like \"true\" are silently ignored by Claude Code.",
+                "Set alwaysLoad to true or false (unquoted). Non-boolean values are not consistently applied by Claude Code - they may be treated as truthy in some code paths and ignored in others.",
             ),
         );
     }

--- a/crates/agnix-core/src/rules/mcp.rs
+++ b/crates/agnix-core/src/rules/mcp.rs
@@ -513,10 +513,7 @@ fn parse_mcp_server_lenient(value: &serde_json::Value) -> McpServerConfig {
         // into `None` for `Option<Value>`. Without this, MCP-025 would
         // false-positive on `alwaysLoad: null` whenever some other field
         // forces the fallback.
-        always_load: obj
-            .get("alwaysLoad")
-            .filter(|v| !v.is_null())
-            .cloned(),
+        always_load: obj.get("alwaysLoad").filter(|v| !v.is_null()).cloned(),
     }
 }
 

--- a/crates/agnix-core/src/schemas/mcp.rs
+++ b/crates/agnix-core/src/schemas/mcp.rs
@@ -182,6 +182,13 @@ pub struct McpServerConfig {
 
     /// Server endpoint URL (required for http/sse)
     pub url: Option<String>,
+
+    /// Claude Code 2.1.121+: when `true`, all tools from this server skip
+    /// tool-search deferral and are always available. Must be a boolean
+    /// when present (MCP-025). Deserialized as `serde_json::Value` so we
+    /// can diagnose wrong types rather than failing the whole parse.
+    #[serde(rename = "alwaysLoad", default)]
+    pub always_load: Option<serde_json::Value>,
 }
 
 /// MCP configuration file schema (standalone .mcp.json)

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -9254,7 +9254,7 @@
         "verified_on": "2026-04-28",
         "applies_to": {
           "tool": "claude-code",
-          "tool_version": ">=2.1.121"
+          "version_range": ">=2.1.121"
         },
         "normative_level": "MUST",
         "tests": {

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 414,
-  "last_updated": "2026-04-26",
+  "total_rules": 415,
+  "last_updated": "2026-04-28",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -9242,6 +9242,34 @@
       "bad_example": "{\n  \"mcpServers\": {\n    \"empty\": {}\n  }\n}"
     },
     {
+      "id": "MCP-025",
+      "name": "Non-boolean alwaysLoad in MCP Server Config",
+      "severity": "MEDIUM",
+      "category": "mcp",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.121"
+        ],
+        "verified_on": "2026-04-28",
+        "applies_to": {
+          "tool": "claude-code",
+          "tool_version": ">=2.1.121"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": true,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"mcpServers\": {\n    \"fs\": {\n      \"type\": \"stdio\",\n      \"command\": \"node\",\n      \"alwaysLoad\": true\n    }\n  }\n}",
+      "bad_example": "{\n  \"mcpServers\": {\n    \"fs\": {\n      \"type\": \"stdio\",\n      \"command\": \"node\",\n      \"alwaysLoad\": \"true\"\n    }\n  }\n}"
+    },
+    {
       "id": "OC-001",
       "name": "Invalid Share Mode",
       "severity": "HIGH",
@@ -11466,7 +11494,7 @@
     },
     "mcp": {
       "prefix": "MCP",
-      "count": 24,
+      "count": 25,
       "description": "Model Context Protocol rules"
     },
     "copilot": {

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -16,7 +16,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-25 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-28 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
 | Codex CLI | `AGENTS.md`, `codex.toml` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-25 | AGM, XP |
 | OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-28 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/powers/*/POWER.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-04-25 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK |

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -1379,6 +1379,13 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 **Fix**: Add at least one meaningful field (`type`, `command`, `url`, `args`, `env`)
 **Source**: modelcontextprotocol.io/specification/2025-11-25/basic/transports
 
+<a id="mcp-025"></a>
+### MCP-025 [MEDIUM] Non-boolean alwaysLoad in MCP Server Config
+**Requirement**: `mcpServers.*.alwaysLoad` MUST be a boolean when present (Claude Code 2.1.121+)
+**Detection**: Validate `mcpServers.*.alwaysLoad` type; flag string / number / array / object values
+**Fix**: Replace the value with an unquoted `true` or `false` (strings like `"true"` are silently ignored)
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.121
+
 ---
 
 ## GITHUB COPILOT RULES
@@ -3387,8 +3394,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 414 validation rules across 40 categories
+**Total Coverage**: 415 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 214 HIGH, 172 MEDIUM, 28 LOW
+**Certainty**: 214 HIGH, 173 MEDIUM, 28 LOW
 **Auto-Fixable**: 129 rules (31%)

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -1383,7 +1383,7 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 ### MCP-025 [MEDIUM] Non-boolean alwaysLoad in MCP Server Config
 **Requirement**: `mcpServers.*.alwaysLoad` MUST be a boolean when present (Claude Code 2.1.121+)
 **Detection**: Validate `mcpServers.*.alwaysLoad` type; flag string / number / array / object values
-**Fix**: Replace the value with an unquoted `true` or `false` (strings like `"true"` are silently ignored)
+**Fix**: Replace the value with an unquoted `true` or `false` (non-boolean values are not consistently applied by Claude Code - they may be treated as truthy in some code paths and ignored in others)
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.121
 
 ---

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -9254,7 +9254,7 @@
         "verified_on": "2026-04-28",
         "applies_to": {
           "tool": "claude-code",
-          "tool_version": ">=2.1.121"
+          "version_range": ">=2.1.121"
         },
         "normative_level": "MUST",
         "tests": {

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 414,
-  "last_updated": "2026-04-26",
+  "total_rules": 415,
+  "last_updated": "2026-04-28",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -9242,6 +9242,34 @@
       "bad_example": "{\n  \"mcpServers\": {\n    \"empty\": {}\n  }\n}"
     },
     {
+      "id": "MCP-025",
+      "name": "Non-boolean alwaysLoad in MCP Server Config",
+      "severity": "MEDIUM",
+      "category": "mcp",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.121"
+        ],
+        "verified_on": "2026-04-28",
+        "applies_to": {
+          "tool": "claude-code",
+          "tool_version": ">=2.1.121"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": true,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"mcpServers\": {\n    \"fs\": {\n      \"type\": \"stdio\",\n      \"command\": \"node\",\n      \"alwaysLoad\": true\n    }\n  }\n}",
+      "bad_example": "{\n  \"mcpServers\": {\n    \"fs\": {\n      \"type\": \"stdio\",\n      \"command\": \"node\",\n      \"alwaysLoad\": \"true\"\n    }\n  }\n}"
+    },
+    {
       "id": "OC-001",
       "name": "Invalid Share Mode",
       "severity": "HIGH",
@@ -11466,7 +11494,7 @@
     },
     "mcp": {
       "prefix": "MCP",
-      "count": 24,
+      "count": 25,
       "description": "Model Context Protocol rules"
     },
     "copilot": {

--- a/tests/fixtures/mcp/always-load-wrong-type.mcp.json
+++ b/tests/fixtures/mcp/always-load-wrong-type.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["./mcp-fs-server.js"],
+      "alwaysLoad": "true"
+    }
+  }
+}

--- a/website/docs/rules/generated/mcp-025.md
+++ b/website/docs/rules/generated/mcp-025.md
@@ -1,0 +1,64 @@
+---
+id: mcp-025
+title: "MCP-025: Non-boolean alwaysLoad in MCP Server Config - MCP"
+sidebar_label: "MCP-025"
+description: "agnix rule MCP-025 checks for non-boolean alwaysload in mcp server config in mcp files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["MCP-025", "non-boolean alwaysload in mcp server config", "mcp", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `MCP-025`
+- **Severity**: `MEDIUM`
+- **Category**: `MCP`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-04-28`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `unspecified`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.121
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `true`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "mcpServers": {
+    "fs": {
+      "type": "stdio",
+      "command": "node",
+      "alwaysLoad": "true"
+    }
+  }
+}
+```
+
+### Valid
+
+```json
+{
+  "mcpServers": {
+    "fs": {
+      "type": "stdio",
+      "command": "node",
+      "alwaysLoad": true
+    }
+  }
+}
+```

--- a/website/docs/rules/generated/mcp-025.md
+++ b/website/docs/rules/generated/mcp-025.md
@@ -18,7 +18,7 @@ keywords: ["MCP-025", "non-boolean alwaysload in mcp server config", "mcp", "val
 ## Applicability
 
 - **Tool**: `claude-code`
-- **Version Range**: `unspecified`
+- **Version Range**: `>=2.1.121`
 - **Spec Revision**: `unspecified`
 
 ## Evidence Sources

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `414` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `415` validation rules generated from `knowledge-base/rules.json`.
 `129` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -338,6 +338,7 @@ This section contains all `414` validation rules generated from `knowledge-base/
 | [MCP-022](./generated/mcp-022.md) | Invalid args Array Type | HIGH | MCP | No |
 | [MCP-023](./generated/mcp-023.md) | Duplicate MCP Server Names | HIGH | MCP | No |
 | [MCP-024](./generated/mcp-024.md) | Empty MCP Server Configuration | HIGH | MCP | No |
+| [MCP-025](./generated/mcp-025.md) | Non-boolean alwaysLoad in MCP Server Config | MEDIUM | MCP | No |
 | [OC-001](./generated/oc-001.md) | Invalid Share Mode | HIGH | OpenCode | Yes (unsafe) |
 | [OC-002](./generated/oc-002.md) | Invalid Instruction Path | HIGH | OpenCode | No |
 | [OC-003](./generated/oc-003.md) | opencode.json Parse Error | HIGH | OpenCode | No |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 414,
+  "totalRules": 415,
   "categoryCount": 40,
   "autofixCount": 129,
   "uniqueTools": [


### PR DESCRIPTION
## Summary

Adds **MCP-025** for a new MCP server config field shipped in Claude Code v2.1.121: `alwaysLoad: boolean`. When `true`, all tools from that server skip tool-search deferral and are always available.

The typo case `\"alwaysLoad\": \"true\"` (string) is a silent footgun — Claude Code treats it as truthy in some paths and ignores it in others, so the user's intent (\"always load these tools\") silently fails. MCP-025 flags non-boolean values before the config reaches Claude Code.

## Changes

- **Validator** (`crates/agnix-core/src/rules/mcp.rs`): MCP-025 check inside `validate_server`; updated `has_meaningful_server_config` so MCP-024 does not fire when `alwaysLoad` is the only field.
- **Schema** (`crates/agnix-core/src/schemas/mcp.rs`): new `always_load: Option<serde_json::Value>` on `McpServerConfig` (kept as `Value` so wrong types surface as MCP-025 rather than failing the whole server parse).
- **Rule metadata**: `knowledge-base/rules.json` entry (source_type: `vendor_docs`, `applies_to.tool: claude-code`, `tool_version: \">=2.1.121\"`) + `VALIDATION-RULES.md` entry under the MCP section.
- **Fixture**: `tests/fixtures/mcp/always-load-wrong-type.mcp.json`.
- **Tests**: 7 new unit tests covering boolean true/false accepted, field missing accepted, string/number/array values flagged, explicit null treated as absent (matches serde `Option<Value>` semantics), plus an MCP-024 negative-case test to prove the \"empty server\" guard does not false-positive when `alwaysLoad` is the only field.
- **Baseline bump**: `.github/tool-release-baselines.json` — claude-code `v2.1.119` → `v2.1.121`, `last_updated` → `2026-04-28`.
- **RESEARCH-TRACKING.md**: Claude Code \"Last Reviewed\" → `2026-04-28`.
- **Bookkeeping**: `scripts/sync-rule-bookkeeping.js` propagated 414 → 415 across `rules.json`, `crates/agnix-rules/rules.json`, `CLAUDE.md`, `AGENTS.md`, `README.md`, `website/docs/`, `website/src/data/siteData.json`.

## Why MEDIUM, not HIGH

The spec is explicit (`alwaysLoad` must be boolean), but an incorrect value fails safe-by-default — Claude Code loads the server normally with on-demand tool search. It's a config smell, not a breakage.

## Test plan

- [x] `cargo test --workspace` — all green (16 parity tests + full suite).
- [x] E2E: `agnix tests/fixtures/mcp/always-load-wrong-type.mcp.json` reports:
  `tests/fixtures/mcp/always-load-wrong-type.mcp.json:7:6 error: Server 'filesystem' has non-boolean 'alwaysLoad' value (got string)`
- [ ] CI green.
- [ ] Closes #835 on merge.

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new MCP lint rule and schema field plus tests/docs, with minimal impact beyond additional diagnostics for mis-typed `alwaysLoad` values.
> 
> **Overview**
> Adds new MCP validation rule **`MCP-025`** to flag non-boolean `mcpServers.*.alwaysLoad` values (e.g. `"true"`) introduced in Claude Code `v2.1.121`, and updates the MCP schema to parse `alwaysLoad` as `Option<Value>` so type mistakes can be diagnosed.
> 
> Adjusts the “empty server” check (`MCP-024`) to treat `alwaysLoad` as a meaningful field (avoiding false positives), adds unit tests + a fixture for the new rule, and propagates bookkeeping/docs updates (rules count `414 → 415`, generated website rule page/index, knowledge-base metadata, and Claude Code release baseline/research tracking dates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e5741331a1fa92cabc7baa728a8334a7340f508. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->