### PR TITLE
feat(tool-release): ground glm triage with citation + rule catalog (closes #837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Tool-release triage is now grounded in the rule catalog** (#837). `scripts/glm-extract.js --mode=agnix-triage` used to ask GLM to classify release notes against a `changes_of_interest` list without any knowledge of existing rules, so its "Rule candidates" invented freeform names (e.g. `mcp-server-always-load-type`) and its "Agnix-relevant changes" never explained *why* a bullet was surfaced. Two changes:
+  1. **Citation requirement**: every Agnix-relevant bullet must cite the `changes_of_interest.relevant` line it matched, shaped `- <phrase> -- matches: <interest>`. Makes the triage auditable and tightens the hallucination guard.
+  2. **Rule-catalog grounding**: `scripts/check-tool-releases.sh` now builds a compact per-tool rule manifest (via the new `scripts/build-rule-manifest.js`) and passes it to the triage prompt via a new `--rules-manifest` flag. GLM can now reclassify changes as "already covered by MCP-024" and propose real next-in-sequence ids (MCP-025 not `mcp-server-always-load-type`). A new `#### Already-covered changes` section surfaces rules that already cover a change so maintainers can close the tracker issue without adding a new rule. Prompt degrades gracefully to the un-grounded form when the manifest is absent.
+- Covered by 18 new unit tests (`node --test scripts/*.test.js`), including prompt-structure regression guards so future prompt edits can't silently drop the citation requirement or the Already-covered section.
+
 ### Added
 - **MCP-025: non-boolean `alwaysLoad` in MCP server config** (#836). Claude Code 2.1.121 introduced an `alwaysLoad: boolean` field on MCP server entries - when `true`, every tool from that server skips tool-search deferral and is always available. A typo like `"alwaysLoad": "true"` (quoted string) is a silent footgun: Claude Code treats it as truthy in some code paths and ignores it in others, so the user's intent silently fails. MCP-025 (MEDIUM) flags non-boolean values before they reach Claude Code. Also teaches MCP-024 that `{ "alwaysLoad": true }` is a deliberate field, not an "empty server" false positive.
 - **Tool baseline**: `claude-code` bumped from v2.1.119 to v2.1.121 in `.github/tool-release-baselines.json` and `knowledge-base/RESEARCH-TRACKING.md`.

--- a/scripts/build-rule-manifest.js
+++ b/scripts/build-rule-manifest.js
@@ -53,10 +53,27 @@ function parseArgs(argv) {
     const eq = raw.indexOf('=');
     const key = eq >= 0 ? raw.slice(2, eq) : raw.slice(2);
     const value = eq >= 0 ? raw.slice(eq + 1) : true;
-    if (key === 'tool') out.tool = typeof value === 'string' ? value : null;
-    else if (key === 'out') out.out = typeof value === 'string' ? value : null;
-    else if (key === 'pretty') out.pretty = true;
-    else {
+    // `--tool` / `--out` take a required non-empty string value. A bare
+    // `--tool` with no `=value` parses `value` as `true` (boolean) which
+    // would silently fall back to "unfiltered manifest" or "write to
+    // stdout" - both plausible defaults but dangerous coincidences that
+    // would mask typos. Fail fast the same way glm-extract.js rejects a
+    // bare `--interests-json`.
+    if (key === 'tool') {
+      if (typeof value !== 'string' || value.length === 0) {
+        console.error('`--tool` requires a non-empty string value, e.g. --tool=claude-code');
+        process.exit(2);
+      }
+      out.tool = value;
+    } else if (key === 'out') {
+      if (typeof value !== 'string' || value.length === 0) {
+        console.error('`--out` requires a non-empty string value, e.g. --out=path/to/manifest.json');
+        process.exit(2);
+      }
+      out.out = value;
+    } else if (key === 'pretty') {
+      out.pretty = true;
+    } else {
       console.error(`unknown flag: --${key}`);
       process.exit(2);
     }

--- a/scripts/build-rule-manifest.js
+++ b/scripts/build-rule-manifest.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/*
+ * Build a compact rule manifest for GLM triage grounding (#837).
+ *
+ * Reads `knowledge-base/rules.json` and emits a trimmed JSON array of
+ * `{id, name, category, tool, version_range}` entries. The full file is
+ * ~1.5 MB and includes evidence URLs, fix metadata, and code examples
+ * that GLM doesn't need to judge "is this release agnix-relevant, and
+ * does any existing rule already cover it?".
+ *
+ * Filtering options:
+ *   --tool=<id>        Keep rules that apply to this tool OR to no
+ *                      specific tool (unscoped / cross-tool). Unscoped
+ *                      rules (e.g. AGENTS.md parsers, MCP core) always
+ *                      matter regardless of which tool's release we're
+ *                      triaging, so we never drop them.
+ *   --out=<path>       Write JSON to this path instead of stdout.
+ *   --pretty           Pretty-print (default: minified to save tokens).
+ *
+ * Output shape (always a JSON array):
+ *   [
+ *     {
+ *       "id": "MCP-025",
+ *       "name": "Non-boolean alwaysLoad in MCP Server Config",
+ *       "category": "mcp",
+ *       "tool": "claude-code",
+ *       "version_range": ">=2.1.121"
+ *     },
+ *     ...
+ *   ]
+ *
+ * Fields `tool` and `version_range` are `null` when absent rather than
+ * omitted, so GLM sees the shape is consistent.
+ *
+ * Exit codes:
+ *   0 - success
+ *   1 - I/O or parse error
+ *   2 - bad argv
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs(argv) {
+  const out = { tool: null, out: null, pretty: false };
+  for (const raw of argv) {
+    if (!raw.startsWith('--')) {
+      console.error(`unexpected positional argument: ${raw}`);
+      process.exit(2);
+    }
+    const eq = raw.indexOf('=');
+    const key = eq >= 0 ? raw.slice(2, eq) : raw.slice(2);
+    const value = eq >= 0 ? raw.slice(eq + 1) : true;
+    if (key === 'tool') out.tool = typeof value === 'string' ? value : null;
+    else if (key === 'out') out.out = typeof value === 'string' ? value : null;
+    else if (key === 'pretty') out.pretty = true;
+    else {
+      console.error(`unknown flag: --${key}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+function loadRules() {
+  // Resolve rules.json relative to the repo root, not the CWD - the
+  // sync/check workflows invoke scripts from various places and this
+  // needs to work from all of them.
+  const rulesPath = path.resolve(__dirname, '..', 'knowledge-base', 'rules.json');
+  try {
+    const raw = fs.readFileSync(rulesPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed.rules)) {
+      throw new Error('rules.json missing `rules` array');
+    }
+    return parsed.rules;
+  } catch (err) {
+    console.error(`failed to load ${rulesPath}: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+function buildManifest(rules, toolFilter) {
+  return rules
+    .filter((rule) => {
+      if (!toolFilter) return true;
+      const ruleTool = rule.evidence?.applies_to?.tool ?? null;
+      // Keep unscoped rules (no tool) and rules that match the filter.
+      // Unscoped rules (AGENTS.md, cross-platform, MCP core) matter
+      // across tools - we don't want GLM to miss them when deciding
+      // "does any existing rule already cover this change?".
+      return ruleTool === null || ruleTool === toolFilter;
+    })
+    .map((rule) => ({
+      id: rule.id,
+      name: rule.name,
+      category: rule.category,
+      tool: rule.evidence?.applies_to?.tool ?? null,
+      version_range: rule.evidence?.applies_to?.version_range ?? null,
+    }));
+}
+
+function main() {
+  const { tool, out, pretty } = parseArgs(process.argv.slice(2));
+  const rules = loadRules();
+  const manifest = buildManifest(rules, tool);
+  const json = pretty ? JSON.stringify(manifest, null, 2) : JSON.stringify(manifest);
+  if (out) {
+    fs.writeFileSync(out, json + '\n');
+  } else {
+    process.stdout.write(json + '\n');
+  }
+}
+
+// Export for unit tests; run only when invoked directly.
+module.exports = { parseArgs, buildManifest };
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/build-rule-manifest.test.js
+++ b/scripts/build-rule-manifest.test.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/*
+ * Unit tests for `scripts/build-rule-manifest.js`.
+ *
+ * Run locally (no npm install needed):
+ *   node --test scripts/build-rule-manifest.test.js
+ *
+ * Covered behaviors:
+ *   - unfiltered mode returns every rule as a trimmed entry
+ *   - tool filter keeps unscoped rules (tool: null) alongside matches
+ *   - tool filter drops rules that belong to a different tool
+ *   - shape is always {id, name, category, tool, version_range} with
+ *     missing fields surfaced as `null` (so GLM sees a consistent shape)
+ *   - parseArgs rejects unknown flags
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { buildManifest, parseArgs } = require('./build-rule-manifest.js');
+
+const sampleRules = [
+  {
+    id: 'AGM-001',
+    name: 'Valid Markdown Structure',
+    category: 'agents-md',
+    evidence: { applies_to: {} },
+  },
+  {
+    id: 'CC-SK-001',
+    name: 'Some Claude Skill Rule',
+    category: 'claude-skills',
+    evidence: { applies_to: { tool: 'claude-code' } },
+  },
+  {
+    id: 'MCP-025',
+    name: 'Non-boolean alwaysLoad',
+    category: 'mcp',
+    evidence: {
+      applies_to: { tool: 'claude-code', version_range: '>=2.1.121' },
+    },
+  },
+  {
+    id: 'CUR-001',
+    name: 'A Cursor Rule',
+    category: 'cursor',
+    evidence: { applies_to: { tool: 'cursor' } },
+  },
+  {
+    id: 'NO-EVIDENCE',
+    name: 'Pathological rule with no evidence key',
+    category: 'mcp',
+    // `evidence` is deliberately absent - the code path must not crash.
+  },
+];
+
+test('unfiltered manifest keeps every rule', () => {
+  const out = buildManifest(sampleRules, null);
+  assert.equal(out.length, sampleRules.length);
+  assert.deepEqual(
+    out.map((r) => r.id),
+    ['AGM-001', 'CC-SK-001', 'MCP-025', 'CUR-001', 'NO-EVIDENCE'],
+  );
+});
+
+test('tool filter keeps unscoped rules alongside matches', () => {
+  const out = buildManifest(sampleRules, 'claude-code');
+  const ids = out.map((r) => r.id).sort();
+  // Unscoped rules (AGM-001, NO-EVIDENCE) survive the filter so GLM
+  // sees cross-tool rules and doesn't miss coverage checks.
+  assert.deepEqual(ids, ['AGM-001', 'CC-SK-001', 'MCP-025', 'NO-EVIDENCE']);
+});
+
+test('tool filter drops rules that belong to a different tool', () => {
+  const out = buildManifest(sampleRules, 'claude-code');
+  assert.ok(!out.some((r) => r.id === 'CUR-001'), 'CUR-001 must be filtered out');
+});
+
+test('every entry has the same shape with null for missing fields', () => {
+  const out = buildManifest(sampleRules, null);
+  for (const entry of out) {
+    assert.deepEqual(
+      Object.keys(entry).sort(),
+      ['category', 'id', 'name', 'tool', 'version_range'],
+      `entry ${entry.id} has unexpected keys`,
+    );
+    // Tool and version_range must be explicitly null when absent
+    // rather than undefined - JSON.stringify would drop undefined.
+    assert.notEqual(entry.tool, undefined);
+    assert.notEqual(entry.version_range, undefined);
+  }
+});
+
+test('entry with version_range is surfaced correctly', () => {
+  const out = buildManifest(sampleRules, null);
+  const mcp025 = out.find((r) => r.id === 'MCP-025');
+  assert.equal(mcp025.tool, 'claude-code');
+  assert.equal(mcp025.version_range, '>=2.1.121');
+});
+
+test('pathological rule with missing evidence returns nulls, does not crash', () => {
+  const out = buildManifest(sampleRules, null);
+  const patho = out.find((r) => r.id === 'NO-EVIDENCE');
+  assert.equal(patho.tool, null);
+  assert.equal(patho.version_range, null);
+});
+
+test('parseArgs rejects unknown flags by exit(2)', () => {
+  // node:test doesn't have a clean "assert process.exit" helper; spawn
+  // the script in a child to observe. We test the function contract via
+  // a stubbed process.exit so the test file stays single-process.
+  const origExit = process.exit;
+  const origErr = console.error;
+  let exitCode = null;
+  process.exit = (c) => { exitCode = c; throw new Error('exit_trap'); };
+  console.error = () => {}; // swallow the expected "unknown flag" message
+  try {
+    assert.throws(() => parseArgs(['--nope']), /exit_trap/);
+    assert.equal(exitCode, 2);
+  } finally {
+    process.exit = origExit;
+    console.error = origErr;
+  }
+});
+
+test('parseArgs accepts known flags and returns defaults for the rest', () => {
+  const parsed = parseArgs(['--tool=claude-code', '--pretty']);
+  assert.equal(parsed.tool, 'claude-code');
+  assert.equal(parsed.pretty, true);
+  assert.equal(parsed.out, null);
+});

--- a/scripts/build-rule-manifest.test.js
+++ b/scripts/build-rule-manifest.test.js
@@ -131,3 +131,52 @@ test('parseArgs accepts known flags and returns defaults for the rest', () => {
   assert.equal(parsed.pretty, true);
   assert.equal(parsed.out, null);
 });
+
+test('parseArgs rejects bare --tool (no value) with exit(2)', () => {
+  // Regression guard: a bare `--tool` used to silently become the
+  // unfiltered manifest, masking operator typos. Must now fail fast.
+  const origExit = process.exit;
+  const origErr = console.error;
+  let exitCode = null;
+  process.exit = (c) => { exitCode = c; throw new Error('exit_trap'); };
+  console.error = () => {};
+  try {
+    assert.throws(() => parseArgs(['--tool']), /exit_trap/);
+    assert.equal(exitCode, 2);
+  } finally {
+    process.exit = origExit;
+    console.error = origErr;
+  }
+});
+
+test('parseArgs rejects bare --out (no value) with exit(2)', () => {
+  const origExit = process.exit;
+  const origErr = console.error;
+  let exitCode = null;
+  process.exit = (c) => { exitCode = c; throw new Error('exit_trap'); };
+  console.error = () => {};
+  try {
+    assert.throws(() => parseArgs(['--out']), /exit_trap/);
+    assert.equal(exitCode, 2);
+  } finally {
+    process.exit = origExit;
+    console.error = origErr;
+  }
+});
+
+test('parseArgs rejects empty string --tool= with exit(2)', () => {
+  // Edge case: `--tool=` (trailing equals, no value) parses `value`
+  // as "". That's still ambiguous operator intent, so reject.
+  const origExit = process.exit;
+  const origErr = console.error;
+  let exitCode = null;
+  process.exit = (c) => { exitCode = c; throw new Error('exit_trap'); };
+  console.error = () => {};
+  try {
+    assert.throws(() => parseArgs(['--tool=']), /exit_trap/);
+    assert.equal(exitCode, 2);
+  } finally {
+    process.exit = origExit;
+    console.error = origErr;
+  }
+});

--- a/scripts/check-tool-releases.sh
+++ b/scripts/check-tool-releases.sh
@@ -250,8 +250,9 @@ sys.stdout.write(m.group(1).strip() if m else "")
       interests_tmp=$(mktemp)
       triage_stderr=$(mktemp)
       rules_manifest_tmp=$(mktemp)
+      rules_manifest_stderr=$(mktemp)
       # shellcheck disable=SC2064  # intentional early expansion of tmp paths
-      trap "rm -f '$interests_tmp' '$triage_stderr' '$rules_manifest_tmp'" EXIT INT TERM
+      trap "rm -f '$interests_tmp' '$triage_stderr' '$rules_manifest_tmp' '$rules_manifest_stderr'" EXIT INT TERM
       printf '%s' "$interests_json" > "$interests_tmp"
 
       # Build a tool-scoped rule manifest so GLM can (a) classify
@@ -259,22 +260,31 @@ sys.stdout.write(m.group(1).strip() if m else "")
       # next-in-sequence rule ids (e.g. MCP-026 after MCP-025).
       # Manifest is tool-scoped + keeps unscoped rules so cross-tool
       # families (MCP, AGENTS.md) are always visible. On build failure
-      # we omit the --rules-manifest flag entirely and the prompt
-      # degrades to the un-grounded form.
-      rules_manifest_flag=""
+      # we drop the --rules-manifest flag entirely and the prompt
+      # degrades to the un-grounded form. Stderr is captured (not
+      # silenced) so the WARN message carries enough detail to debug
+      # a regression in CI without needing to re-run with more logging.
+      #
+      # Use a bash array for the optional flag rather than an unquoted
+      # string splat so a space in $rules_manifest_tmp (unlikely but
+      # possible if TMPDIR is user-configured) can't word-split into
+      # extra argv entries. The empty-array expansion contributes no
+      # tokens to the command line at all.
+      rules_manifest_args=()
       if node "$script_dir/build-rule-manifest.js" \
-           --tool="$tool_id" --out="$rules_manifest_tmp" 2>/dev/null; then
-        rules_manifest_flag="--rules-manifest=$rules_manifest_tmp"
+           --tool="$tool_id" --out="$rules_manifest_tmp" 2>"$rules_manifest_stderr"; then
+        rules_manifest_args=("--rules-manifest=$rules_manifest_tmp")
         echo "  [triage] rule manifest built ($(wc -c <"$rules_manifest_tmp") bytes, tool=$tool_id)"
       else
-        echo "  WARN: build-rule-manifest.js failed - triage will run without rule grounding"
+        first_error_line=$(head -1 "$rules_manifest_stderr" 2>/dev/null)
+        [[ -z "$first_error_line" ]] && first_error_line="(no error details)"
+        echo "  WARN: build-rule-manifest.js failed ($first_error_line) - triage will run without rule grounding"
       fi
 
-      # shellcheck disable=SC2086  # $rules_manifest_flag is intentionally unquoted so the empty-string case drops the flag entirely
       triage_out=$(node "$script_dir/glm-extract.js" \
         "--mode=agnix-triage" \
         "--interests-json=$interests_tmp" \
-        $rules_manifest_flag \
+        "${rules_manifest_args[@]}" \
         "$display_name" "$latest_version" "$release_url" \
         2>"$triage_stderr" <<< "$release_body" || true)
       if [[ -n "$triage_out" ]]; then
@@ -283,7 +293,7 @@ sys.stdout.write(m.group(1).strip() if m else "")
       else
         echo "  WARN: GLM triage returned empty (stderr: $(head -1 "$triage_stderr" 2>/dev/null)) - posting raw changelog only"
       fi
-      rm -f "$interests_tmp" "$triage_stderr" "$rules_manifest_tmp"
+      rm -f "$interests_tmp" "$triage_stderr" "$rules_manifest_tmp" "$rules_manifest_stderr"
       trap - EXIT INT TERM
     fi
   fi

--- a/scripts/check-tool-releases.sh
+++ b/scripts/check-tool-releases.sh
@@ -249,12 +249,32 @@ sys.stdout.write(m.group(1).strip() if m else "")
       # below fails mid-way (CI interruption, SIGTERM, etc.).
       interests_tmp=$(mktemp)
       triage_stderr=$(mktemp)
+      rules_manifest_tmp=$(mktemp)
       # shellcheck disable=SC2064  # intentional early expansion of tmp paths
-      trap "rm -f '$interests_tmp' '$triage_stderr'" EXIT INT TERM
+      trap "rm -f '$interests_tmp' '$triage_stderr' '$rules_manifest_tmp'" EXIT INT TERM
       printf '%s' "$interests_json" > "$interests_tmp"
+
+      # Build a tool-scoped rule manifest so GLM can (a) classify
+      # changes as already-covered by existing rules, and (b) propose
+      # next-in-sequence rule ids (e.g. MCP-026 after MCP-025).
+      # Manifest is tool-scoped + keeps unscoped rules so cross-tool
+      # families (MCP, AGENTS.md) are always visible. On build failure
+      # we omit the --rules-manifest flag entirely and the prompt
+      # degrades to the un-grounded form.
+      rules_manifest_flag=""
+      if node "$script_dir/build-rule-manifest.js" \
+           --tool="$tool_id" --out="$rules_manifest_tmp" 2>/dev/null; then
+        rules_manifest_flag="--rules-manifest=$rules_manifest_tmp"
+        echo "  [triage] rule manifest built ($(wc -c <"$rules_manifest_tmp") bytes, tool=$tool_id)"
+      else
+        echo "  WARN: build-rule-manifest.js failed - triage will run without rule grounding"
+      fi
+
+      # shellcheck disable=SC2086  # $rules_manifest_flag is intentionally unquoted so the empty-string case drops the flag entirely
       triage_out=$(node "$script_dir/glm-extract.js" \
         "--mode=agnix-triage" \
         "--interests-json=$interests_tmp" \
+        $rules_manifest_flag \
         "$display_name" "$latest_version" "$release_url" \
         2>"$triage_stderr" <<< "$release_body" || true)
       if [[ -n "$triage_out" ]]; then
@@ -263,7 +283,7 @@ sys.stdout.write(m.group(1).strip() if m else "")
       else
         echo "  WARN: GLM triage returned empty (stderr: $(head -1 "$triage_stderr" 2>/dev/null)) - posting raw changelog only"
       fi
-      rm -f "$interests_tmp" "$triage_stderr"
+      rm -f "$interests_tmp" "$triage_stderr" "$rules_manifest_tmp"
       trap - EXIT INT TERM
     fi
   fi

--- a/scripts/glm-extract.js
+++ b/scripts/glm-extract.js
@@ -18,11 +18,20 @@
  *     for this tool (which config files, which change-types matter).
  *     Asks GLM to filter the notes down to just validator-relevant items
  *     + rule candidates. Output is markdown with:
- *       ## Agnix-relevant changes
+ *       ## Agnix-relevant changes  (each bullet cites the matching interest)
+ *       ## Already-covered changes (when --rules-manifest is provided)
  *       ## Rule candidates (if any)
  *       ## Irrelevant (UI, perf, telemetry, etc.)
  *     Used by tool-release-watch.yml to pre-triage the per-tool issue so
  *     a human reads a summary instead of the full changelog.
+ *
+ *     Optional `--rules-manifest=<file>` passes a compact rule catalog
+ *     (built by scripts/build-rule-manifest.js) so GLM can (a) classify
+ *     changes as already-covered instead of listing them as new, and
+ *     (b) propose next-in-sequence rule ids (e.g. MCP-025 after
+ *     MCP-001..024) instead of inventing freeform names. The workflow
+ *     builds this manifest per-tool and passes it automatically; the
+ *     prompt degrades gracefully to the un-grounded form when absent.
  *
  * Surface and defaults distilled from github.com/avifenesh/cairn
  * internal/llm/glm.go (z.ai coding-paas endpoint, Bearer auth, OpenAI-
@@ -30,7 +39,7 @@
  *
  * Usage:
  *   echo "<html>" | node scripts/glm-extract.js <tool_display_name> <version> <source_url>
- *   echo "<notes>" | node scripts/glm-extract.js --mode=agnix-triage --interests-json=/tmp/interests.json <tool_display_name> <version> <source_url>
+ *   echo "<notes>" | node scripts/glm-extract.js --mode=agnix-triage --interests-json=/tmp/interests.json [--rules-manifest=/tmp/rules.json] <tool_display_name> <version> <source_url>
  *
  * Env:
  *   GLM_API_KEY  required - z.ai key in "id.secret" format
@@ -59,42 +68,19 @@ const INPUT_BUDGET = 80_000;
 const MAX_TOKENS = 4096;
 const TEMPERATURE = 0.3; // extraction task, prefer determinism
 
-// Parse argv: collect flags into an options object + leave positional args.
-const argv = process.argv.slice(2);
-const flags = {};
-const positional = [];
-for (const arg of argv) {
-  if (arg.startsWith('--')) {
-    const eq = arg.indexOf('=');
-    if (eq >= 0) {
-      flags[arg.slice(2, eq)] = arg.slice(eq + 1);
-    } else {
-      flags[arg.slice(2)] = true;
-    }
-  } else {
-    positional.push(arg);
-  }
-}
-
-const mode = flags.mode || 'extract';
-const [toolDisplay, version, sourceUrl] = positional;
-if (!toolDisplay || !version || !sourceUrl) {
-  console.error('usage: glm-extract.js [--mode=extract|agnix-triage] [--interests-json=<path>] <tool_display_name> <version> <source_url>');
-  process.exit(2);
-}
-if (!['extract', 'agnix-triage'].includes(mode)) {
-  console.error(`unknown --mode=${mode}; expected 'extract' or 'agnix-triage'`);
-  process.exit(2);
-}
-
-const apiKey = process.env.GLM_API_KEY;
-if (!apiKey) {
-  console.error('GLM_API_KEY env var is required');
-  process.exit(2);
-}
-
-const model = process.env.GLM_MODEL || 'glm-5';
-const baseUrl = (process.env.GLM_BASE_URL || 'https://api.z.ai/api/coding/paas/v4').replace(/\/$/, '');
+// Module-scoped argv/env holders. Populated by runCli() when invoked
+// directly; left undefined when required as a library (so the prompt
+// builders can be unit-tested without triggering the CLI's process.exit
+// on "missing positional arg"). Builders default their `ctx` param to
+// these so the CLI path stays a one-liner.
+let flags = {};
+let toolDisplay;
+let version;
+let sourceUrl;
+let mode;
+let apiKey;
+let model;
+let baseUrl;
 
 /**
  * Load the changes_of_interest descriptor for the target tool. Schema:
@@ -123,6 +109,34 @@ function loadInterests() {
   }
 }
 
+/**
+ * Load the compact rule manifest produced by
+ * `scripts/build-rule-manifest.js`. Optional - when absent the prompt
+ * still works but the model has no grounding for rule-id proposals or
+ * "already covered by MCP-*" reasoning.
+ *
+ * Returns `null` when the flag is unset or the file can't be read
+ * (non-fatal: we'd rather produce a degraded triage than lose the
+ * release notes entirely). Invalid JSON is also non-fatal but logged.
+ */
+function loadRulesManifest() {
+  const raw = flags['rules-manifest'];
+  if (!raw || typeof raw !== 'string') {
+    return null;
+  }
+  try {
+    const data = JSON.parse(fs.readFileSync(raw, 'utf8'));
+    if (!Array.isArray(data)) {
+      console.error(`rules manifest at ${raw} is not a JSON array - ignoring`);
+      return null;
+    }
+    return data;
+  } catch (err) {
+    console.error(`failed to read rules manifest ${raw}: ${err.message} - ignoring`);
+    return null;
+  }
+}
+
 async function readStdin() {
   return new Promise((resolve, reject) => {
     let buf = '';
@@ -133,32 +147,56 @@ async function readStdin() {
   });
 }
 
-function buildExtractPrompt(html) {
+function buildExtractPrompt(html, ctx = { toolDisplay, version, sourceUrl }) {
   return [
-    `Extract the release notes for ${toolDisplay} ${version} from the page below.`,
+    `Extract the release notes for ${ctx.toolDisplay} ${ctx.version} from the page below.`,
     '',
     'Reply as concise markdown with these sections:',
     '## What changed',
     '## Likely impact on agnix rules (one line; "none likely" if unclear)',
     '',
-    `If the exact version is not on the page, summarize the most recent release instead and note that ${version} was not present.`,
+    `If the exact version is not on the page, summarize the most recent release instead and note that ${ctx.version} was not present.`,
     'No preamble, no commentary about the HTML structure or extraction process.',
     '',
-    `Source URL: ${sourceUrl}`,
+    `Source URL: ${ctx.sourceUrl}`,
     '',
     'Page content:',
     html,
   ].join('\n');
 }
 
-function buildAgnixTriagePrompt(notes, interests) {
+function buildAgnixTriagePrompt(notes, interests, rulesManifest, ctx = { toolDisplay, version, sourceUrl }) {
   const surfaces = (interests.config_surfaces || []).map((s) => `- \`${s}\``).join('\n') || '- (none declared)';
   const relevant = (interests.relevant || []).map((s) => `- ${s}`).join('\n') || '- (none declared)';
   const irrelevant = (interests.irrelevant || []).map((s) => `- ${s}`).join('\n') || '- (none declared)';
-  return [
-    `You are triaging release notes for ${toolDisplay} ${version} from the perspective of agnix, a linter for AI coding-tool config files.`,
+
+  // Rule-catalog grounding: give GLM the existing rule manifest so its
+  // "Rule candidates" section proposes real next-in-sequence ids
+  // (e.g., MCP-025 after MCP-001..024) instead of inventing freeform
+  // names, and its "Agnix-relevant changes" section can recognize when
+  // an existing rule already covers the change.
+  //
+  // When the manifest is absent (no --rules-manifest flag or load
+  // failed) we fall back to the un-grounded prompt - the workflow
+  // keeps working, just with the same quality as before.
+  const rulesBlock = rulesManifest
+    ? [
+        '',
+        'Agnix already ships these validation rules (trimmed to id + name + category + scope for brevity). When a release note describes behavior these rules already cover, classify the change as irrelevant and name the covering rule id. When it describes new behavior in an existing family, the next-free id in that family is a natural rule candidate - use the exact prefix and the next sequential number.',
+        '',
+        '```json',
+        JSON.stringify(rulesManifest),
+        '```',
+      ].join('\n')
+    : '';
+
+  // Use `null` as a sentinel for "skip this line" (a conditional line
+  // whose condition was false). Empty strings are meaningful paragraph
+  // separators and must survive the join.
+  const lines = [
+    `You are triaging release notes for ${ctx.toolDisplay} ${ctx.version} from the perspective of agnix, a linter for AI coding-tool config files.`,
     '',
-    `Agnix validates these ${toolDisplay} config surfaces:`,
+    `Agnix validates these ${ctx.toolDisplay} config surfaces:`,
     surfaces,
     '',
     'Items that matter to agnix (would likely require a validator update):',
@@ -166,28 +204,85 @@ function buildAgnixTriagePrompt(notes, interests) {
     '',
     'Items that do NOT matter to agnix (safe to ignore):',
     irrelevant,
+    rulesBlock || null,
     '',
     'Read the release notes below and classify each bullet point. Reply as concise markdown with these sections in order. Use #### (four hashes) for section headers so they nest under the outer ### Agnix Triage section that wraps this output in the GitHub issue body:',
     '',
     '#### Agnix-relevant changes',
-    'List each change-type relevant item as a single bullet. Quote the exact phrase from the notes in backticks. If none, write `_None - this release is agnix-irrelevant._`.',
+    'List each change-type relevant item as ONE bullet shaped exactly like:',
+    '  - `<exact phrase from notes>` -- matches: `<verbatim line from "Items that matter">`',
+    'The double-dash ` -- ` separator and the `matches:` label are required so a human reviewer can audit the mapping. If no item matches ANY "Items that matter" line, write `_None - this release is agnix-irrelevant._`. Never list an item without naming a matching interest; never invent a new interest that is not in the list above.',
+    rulesManifest
+      ? 'If a change is already covered by an existing rule from the manifest above, do NOT list it here; mention it in the "Already-covered" section below instead.'
+      : null,
     '',
+    rulesManifest ? '#### Already-covered changes' : null,
+    rulesManifest
+      ? 'List each change whose behavior is already enforced by an existing rule, shaped `- <exact phrase from notes> -- covered by <RULE-ID>`. If none, write `_None._`.'
+      : null,
+    rulesManifest ? '' : null,
     '#### Rule candidates',
-    'If any relevant change suggests a new validation rule, propose it as `- <rule name>: <one-line description>`. If none, write `_None._`.',
+    rulesManifest
+      ? 'If any relevant change suggests a NEW validation rule (not already in the manifest above), propose it as `- <NEXT-FREE-ID>: <one-line description>`. Pick the id by finding the highest existing number for the matching category prefix in the manifest and adding 1 (e.g., if the manifest ends at MCP-024, propose MCP-025). If none, write `_None._`.'
+      : 'If any relevant change suggests a new validation rule, propose it as `- <rule name>: <one-line description>`. If none, write `_None._`.',
     '',
     '#### Irrelevant changes (not reviewed)',
     'One-line summary like `5 items: model additions, UI polish, bug fixes`. Do not enumerate.',
     '',
-    'Rules: no preamble, no commentary about extraction, be strict about relevance - when in doubt, classify as irrelevant. Do not fabricate items that are not in the notes.',
+    rulesManifest
+      ? 'Rules: no preamble, no commentary about extraction, be strict about relevance - when in doubt, classify as irrelevant. Do not fabricate items that are not in the notes. Do not cite manifest rule ids that are not in the manifest above.'
+      : 'Rules: no preamble, no commentary about extraction, be strict about relevance - when in doubt, classify as irrelevant. Do not fabricate items that are not in the notes.',
     '',
-    `Source URL: ${sourceUrl}`,
+    `Source URL: ${ctx.sourceUrl}`,
     '',
     'Release notes:',
     notes,
-  ].join('\n');
+  ];
+  return lines.filter((line) => line !== null).join('\n');
 }
 
-(async () => {
+function parseArgv(argv) {
+  const parsedFlags = {};
+  const positional = [];
+  for (const arg of argv) {
+    if (arg.startsWith('--')) {
+      const eq = arg.indexOf('=');
+      if (eq >= 0) {
+        parsedFlags[arg.slice(2, eq)] = arg.slice(eq + 1);
+      } else {
+        parsedFlags[arg.slice(2)] = true;
+      }
+    } else {
+      positional.push(arg);
+    }
+  }
+  return { flags: parsedFlags, positional };
+}
+
+async function runCli() {
+  const parsed = parseArgv(process.argv.slice(2));
+  flags = parsed.flags;
+  [toolDisplay, version, sourceUrl] = parsed.positional;
+  mode = flags.mode || 'extract';
+
+  if (!toolDisplay || !version || !sourceUrl) {
+    console.error('usage: glm-extract.js [--mode=extract|agnix-triage] [--interests-json=<path>] [--rules-manifest=<path>] <tool_display_name> <version> <source_url>');
+    process.exit(2);
+  }
+  if (!['extract', 'agnix-triage'].includes(mode)) {
+    console.error(`unknown --mode=${mode}; expected 'extract' or 'agnix-triage'`);
+    process.exit(2);
+  }
+
+  apiKey = process.env.GLM_API_KEY;
+  if (!apiKey) {
+    console.error('GLM_API_KEY env var is required');
+    process.exit(2);
+  }
+
+  model = process.env.GLM_MODEL || 'glm-5';
+  baseUrl = (process.env.GLM_BASE_URL || 'https://api.z.ai/api/coding/paas/v4').replace(/\/$/, '');
+
   const stdin = (await readStdin()).slice(0, INPUT_BUDGET);
   if (!stdin.trim()) {
     console.error('stdin was empty - nothing to process');
@@ -199,7 +294,8 @@ function buildAgnixTriagePrompt(notes, interests) {
     prompt = buildExtractPrompt(stdin);
   } else {
     const interests = loadInterests();
-    prompt = buildAgnixTriagePrompt(stdin, interests);
+    const rulesManifest = loadRulesManifest();
+    prompt = buildAgnixTriagePrompt(stdin, interests, rulesManifest);
   }
 
   let res;
@@ -244,4 +340,16 @@ function buildAgnixTriagePrompt(notes, interests) {
     process.exit(1);
   }
   process.stdout.write(content);
-})();
+}
+
+// Export the prompt builders for unit tests. `ctx` lets tests pass
+// tool/version/source without triggering the CLI's argv parsing.
+module.exports = {
+  buildExtractPrompt,
+  buildAgnixTriagePrompt,
+  parseArgv,
+};
+
+if (require.main === module) {
+  runCli();
+}

--- a/scripts/glm-extract.js
+++ b/scripts/glm-extract.js
@@ -17,11 +17,13 @@
  *     a `--interests-json=<file>` that describes what agnix cares about
  *     for this tool (which config files, which change-types matter).
  *     Asks GLM to filter the notes down to just validator-relevant items
- *     + rule candidates. Output is markdown with:
- *       ## Agnix-relevant changes  (each bullet cites the matching interest)
- *       ## Already-covered changes (when --rules-manifest is provided)
- *       ## Rule candidates (if any)
- *       ## Irrelevant (UI, perf, telemetry, etc.)
+ *     + rule candidates. Output is markdown nested under the outer
+ *     `### Agnix Triage` heading that the workflow wraps around this
+ *     stdout; the builder uses `#### ...` so nesting stays correct:
+ *       #### Agnix-relevant changes  (each bullet cites the matching interest)
+ *       #### Already-covered changes (only when --rules-manifest is provided)
+ *       #### Rule candidates (if any)
+ *       #### Irrelevant changes (not reviewed)
  *     Used by tool-release-watch.yml to pre-triage the per-tool issue so
  *     a human reads a summary instead of the full changelog.
  *
@@ -351,5 +353,13 @@ module.exports = {
 };
 
 if (require.main === module) {
-  runCli();
+  // Attach a .catch() so any exception that escapes runCli() (e.g. a
+  // future refactor that adds a throw outside an existing try/catch)
+  // surfaces as an intelligible error + deterministic exit 1, not as
+  // an unhandled promise rejection with Node's default behavior.
+  void runCli().catch((err) => {
+    const msg = err && err.message ? err.message : String(err);
+    console.error(`Unexpected error: ${msg}`);
+    process.exit(1);
+  });
 }

--- a/scripts/glm-extract.test.js
+++ b/scripts/glm-extract.test.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/*
+ * Unit tests for the prompt builders in `scripts/glm-extract.js`.
+ *
+ * Run:
+ *   node --test scripts/glm-extract.test.js
+ *
+ * These lock in the prompt contract so subtle drift (missing the
+ * `-- matches:` citation, dropping the `#### Already-covered` section
+ * when the manifest is present, leaking `[object Object]` into the
+ * embedded manifest) breaks the test instead of silently degrading
+ * triage quality.
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildExtractPrompt,
+  buildAgnixTriagePrompt,
+  parseArgv,
+} = require('./glm-extract.js');
+
+const CTX = {
+  toolDisplay: 'Claude Code',
+  version: 'v2.1.122',
+  sourceUrl: 'https://example.com/release',
+};
+
+const SAMPLE_INTERESTS = {
+  config_surfaces: ['CLAUDE.md', '.claude/settings.json'],
+  relevant: ['MCP server definition shape', 'Hook event names'],
+  irrelevant: ['UI polish', 'Model additions'],
+};
+
+const SAMPLE_MANIFEST = [
+  {
+    id: 'MCP-024',
+    name: 'Empty MCP Server Configuration',
+    category: 'mcp',
+    tool: null,
+    version_range: null,
+  },
+  {
+    id: 'MCP-025',
+    name: 'Non-boolean alwaysLoad in MCP Server Config',
+    category: 'mcp',
+    tool: 'claude-code',
+    version_range: '>=2.1.121',
+  },
+];
+
+const SAMPLE_NOTES = '- Added alwaysLoad option to MCP server config\n- UI scroll fix';
+
+test('buildExtractPrompt inlines tool+version+source', () => {
+  const out = buildExtractPrompt('<html>notes</html>', CTX);
+  assert.match(out, /Claude Code v2\.1\.122/);
+  assert.match(out, /Source URL: https:\/\/example\.com\/release/);
+  assert.match(out, /## What changed/);
+});
+
+test('buildAgnixTriagePrompt without manifest omits Already-covered section', () => {
+  const out = buildAgnixTriagePrompt(SAMPLE_NOTES, SAMPLE_INTERESTS, null, CTX);
+  assert.ok(!out.includes('#### Already-covered'), 'Already-covered must not appear without manifest');
+  assert.ok(!out.includes('manifest above'), 'must not reference a manifest that was not provided');
+  // Core sections still there:
+  assert.match(out, /#### Agnix-relevant changes/);
+  assert.match(out, /#### Rule candidates/);
+  assert.match(out, /#### Irrelevant changes \(not reviewed\)/);
+});
+
+test('buildAgnixTriagePrompt with manifest adds Already-covered section', () => {
+  const out = buildAgnixTriagePrompt(SAMPLE_NOTES, SAMPLE_INTERESTS, SAMPLE_MANIFEST, CTX);
+  assert.match(out, /#### Already-covered changes/);
+  assert.match(out, /#### Rule candidates/);
+  // Agnix-relevant + Already-covered + Rule candidates + Irrelevant = 4 sections
+  const sectionCount = (out.match(/^#### /gm) || []).length;
+  assert.equal(sectionCount, 4, 'expected 4 #### sections with manifest');
+});
+
+test('citation requirement is present with or without manifest', () => {
+  // The `-- matches: ...` citation requirement was the core #837 fix
+  // and must appear in both code paths so the reviewer can always
+  // audit why a bullet was surfaced.
+  const withManifest = buildAgnixTriagePrompt(SAMPLE_NOTES, SAMPLE_INTERESTS, SAMPLE_MANIFEST, CTX);
+  const withoutManifest = buildAgnixTriagePrompt(SAMPLE_NOTES, SAMPLE_INTERESTS, null, CTX);
+  for (const prompt of [withManifest, withoutManifest]) {
+    assert.match(prompt, /-- matches:/, 'prompt must require "-- matches:" citation');
+    assert.match(prompt, /Never list an item without naming a matching interest/);
+  }
+});
+
+test('manifest is embedded as valid JSON that round-trips', () => {
+  const out = buildAgnixTriagePrompt(SAMPLE_NOTES, SAMPLE_INTERESTS, SAMPLE_MANIFEST, CTX);
+  const m = out.match(/```json\n(\[.*?\])\n```/s);
+  assert.ok(m, 'expected a fenced JSON block');
+  const roundTripped = JSON.parse(m[1]);
+  assert.deepEqual(roundTripped, SAMPLE_MANIFEST, 'embedded manifest must round-trip exactly');
+});
+
+test('manifest prompt explains next-free id computation', () => {
+  const out = buildAgnixTriagePrompt(SAMPLE_NOTES, SAMPLE_INTERESTS, SAMPLE_MANIFEST, CTX);
+  assert.match(out, /highest existing number for the matching category prefix/);
+  assert.match(out, /MCP-024/); // example used in the prompt
+  assert.match(out, /MCP-025/);
+});
+
+test('interests are rendered as bulleted lists in source order', () => {
+  const out = buildAgnixTriagePrompt(SAMPLE_NOTES, SAMPLE_INTERESTS, null, CTX);
+  // Each interest should appear as "- <line>" with order preserved.
+  const relevantBlock = out.slice(out.indexOf('Items that matter'), out.indexOf('Items that do NOT'));
+  const mccPos = relevantBlock.indexOf('MCP server definition shape');
+  const hookPos = relevantBlock.indexOf('Hook event names');
+  assert.ok(mccPos >= 0 && hookPos > mccPos, 'relevant interests must appear in declared order');
+});
+
+test('missing interest arrays degrade to "(none declared)" rather than crashing', () => {
+  const out = buildAgnixTriagePrompt(SAMPLE_NOTES, {}, null, CTX);
+  assert.match(out, /\(none declared\)/);
+});
+
+test('parseArgv splits flags and positionals correctly', () => {
+  const { flags, positional } = parseArgv([
+    '--mode=agnix-triage',
+    '--interests-json=/tmp/i.json',
+    '--rules-manifest=/tmp/r.json',
+    'Claude Code',
+    'v2.1.122',
+    'https://example.com',
+  ]);
+  assert.equal(flags.mode, 'agnix-triage');
+  assert.equal(flags['interests-json'], '/tmp/i.json');
+  assert.equal(flags['rules-manifest'], '/tmp/r.json');
+  assert.deepEqual(positional, ['Claude Code', 'v2.1.122', 'https://example.com']);
+});
+
+test('parseArgv handles bare flags as boolean true', () => {
+  const { flags } = parseArgv(['--pretty']);
+  assert.equal(flags.pretty, true);
+});


### PR DESCRIPTION
## Summary

Closes #837. The auto-triage that runs on every tool-release issue (`scripts/glm-extract.js --mode=agnix-triage`) used to classify release notes against the per-tool `changes_of_interest.relevant` list without any knowledge of the existing rule catalog. Two concrete problems surfaced during #836 review:

1. **"Agnix-relevant changes" listed *what* changed but never *why***. The reader had to re-read both the changelog and the interests list and mentally verify the match.
2. **"Rule candidates" invented freeform names** (`mcp-server-always-load-type`) instead of proposing real next-in-sequence ids. #836 also caught that I typed `applies_to.tool_version` when the schema wanted `version_range` - a mistake GLM couldn't catch because it had never seen the schema.

## Changes

### 1. Citation requirement (prompt-only tweak)

Agnix-relevant bullets now must cite the interest line they matched:

```
- `<exact phrase from notes>` -- matches: `<verbatim interest>`
```

The prompt explicitly forbids listing an item without a matching interest or inventing interests not in the list. Makes the triage auditable and tightens the hallucination guard. Present in BOTH the grounded and un-grounded code paths.

### 2. Rule-catalog grounding

- **New** `scripts/build-rule-manifest.js` emits a compact `{id, name, category, tool, version_range}` array filtered by tool (always keeping unscoped cross-tool rules like AGENTS.md + MCP core). For `claude-code` that's 19 KB, well inside the existing 80 KB `INPUT_BUDGET`.
- **Updated** `scripts/check-tool-releases.sh` builds the manifest per-tool and passes it via a new `--rules-manifest` flag on `glm-extract.js`. The triage prompt now:
  - Shows GLM the existing rule catalog inline (fenced JSON block).
  - Adds a new `#### Already-covered changes` section for items an existing rule already enforces (classified by citing the RULE-ID).
  - Tells GLM to pick rule-candidate ids by "find the highest number for the matching category prefix and add 1" - so proposals are `MCP-025` (not `mcp-server-always-load-type`).
- **Degrades gracefully** to the un-grounded form when the manifest is absent (build failure, missing node, etc) - workflow keeps shipping triage.

### Testability refactor

- `scripts/glm-extract.js` refactored to export its prompt builders and `parseArgv` so they can be unit-tested without shelling out. CLI execution gated behind `require.main === module`; argv/env parsing moved inside `runCli()` so `require()`ing the module from tests no longer trips `process.exit(2)`.
- Builders now take an explicit `ctx = { toolDisplay, version, sourceUrl }` param (defaulted to the module-top vars) so tests pass a known shape without CLI side-effects.

## Test plan

- [x] `node --test scripts/build-rule-manifest.test.js scripts/glm-extract.test.js` - 18/18 pass.
- [x] E2E with a fake GLM server: script builds the 19754-byte manifest for `claude-code`, the prompt sent to GLM includes both `Agnix already ships these validation rules` and `-- matches:`, and the response flows back into the issue body via the existing path. Logs observed:
  ```
  [triage] rule manifest built (19754 bytes, tool=claude-code)
  [fake-glm] prompt len=27798 manifest=true citation=true
  [triage] produced 175 chars of agnix-focused summary
  ```
- [ ] CI green.
- [ ] After merge, the next scheduled `tool-release-watch` run produces a triage block with `-- matches:` bullets and either a `#### Already-covered changes` section or `_None._`.

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the tool-release watcher’s LLM triage inputs/outputs and temp-file handling, which could affect CI issue generation and triage quality, but it’s isolated to release-monitoring scripts (no runtime validator logic).
> 
> **Overview**
> **Improves tool-release auto-triage quality and auditability.** The GLM triage prompt now requires each “Agnix-relevant changes” bullet to cite the exact matching `changes_of_interest.relevant` line via a strict `-- matches:` format to reduce hallucinated relevance.
> 
> **Grounds triage against the existing rule catalog.** Adds `scripts/build-rule-manifest.js` to emit a compact per-tool rule manifest (keeping unscoped rules), updates `check-tool-releases.sh` to generate/pass it via a new `--rules-manifest` flag, and updates `glm-extract.js` to optionally embed the manifest, add an `#### Already-covered changes` section, and request next-in-sequence rule IDs rather than freeform names (with graceful fallback when the manifest is absent).
> 
> **Adds regression tests and refactors for testability.** `glm-extract.js` now exports prompt builders/`parseArgv` and gates CLI execution behind `require.main`, with new Node `--test` suites covering manifest building and prompt structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a46c549c5adbb2a909cc11dbbb5a47c95ad4631c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->