### PR TITLE
feat(gm): add GM-010 for memoryManager/autoMemory v0.40 split + baseline bumps

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-04-28",
+  "last_updated": "2026-04-29",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.121",
+      "last_known_version": "v2.1.123",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.14.28",
+      "last_known_version": "v1.14.29",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -234,7 +234,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.2.11",
+      "last_known_version": "3.2.16",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {
@@ -316,7 +316,7 @@
         "gemini_ignore"
       ],
       "github_repo": "google-gemini/gemini-cli",
-      "last_known_version": "v0.39.1",
+      "last_known_version": "v0.40.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 415 rules, 75+ sources, rules.json
+knowledge-base/     # 416 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-415 rules defined in `knowledge-base/rules.json` (source of truth)
+416 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.18.0 - Production-ready with full validation pipeline
-- 415 validation rules across 42 validators
+- 416 validation rules across 42 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **GM-010: memoryManager without autoMemory after v0.40 split** (#846). Gemini CLI v0.40 (PR google-gemini/gemini-cli#25601) split the combined `experimental.memoryManager` flag. Pre-v0.40 it gated both the Memory Manager subagent and background skill extraction + `/memory inbox`. Post-v0.40 `memoryManager` gates only the subagent; extraction and the inbox move to the new `autoMemory` flag. Users carrying forward only `memoryManager: true` lose the inbox silently. GM-010 (MEDIUM) warns when `memoryManager` is true and `autoMemory` is missing or false, suggesting setting both to preserve pre-v0.40 behavior. Covered by 6 comprehensive tests plus 3 schema parsing tests.
 - **Tool baselines**: Updated via `.github/tool-release-baselines.json` for four tools:
-  - `claude-code`: v2.1.121 -> v2.1.123 (closes #842)
-  - `cursor`: v0.44.10 -> v0.44.12 (closes #843)
-  - `gemini-cli`: v0.39.1 -> v0.40.2 (closes #844)
-  - `opencode`: v1.14.28 -> v1.14.30 (closes #845)
+  - `claude-code`: v2.1.121 -> v2.1.123 (closes #842) - OAuth 401 retry-loop fix under `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1`; no config surface.
+  - `cursor`: 3.2.11 -> 3.2.16 (closes #843) - 3.2 line ships Multitask / Worktrees / Multi-root Workspaces (agent-window UX, on Cursor's explicit irrelevant list).
+  - `gemini-cli`: v0.39.1 -> v0.40.0 (closes #844) - `memoryManager` split covered by GM-010; remaining changes are model/provider/UX.
+  - `opencode`: v1.14.28 -> v1.14.29 (closes #845) - sole validator-adjacent item (`opencode agent create` writing valid `permissions.deny`) already enforced by OC-008.
 - **Rule count**: 415 -> 416 across all derived locations (rules.json, CLAUDE.md, AGENTS.md, README.md, plugin.json, SKILL.md files, website docs) via `scripts/sync-rule-bookkeeping.js`.
+
 ## [0.23.0] - 2026-04-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **GM-010: memoryManager without autoMemory after v0.40 split** (#846). Gemini CLI v0.40 (PR google-gemini/gemini-cli#25601) split the combined `experimental.memoryManager` flag. Pre-v0.40 it gated both the Memory Manager subagent and background skill extraction + `/memory inbox`. Post-v0.40 `memoryManager` gates only the subagent; extraction and the inbox move to the new `autoMemory` flag. Users carrying forward only `memoryManager: true` lose the inbox silently. GM-010 (MEDIUM) warns when `memoryManager` is true and `autoMemory` is missing or false, suggesting setting both to preserve pre-v0.40 behavior. Covered by 6 comprehensive tests plus 3 schema parsing tests.
+- **Tool baselines**: Updated via `.github/tool-release-baselines.json` for four tools:
+  - `claude-code`: v2.1.121 -> v2.1.123 (closes #842)
+  - `cursor`: v0.44.10 -> v0.44.12 (closes #843)
+  - `gemini-cli`: v0.39.1 -> v0.40.2 (closes #844)
+  - `opencode`: v1.14.28 -> v1.14.30 (closes #845)
+- **Rule count**: 415 -> 416 across all derived locations (rules.json, CLAUDE.md, AGENTS.md, README.md, plugin.json, SKILL.md files, website docs) via `scripts/sync-rule-bookkeeping.js`.
 ## [0.23.0] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 415 rules, 75+ sources, rules.json
+knowledge-base/     # 416 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-415 rules defined in `knowledge-base/rules.json` (source of truth)
+416 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.18.0 - Production-ready with full validation pipeline
-- 415 validation rules across 42 validators
+- 416 validation rules across 42 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>415 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>416 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 415 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 416 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # agnix Technical Reference
 
-> Linter for agent configs. 405 rules across 36 categories.
+> Linter for agent configs. 416 rules across 40 categories.
 
 
 ## What agnix Validates

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -615,6 +615,9 @@ rules:
     message: "Failed to parse .gemini/settings.json: %{error}"
     suggestion: "Fix the JSON syntax error in .gemini/settings.json"
     unknown_key: "Unknown top-level key '%{key}' in .gemini/settings.json"
+  gm_010:
+    message: "experimental.memoryManager is enabled without experimental.autoMemory (Gemini CLI v0.40+ split these flags)"
+    suggestion: "Set experimental.autoMemory: true alongside memoryManager to keep background skill extraction and /memory inbox working after v0.40 (see https://github.com/google-gemini/gemini-cli/pull/25601)"
 
   # --- OpenCode (opencode.rs) ---
   oc_001:

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -469,6 +469,9 @@ rules:
     message: "Error al analizar .gemini/settings.json: %{error}"
     suggestion: "Corrige el error de sintaxis JSON en .gemini/settings.json"
     unknown_key: "Clave de nivel superior desconocida '%{key}' en .gemini/settings.json"
+  gm_010:
+    message: "experimental.memoryManager está habilitado sin experimental.autoMemory (Gemini CLI v0.40+ dividió estas banderas)"
+    suggestion: "Establece experimental.autoMemory: true junto a memoryManager para mantener la extracción de habilidades en segundo plano y /memory inbox después de v0.40 (ver https://github.com/google-gemini/gemini-cli/pull/25601)"
 
   # --- OpenCode (opencode.rs) ---
   oc_001:

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -469,6 +469,9 @@ rules:
     message: "解析 .gemini/settings.json 失败: %{error}"
     suggestion: "修复 .gemini/settings.json 中的 JSON 语法错误"
     unknown_key: ".gemini/settings.json 中未知的顶级键 '%{key}'"
+  gm_010:
+    message: "experimental.memoryManager 已启用但未设置 experimental.autoMemory（Gemini CLI v0.40+ 已拆分这两个标志）"
+    suggestion: "在 memoryManager 旁同时设置 experimental.autoMemory: true，以保持 v0.40 之后后台技能提取和 /memory inbox 正常工作（参见 https://github.com/google-gemini/gemini-cli/pull/25601）"
 
   # --- OpenCode (opencode.rs) ---
   oc_001:

--- a/crates/agnix-core/src/rules/gemini_settings.rs
+++ b/crates/agnix-core/src/rules/gemini_settings.rs
@@ -253,11 +253,19 @@ impl Validator for GeminiSettingsValidator {
 
 /// Find the 1-indexed line number of a JSON key in the content.
 /// Checks for a colon after the quoted key to avoid matching string values.
+/// Skips matches that appear in comments (after // to end of line).
 fn find_key_line(content: &str, key: &str) -> Option<usize> {
     let needle = format!("\"{}\"", key);
     for (i, line) in content.lines().enumerate() {
-        if let Some(pos) = line.find(&needle) {
-            let after = &line[pos + needle.len()..];
+        // Strip inline comments to avoid false matches in comments
+        let line_no_comment = if let Some(comment_pos) = line.find("//") {
+            &line[..comment_pos]
+        } else {
+            line
+        };
+
+        if let Some(pos) = line_no_comment.find(&needle) {
+            let after = &line_no_comment[pos + needle.len()..];
             if after.trim_start().starts_with(':') {
                 return Some(i + 1);
             }

--- a/crates/agnix-core/src/rules/gemini_settings.rs
+++ b/crates/agnix-core/src/rules/gemini_settings.rs
@@ -485,7 +485,11 @@ mod tests {
 }"#;
         let diagnostics = validate(content);
         let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
-        assert_eq!(gm_010.len(), 1, "GM-010 should fire when only memoryManager is true");
+        assert_eq!(
+            gm_010.len(),
+            1,
+            "GM-010 should fire when only memoryManager is true"
+        );
         assert_eq!(gm_010[0].level, DiagnosticLevel::Warning);
     }
 
@@ -516,7 +520,10 @@ mod tests {
 }"#;
         let diagnostics = validate(content);
         let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
-        assert!(gm_010.is_empty(), "GM-010 should not fire when both flags are true");
+        assert!(
+            gm_010.is_empty(),
+            "GM-010 should not fire when both flags are true"
+        );
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/gemini_settings.rs
+++ b/crates/agnix-core/src/rules/gemini_settings.rs
@@ -1,8 +1,9 @@
-//! Gemini CLI settings validation rules (GM-004, GM-009)
+//! Gemini CLI settings validation rules (GM-004, GM-009, GM-010)
 //!
 //! Validates:
 //! - GM-009: Settings.json parse error (HIGH) - must be valid JSON/JSONC
 //! - GM-004: Invalid hooks configuration (MEDIUM) - unknown events, missing fields
+//! - GM-010: memoryManager without autoMemory (MEDIUM) - behavior split in v0.40
 
 use crate::{
     config::LintConfig,
@@ -13,7 +14,7 @@ use crate::{
 use rust_i18n::t;
 use std::path::Path;
 
-const RULE_IDS: &[&str] = &["GM-004", "GM-009"];
+const RULE_IDS: &[&str] = &["GM-004", "GM-009", "GM-010"];
 
 pub struct GeminiSettingsValidator;
 
@@ -78,6 +79,37 @@ impl Validator for GeminiSettingsValidator {
                 }
 
                 diagnostics.push(diagnostic);
+            }
+        }
+
+        // GM-010: memoryManager without autoMemory (WARNING)
+        //
+        // Gemini CLI v0.40 split the combined `experimental.memoryManager`
+        // flag (PR google-gemini/gemini-cli#25601). Before the split, setting
+        // `memoryManager: true` gave the user BOTH the Memory Manager
+        // subagent AND background skill extraction + `/memory inbox`. After
+        // the split, `memoryManager` gates only the subagent; the inbox and
+        // background extraction move to the new `experimental.autoMemory`
+        // flag. Users who carried forward only `memoryManager: true` lose
+        // the inbox silently. This rule fires whenever `memoryManager` is
+        // explicitly true and `autoMemory` is missing or false - setting
+        // both is safe on older versions (they ignore unknown flags), so no
+        // version gate is applied.
+        if config.is_rule_enabled("GM-010") {
+            if let Some(exp) = schema.experimental.as_ref() {
+                if exp.memory_manager == Some(true) && exp.auto_memory != Some(true) {
+                    let line = find_key_line(content, "memoryManager").unwrap_or(1);
+                    diagnostics.push(
+                        Diagnostic::warning(
+                            path_buf.clone(),
+                            line,
+                            0,
+                            "GM-010",
+                            t!("rules.gm_010.message"),
+                        )
+                        .with_suggestion(t!("rules.gm_010.suggestion")),
+                    );
+                }
             }
         }
 
@@ -440,6 +472,99 @@ mod tests {
             !gm_004.is_empty(),
             "GM-004 should fire for empty command field"
         );
+    }
+
+    // ===== GM-010: memoryManager without autoMemory =====
+
+    #[test]
+    fn test_gm_010_memory_manager_without_auto_memory() {
+        let content = r#"{
+  "experimental": {
+    "memoryManager": true
+  }
+}"#;
+        let diagnostics = validate(content);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert_eq!(gm_010.len(), 1, "GM-010 should fire when only memoryManager is true");
+        assert_eq!(gm_010[0].level, DiagnosticLevel::Warning);
+    }
+
+    #[test]
+    fn test_gm_010_memory_manager_with_auto_memory_false() {
+        let content = r#"{
+  "experimental": {
+    "memoryManager": true,
+    "autoMemory": false
+  }
+}"#;
+        let diagnostics = validate(content);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert_eq!(
+            gm_010.len(),
+            1,
+            "GM-010 should fire when autoMemory is explicitly false"
+        );
+    }
+
+    #[test]
+    fn test_gm_010_both_flags_true_no_diagnostic() {
+        let content = r#"{
+  "experimental": {
+    "memoryManager": true,
+    "autoMemory": true
+  }
+}"#;
+        let diagnostics = validate(content);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert!(gm_010.is_empty(), "GM-010 should not fire when both flags are true");
+    }
+
+    #[test]
+    fn test_gm_010_memory_manager_false_no_diagnostic() {
+        let content = r#"{
+  "experimental": {
+    "memoryManager": false
+  }
+}"#;
+        let diagnostics = validate(content);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert!(
+            gm_010.is_empty(),
+            "GM-010 should not fire when memoryManager is false"
+        );
+    }
+
+    #[test]
+    fn test_gm_010_auto_memory_only_no_diagnostic() {
+        let content = r#"{
+  "experimental": {
+    "autoMemory": true
+  }
+}"#;
+        let diagnostics = validate(content);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert!(
+            gm_010.is_empty(),
+            "GM-010 should not fire when only autoMemory is set"
+        );
+    }
+
+    #[test]
+    fn test_gm_010_no_experimental_block_no_diagnostic() {
+        let diagnostics = validate(r#"{"general": {}}"#);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert!(gm_010.is_empty());
+    }
+
+    #[test]
+    fn test_gm_010_disabled_by_config() {
+        let mut config = LintConfig::default();
+        config.rules_mut().disabled_rules = vec!["GM-010".to_string()];
+
+        let content = r#"{"experimental": {"memoryManager": true}}"#;
+        let diagnostics = validate_with_config(content, &config);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert!(gm_010.is_empty());
     }
 
     // ===== Autofix Tests =====

--- a/crates/agnix-core/src/rules/gemini_settings.rs
+++ b/crates/agnix-core/src/rules/gemini_settings.rs
@@ -305,7 +305,6 @@ fn find_line_comment_start(line: &str) -> Option<usize> {
     None
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/agnix-core/src/rules/gemini_settings.rs
+++ b/crates/agnix-core/src/rules/gemini_settings.rs
@@ -9,7 +9,9 @@ use crate::{
     config::LintConfig,
     diagnostics::{Diagnostic, Fix},
     rules::{Validator, ValidatorMetadata},
-    schemas::gemini_settings::{GeminiHook, VALID_HOOK_EVENTS, parse_gemini_settings},
+    schemas::gemini_settings::{
+        GeminiHook, VALID_HOOK_EVENTS, parse_gemini_settings, strip_jsonc_comments,
+    },
 };
 use rust_i18n::t;
 use std::path::Path;
@@ -79,37 +81,6 @@ impl Validator for GeminiSettingsValidator {
                 }
 
                 diagnostics.push(diagnostic);
-            }
-        }
-
-        // GM-010: memoryManager without autoMemory (WARNING)
-        //
-        // Gemini CLI v0.40 split the combined `experimental.memoryManager`
-        // flag (PR google-gemini/gemini-cli#25601). Before the split, setting
-        // `memoryManager: true` gave the user BOTH the Memory Manager
-        // subagent AND background skill extraction + `/memory inbox`. After
-        // the split, `memoryManager` gates only the subagent; the inbox and
-        // background extraction move to the new `experimental.autoMemory`
-        // flag. Users who carried forward only `memoryManager: true` lose
-        // the inbox silently. This rule fires whenever `memoryManager` is
-        // explicitly true and `autoMemory` is missing or false - setting
-        // both is safe on older versions (they ignore unknown flags), so no
-        // version gate is applied.
-        if config.is_rule_enabled("GM-010") {
-            if let Some(exp) = schema.experimental.as_ref() {
-                if exp.memory_manager == Some(true) && exp.auto_memory != Some(true) {
-                    let line = find_key_line(content, "memoryManager").unwrap_or(1);
-                    diagnostics.push(
-                        Diagnostic::warning(
-                            path_buf.clone(),
-                            line,
-                            0,
-                            "GM-010",
-                            t!("rules.gm_010.message"),
-                        )
-                        .with_suggestion(t!("rules.gm_010.suggestion")),
-                    );
-                }
             }
         }
 
@@ -247,58 +218,56 @@ impl Validator for GeminiSettingsValidator {
             }
         }
 
+        // GM-010: memoryManager without autoMemory (WARNING)
+        //
+        // Gemini CLI v0.40 split the combined `experimental.memoryManager`
+        // flag (PR google-gemini/gemini-cli#25601). Before the split, setting
+        // `memoryManager: true` gave the user BOTH the Memory Manager
+        // subagent AND background skill extraction + `/memory inbox`. After
+        // the split, `memoryManager` gates only the subagent; the inbox and
+        // background extraction move to the new `experimental.autoMemory`
+        // flag. Users who carried forward only `memoryManager: true` lose
+        // the inbox silently. This rule fires whenever `memoryManager` is
+        // explicitly true and `autoMemory` is missing or false - setting
+        // both is safe on older versions (they ignore unknown flags), so no
+        // version gate is applied.
+        if config.is_rule_enabled("GM-010") {
+            if let Some(exp) = schema.experimental.as_ref() {
+                if exp.memory_manager == Some(true) && exp.auto_memory != Some(true) {
+                    let line = find_key_line(content, "memoryManager").unwrap_or(1);
+                    diagnostics.push(
+                        Diagnostic::warning(
+                            path_buf.clone(),
+                            line,
+                            0,
+                            "GM-010",
+                            t!("rules.gm_010.message"),
+                        )
+                        .with_suggestion(t!("rules.gm_010.suggestion")),
+                    );
+                }
+            }
+        }
+
         diagnostics
     }
 }
 
 /// Find the 1-indexed line number of a JSON key in the content.
-/// Checks for a colon after the quoted key to avoid matching string values.
-/// Skips matches that appear in comments (handling // while respecting strings).
+///
+/// Uses the shared `strip_jsonc_comments` helper so both `//` line comments
+/// and `/* ... */` block comments are skipped without affecting line counts
+/// (newlines inside comments are preserved). This mirrors what the parser
+/// sees, so a key that only appears inside a comment will not produce a
+/// diagnostic line number.
 fn find_key_line(content: &str, key: &str) -> Option<usize> {
+    let stripped = strip_jsonc_comments(content);
     let needle = format!("\"{}\"", key);
-    for (i, line) in content.lines().enumerate() {
-        // Strip line comments (// to EOL) while respecting strings
-        let line_no_comment = if let Some(comment_pos) = find_line_comment_start(line) {
-            &line[..comment_pos]
-        } else {
-            line
-        };
-
-        if let Some(pos) = line_no_comment.find(&needle) {
-            let after = &line_no_comment[pos + needle.len()..];
+    for (i, line) in stripped.lines().enumerate() {
+        if let Some(pos) = line.find(&needle) {
+            let after = &line[pos + needle.len()..];
             if after.trim_start().starts_with(':') {
                 return Some(i + 1);
-            }
-        }
-    }
-    None
-}
-
-/// Find the start of a line comment (//) in a line, respecting string boundaries.
-/// Returns the index of the first / in //, or None if no // found outside strings.
-fn find_line_comment_start(line: &str) -> Option<usize> {
-    let chars: Vec<char> = line.chars().collect();
-    let mut in_string = false;
-    let mut i = 0;
-
-    while i < chars.len() {
-        if in_string {
-            if chars[i] == '\\' && i + 1 < chars.len() {
-                i += 2; // Skip escaped character
-            } else if chars[i] == '"' {
-                in_string = false;
-                i += 1;
-            } else {
-                i += 1;
-            }
-        } else {
-            if chars[i] == '"' {
-                in_string = true;
-                i += 1;
-            } else if chars[i] == '/' && i + 1 < chars.len() && chars[i + 1] == '/' {
-                return Some(i);
-            } else {
-                i += 1;
             }
         }
     }
@@ -598,6 +567,36 @@ mod tests {
     #[test]
     fn test_gm_010_no_experimental_block_no_diagnostic() {
         let diagnostics = validate(r#"{"general": {}}"#);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert!(gm_010.is_empty());
+    }
+
+    #[test]
+    fn test_gm_010_ignores_key_inside_block_comment() {
+        // The string "memoryManager" appears inside a /* ... */ block comment.
+        // find_key_line must not report the comment line; since there is no
+        // real `experimental.memoryManager` key, GM-010 must not fire.
+        let content = r#"{
+  /* note: experimental.memoryManager was deprecated in v0.40,
+     see https://github.com/google-gemini/gemini-cli/pull/25601 */
+  "experimental": {}
+}"#;
+        let diagnostics = validate(content);
+        let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
+        assert!(
+            gm_010.is_empty(),
+            "GM-010 must not fire when memoryManager only appears in a block comment"
+        );
+    }
+
+    #[test]
+    fn test_gm_010_ignores_key_inside_line_comment() {
+        // Same check for `//` comments on the same line as a URL-like string.
+        let content = r#"{
+  // doc: https://example.com/gemini-cli/experimental.memoryManager
+  "experimental": {}
+}"#;
+        let diagnostics = validate(content);
         let gm_010: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-010").collect();
         assert!(gm_010.is_empty());
     }

--- a/crates/agnix-core/src/rules/gemini_settings.rs
+++ b/crates/agnix-core/src/rules/gemini_settings.rs
@@ -253,12 +253,12 @@ impl Validator for GeminiSettingsValidator {
 
 /// Find the 1-indexed line number of a JSON key in the content.
 /// Checks for a colon after the quoted key to avoid matching string values.
-/// Skips matches that appear in comments (after // to end of line).
+/// Skips matches that appear in comments (handling // while respecting strings).
 fn find_key_line(content: &str, key: &str) -> Option<usize> {
     let needle = format!("\"{}\"", key);
     for (i, line) in content.lines().enumerate() {
-        // Strip inline comments to avoid false matches in comments
-        let line_no_comment = if let Some(comment_pos) = line.find("//") {
+        // Strip line comments (// to EOL) while respecting strings
+        let line_no_comment = if let Some(comment_pos) = find_line_comment_start(line) {
             &line[..comment_pos]
         } else {
             line
@@ -273,6 +273,38 @@ fn find_key_line(content: &str, key: &str) -> Option<usize> {
     }
     None
 }
+
+/// Find the start of a line comment (//) in a line, respecting string boundaries.
+/// Returns the index of the first / in //, or None if no // found outside strings.
+fn find_line_comment_start(line: &str) -> Option<usize> {
+    let chars: Vec<char> = line.chars().collect();
+    let mut in_string = false;
+    let mut i = 0;
+
+    while i < chars.len() {
+        if in_string {
+            if chars[i] == '\\' && i + 1 < chars.len() {
+                i += 2; // Skip escaped character
+            } else if chars[i] == '"' {
+                in_string = false;
+                i += 1;
+            } else {
+                i += 1;
+            }
+        } else {
+            if chars[i] == '"' {
+                in_string = true;
+                i += 1;
+            } else if chars[i] == '/' && i + 1 < chars.len() && chars[i + 1] == '/' {
+                return Some(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+    None
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/crates/agnix-core/src/schemas/gemini_settings.rs
+++ b/crates/agnix-core/src/schemas/gemini_settings.rs
@@ -108,8 +108,12 @@ pub struct GeminiHook {
     pub description: Option<String>,
 }
 
-/// Strip single-line (//) and multi-line (/* */) comments from JSONC content
-fn strip_jsonc_comments(input: &str) -> String {
+/// Strip single-line (//) and multi-line (/* */) comments from JSONC content.
+///
+/// Preserves newlines inside block comments so byte-line counts stay aligned
+/// with the original input - useful when callers want to search the stripped
+/// buffer but still report a line number matching the raw file.
+pub fn strip_jsonc_comments(input: &str) -> String {
     let mut result = String::with_capacity(input.len());
     let chars: Vec<char> = input.chars().collect();
     let len = chars.len();

--- a/crates/agnix-core/src/schemas/gemini_settings.rs
+++ b/crates/agnix-core/src/schemas/gemini_settings.rs
@@ -65,6 +65,28 @@ pub struct GeminiSettingsSchema {
     /// Hooks configuration object
     #[serde(rename = "hooksConfig")]
     pub hooks_config: Option<serde_json::Value>,
+    /// Experimental feature flags (nested object).
+    /// Only the flags agnix validates are modeled; unknown flags are preserved
+    /// in the raw JSON value and ignored by the typed view.
+    #[serde(default)]
+    pub experimental: Option<GeminiExperimentalFlags>,
+}
+
+/// The subset of `experimental.*` flags agnix tracks.
+///
+/// Gemini CLI v0.40 (PR google-gemini/gemini-cli#25601) split the combined
+/// `experimental.memoryManager` flag. `memoryManager` now gates ONLY the
+/// Memory Manager subagent + `save_memory` tool swap, while a new
+/// `experimental.autoMemory` flag gates background skill extraction and the
+/// `/memory inbox` UI. Users who upgrade with only `memoryManager: true` lose
+/// the inbox/extraction silently. GM-010 enforces setting both to preserve
+/// pre-v0.40 behavior.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct GeminiExperimentalFlags {
+    #[serde(rename = "memoryManager", default)]
+    pub memory_manager: Option<bool>,
+    #[serde(rename = "autoMemory", default)]
+    pub auto_memory: Option<bool>,
 }
 
 /// A single hook definition in hooksConfig
@@ -181,9 +203,19 @@ pub fn parse_gemini_settings(content: &str) -> ParsedGeminiSettings {
     // Extract hooks_config
     let hooks_config = value.get("hooksConfig").cloned();
 
+    // Extract experimental.* flags agnix tracks. Unknown flags under
+    // `experimental` are preserved in the raw JSON but not surfaced here;
+    // see GeminiExperimentalFlags for the list of modeled flags.
+    let experimental = value
+        .get("experimental")
+        .and_then(|v| serde_json::from_value::<GeminiExperimentalFlags>(v.clone()).ok());
+
     ParsedGeminiSettings {
         parse_error: None,
-        schema: Some(GeminiSettingsSchema { hooks_config }),
+        schema: Some(GeminiSettingsSchema {
+            hooks_config,
+            experimental,
+        }),
         unknown_top_keys,
     }
 }
@@ -315,5 +347,36 @@ mod tests {
     #[test]
     fn test_valid_top_level_keys_count() {
         assert_eq!(VALID_TOP_LEVEL_KEYS.len(), 12);
+    }
+
+    #[test]
+    fn test_experimental_flags_parsed() {
+        let content = r#"{
+  "experimental": {
+    "memoryManager": true,
+    "autoMemory": false
+  }
+}"#;
+        let result = parse_gemini_settings(content);
+        let schema = result.schema.unwrap();
+        let exp = schema.experimental.expect("experimental block parsed");
+        assert_eq!(exp.memory_manager, Some(true));
+        assert_eq!(exp.auto_memory, Some(false));
+    }
+
+    #[test]
+    fn test_experimental_missing_flags_are_none() {
+        let content = r#"{"experimental": {}}"#;
+        let result = parse_gemini_settings(content);
+        let exp = result.schema.unwrap().experimental.unwrap();
+        assert!(exp.memory_manager.is_none());
+        assert!(exp.auto_memory.is_none());
+    }
+
+    #[test]
+    fn test_experimental_absent() {
+        let content = r#"{"general": {}}"#;
+        let result = parse_gemini_settings(content);
+        assert!(result.schema.unwrap().experimental.is_none());
     }
 }

--- a/crates/agnix-core/src/schemas/gemini_settings.rs
+++ b/crates/agnix-core/src/schemas/gemini_settings.rs
@@ -66,8 +66,8 @@ pub struct GeminiSettingsSchema {
     #[serde(rename = "hooksConfig")]
     pub hooks_config: Option<serde_json::Value>,
     /// Experimental feature flags (nested object).
-    /// Only the flags agnix validates are modeled; unknown flags are preserved
-    /// in the raw JSON value and ignored by the typed view.
+    /// Only the flags agnix validates are modeled; unknown flags under `experimental`
+    /// are dropped from the typed result and not accessible via this struct.
     #[serde(default)]
     pub experimental: Option<GeminiExperimentalFlags>,
 }
@@ -204,8 +204,8 @@ pub fn parse_gemini_settings(content: &str) -> ParsedGeminiSettings {
     let hooks_config = value.get("hooksConfig").cloned();
 
     // Extract experimental.* flags agnix tracks. Unknown flags under
-    // `experimental` are preserved in the raw JSON but not surfaced here;
-    // see GeminiExperimentalFlags for the list of modeled flags.
+    // `experimental` are not returned; only the modeled flags in
+    // GeminiExperimentalFlags are extracted.
     let experimental = value
         .get("experimental")
         .and_then(|v| serde_json::from_value::<GeminiExperimentalFlags>(v.clone()).ok());

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 415,
-  "last_updated": "2026-04-28",
+  "total_rules": 416,
+  "last_updated": "2026-04-29",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -7089,6 +7089,36 @@
       "bad_example": "{ invalid json }"
     },
     {
+      "id": "GM-010",
+      "name": "memoryManager Without autoMemory After v0.40 Split",
+      "severity": "MEDIUM",
+      "category": "gemini-cli",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/google-gemini/gemini-cli/pull/25601",
+          "https://github.com/google-gemini/gemini-cli/blob/v0.40.0/packages/cli/src/config/settingsSchema.ts",
+          "https://github.com/google-gemini/gemini-cli/blob/v0.40.0/docs/cli/auto-memory.md"
+        ],
+        "verified_on": "2026-04-29",
+        "applies_to": {
+          "tool": "gemini-cli",
+          "version_range": ">=0.40.0"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\"experimental\":{\"memoryManager\":true,\"autoMemory\":true}}",
+      "bad_example": "{\"experimental\":{\"memoryManager\":true}}"
+    },
+    {
       "id": "GM-AG-001",
       "name": "Invalid auth block in Gemini agent MCP server",
       "severity": "HIGH",
@@ -11519,7 +11549,7 @@
     },
     "gemini-cli": {
       "prefix": "GM",
-      "count": 9,
+      "count": 10,
       "description": "Gemini CLI instruction file rules"
     },
     "codex": {

--- a/editors/zed/README.md
+++ b/editors/zed/README.md
@@ -10,7 +10,7 @@ Provides real-time validation of AI agent configuration files (CLAUDE.md, AGENTS
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for configuration fields
-- 405 validation rules across 36 categories
+- 416 validation rules across 40 categories
 - MDC file type support for Cursor rules
 
 ## Requirements

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -89,42 +89,46 @@ knowledge-base/
 | Category | Rules | HIGH | MEDIUM | LOW | Auto-Fix |
 |----------|-------|------|--------|-----|----------|
 | Agent Skills | 19 | 15 | 4 | 0 | 9 |
-| Claude Skills | 20 | 11 | 8 | 1 | 13 |
-| Claude Hooks | 25 | 13 | 8 | 4 | 16 |
-| Claude Agents | 17 | 12 | 4 | 1 | 10 |
-| Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | AGENTS.md | 6 | 1 | 5 | 0 | 1 |
+| Amp Checks | 4 | 2 | 2 | 0 | 3 |
+| Amp Skills | 1 | 0 | 1 | 0 | 1 |
+| Claude Agents | 17 | 12 | 4 | 1 | 10 |
+| Claude Hooks | 27 | 15 | 8 | 4 | 16 |
+| Claude Memory | 13 | 8 | 5 | 0 | 3 |
+| Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 14 | 9 | 5 | 0 | 4 |
+| Claude Settings | 1 | 0 | 1 | 0 | 0 |
+| Claude Skills | 20 | 11 | 8 | 1 | 13 |
+| Cline | 7 | 4 | 3 | 0 | 3 |
+| Cline Skills | 3 | 2 | 1 | 0 | 2 |
+| Codex CLI | 60 | 30 | 25 | 5 | 10 |
+| Codex Skills | 1 | 0 | 1 | 0 | 1 |
 | GitHub Copilot | 25 | 13 | 9 | 3 | 11 |
-| MCP | 24 | 19 | 5 | 0 | 7 |
-| XML | 3 | 3 | 0 | 0 | 3 |
-| References | 4 | 2 | 2 | 0 | 1 |
-| Prompt Eng | 6 | 0 | 6 | 0 | 2 |
+| Copilot Skills | 1 | 0 | 1 | 0 | 1 |
 | Cross-Platform | 9 | 2 | 6 | 1 | 0 |
 | Cursor | 19 | 9 | 9 | 1 | 6 |
 | Cursor Skills | 1 | 0 | 1 | 0 | 1 |
-| Cline | 7 | 4 | 3 | 0 | 3 |
-| Cline Skills | 3 | 2 | 1 | 0 | 2 |
-| OpenCode | 45 | 28 | 16 | 1 | 10 |
-| OpenCode Skills | 1 | 0 | 1 | 0 | 1 |
-| Gemini CLI | 9 | 3 | 4 | 2 | 3 |
-| Version Awareness | 1 | 0 | 0 | 1 | 0 |
-| Codex CLI | 58 | 28 | 25 | 5 | 10 |
-| Copilot Skills | 1 | 0 | 1 | 0 | 1 |
-| Codex Skills | 1 | 0 | 1 | 0 | 1 |
-| Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
-| Kiro Skills | 1 | 0 | 1 | 0 | 1 |
+| Gemini Agents | 1 | 1 | 0 | 0 | 0 |
+| Gemini CLI | 10 | 3 | 5 | 2 | 3 |
 | Kiro Agents | 13 | 4 | 7 | 2 | 0 |
 | Kiro Hooks | 10 | 6 | 4 | 0 | 0 |
 | Kiro MCP | 5 | 2 | 3 | 0 | 0 |
 | Kiro Powers | 8 | 3 | 4 | 1 | 0 |
-| Amp Skills | 1 | 0 | 1 | 0 | 1 |
-| Amp Checks | 4 | 2 | 2 | 0 | 3 |
-| Roo Code Skills | 1 | 0 | 1 | 0 | 1 |
-| Roo Code | 6 | 3 | 3 | 0 | 0 |
-| Windsurf | 4 | 1 | 2 | 1 | 0 |
+| Kiro Settings | 3 | 1 | 2 | 0 | 3 |
+| Kiro Skills | 1 | 0 | 1 | 0 | 1 |
 | Kiro Steering | 14 | 3 | 9 | 2 | 1 |
-| **TOTAL** | **416** | **206** | **167** | **26** | **126** |
+| MCP | 25 | 19 | 6 | 0 | 7 |
+| OpenCode | 45 | 28 | 16 | 1 | 10 |
+| OpenCode Skills | 1 | 0 | 1 | 0 | 1 |
+| Prompt Eng | 6 | 0 | 6 | 0 | 2 |
+| References | 4 | 2 | 2 | 0 | 1 |
+| Roo Code | 6 | 3 | 3 | 0 | 0 |
+| Roo Code Skills | 1 | 0 | 1 | 0 | 1 |
+| Version Awareness | 1 | 0 | 0 | 1 | 0 |
+| Windsurf | 4 | 1 | 2 | 1 | 0 |
+| Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
+| XML | 3 | 3 | 0 | 0 | 3 |
+| **TOTAL** | **416** | **214** | **174** | **28** | **129** |
 
 
 ---

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 416 validation rules across 36 categories, sourced from 75+ references
+> 416 validation rules across 40 categories, sourced from 75+ references
 
 
 ---

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 415 validation rules across 36 categories, sourced from 75+ references
+> 416 validation rules across 36 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 415 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 416 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (415 rules)
+├── VALIDATION-RULES.md             # Master validation reference (416 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **415 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **416 rules** |
 
 
 ### Validation Rules by Category
@@ -124,7 +124,7 @@ knowledge-base/
 | Roo Code | 6 | 3 | 3 | 0 | 0 |
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Kiro Steering | 14 | 3 | 9 | 2 | 1 |
-| **TOTAL** | **415** | **206** | **167** | **26** | **126** |
+| **TOTAL** | **416** | **206** | **167** | **26** | **126** |
 
 
 ---
@@ -162,7 +162,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 415 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 416 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -288,7 +288,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     415 rules
+Validation Rules:     416 rules
 Auto-Fixable Rules:   96 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 415 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 416 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-04-25
+**Last Updated**: 2026-04-29
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -16,9 +16,9 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-28 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-29 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
 | Codex CLI | `AGENTS.md`, `codex.toml` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-25 | AGM, XP |
-| OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-28 | AGM, XP, OC |
+| OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-29 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/powers/*/POWER.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-04-25 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK |
 
 ### A Tier (test on major changes)
@@ -27,7 +27,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-04-22 | COP |
 | Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-04-25 | CLN, CL-SK |
-| Cursor | `.cursor/rules/*.mdc`, `.cursorrules`, `.cursor/hooks.json`, `.cursor/agents/*.md`, `.cursor/environment.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-04-25 | CUR |
+| Cursor | `.cursor/rules/*.mdc`, `.cursorrules`, `.cursor/hooks.json`, `.cursor/agents/*.md`, `.cursor/environment.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-04-29 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 
@@ -40,7 +40,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-04-25 | GM |
+| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-04-29 | GM |
 
 ### D Tier (no support, nice to have)
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -2156,6 +2156,14 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 **Fix**: [AUTO-FIX] No auto-fix (correct the JSON syntax)
 **Source**: geminicli.com/docs/cli/settings
 
+<a id="gm-010"></a>
+### GM-010 [MEDIUM] memoryManager Without autoMemory After v0.40 Split
+**Requirement**: Users who set `experimental.memoryManager: true` SHOULD also set `experimental.autoMemory: true` on Gemini CLI v0.40+
+**Detection**: Parse `.gemini/settings.json`; warn when `experimental.memoryManager === true` and `experimental.autoMemory` is missing or false
+**Fix**: No auto-fix (upstream declined to ship a migration shim - users may legitimately want only the subagent)
+**Rationale**: Gemini CLI v0.40 (PR #25601) split the combined `memoryManager` flag. Pre-v0.40 it gated both the Memory Manager subagent and background skill extraction + `/memory inbox`. Post-v0.40 `memoryManager` gates only the subagent; extraction and the inbox move to the new `autoMemory` flag. Users carrying forward only `memoryManager: true` lose the inbox silently.
+**Source**: github.com/google-gemini/gemini-cli/pull/25601
+
 ## GEMINI CLI AGENT RULES
 
 Rules for local Gemini agent markdown files at `.gemini/agents/*.md`. These define `kind: local` agents with YAML frontmatter containing `name`, `description`, `tools`, `mcp_servers`, and `system_prompt`. Schema documented in the gemini-cli source at `packages/core/src/agents/agentLoader.ts`.
@@ -3394,8 +3402,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 415 validation rules across 40 categories
+**Total Coverage**: 416 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 214 HIGH, 173 MEDIUM, 28 LOW
+**Certainty**: 214 HIGH, 174 MEDIUM, 28 LOW
 **Auto-Fixable**: 129 rules (31%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 415,
-  "last_updated": "2026-04-28",
+  "total_rules": 416,
+  "last_updated": "2026-04-29",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -7089,6 +7089,36 @@
       "bad_example": "{ invalid json }"
     },
     {
+      "id": "GM-010",
+      "name": "memoryManager Without autoMemory After v0.40 Split",
+      "severity": "MEDIUM",
+      "category": "gemini-cli",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/google-gemini/gemini-cli/pull/25601",
+          "https://github.com/google-gemini/gemini-cli/blob/v0.40.0/packages/cli/src/config/settingsSchema.ts",
+          "https://github.com/google-gemini/gemini-cli/blob/v0.40.0/docs/cli/auto-memory.md"
+        ],
+        "verified_on": "2026-04-29",
+        "applies_to": {
+          "tool": "gemini-cli",
+          "version_range": ">=0.40.0"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\"experimental\":{\"memoryManager\":true,\"autoMemory\":true}}",
+      "bad_example": "{\"experimental\":{\"memoryManager\":true}}"
+    },
+    {
       "id": "GM-AG-001",
       "name": "Invalid auth block in Gemini agent MCP server",
       "severity": "HIGH",
@@ -11519,7 +11549,7 @@
     },
     "gemini-cli": {
       "prefix": "GM",
-      "count": 9,
+      "count": 10,
       "description": "Gemini CLI instruction file rules"
     },
     "codex": {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -600,6 +600,9 @@ rules:
     message: "Failed to parse .gemini/settings.json: %{error}"
     suggestion: "Fix the JSON syntax error in .gemini/settings.json"
     unknown_key: "Unknown top-level key '%{key}' in .gemini/settings.json"
+  gm_010:
+    message: "experimental.memoryManager is enabled without experimental.autoMemory (Gemini CLI v0.40+ split these flags)"
+    suggestion: "Set experimental.autoMemory: true alongside memoryManager to keep background skill extraction and /memory inbox working after v0.40 (see https://github.com/google-gemini/gemini-cli/pull/25601)"
 
   # --- OpenCode (opencode.rs) ---
   oc_001:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -454,6 +454,9 @@ rules:
     message: "Error al analizar .gemini/settings.json: %{error}"
     suggestion: "Corrige el error de sintaxis JSON en .gemini/settings.json"
     unknown_key: "Clave de nivel superior desconocida '%{key}' en .gemini/settings.json"
+  gm_010:
+    message: "experimental.memoryManager está habilitado sin experimental.autoMemory (Gemini CLI v0.40+ dividió estas banderas)"
+    suggestion: "Establece experimental.autoMemory: true junto a memoryManager para mantener la extracción de habilidades en segundo plano y /memory inbox después de v0.40 (ver https://github.com/google-gemini/gemini-cli/pull/25601)"
 
   # --- OpenCode (opencode.rs) ---
   oc_001:

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -454,6 +454,9 @@ rules:
     message: "解析 .gemini/settings.json 失败: %{error}"
     suggestion: "修复 .gemini/settings.json 中的 JSON 语法错误"
     unknown_key: ".gemini/settings.json 中未知的顶级键 '%{key}'"
+  gm_010:
+    message: "experimental.memoryManager 已启用但未设置 experimental.autoMemory（Gemini CLI v0.40+ 已拆分这两个标志）"
+    suggestion: "在 memoryManager 旁同时设置 experimental.autoMemory: true，以保持 v0.40 之后后台技能提取和 /memory inbox 正常工作（参见 https://github.com/google-gemini/gemini-cli/pull/25601）"
 
   # --- OpenCode (opencode.rs) ---
   oc_001:

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.23.0",
-  "description": "Lint agent configurations before they break your workflow. 415 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 416 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "[email protected]",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 415 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 416 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 415 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 416 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 415 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 416 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/rules/generated/gm-010.md
+++ b/website/docs/rules/generated/gm-010.md
@@ -1,0 +1,50 @@
+---
+id: gm-010
+title: "GM-010: memoryManager Without autoMemory After v0.40 Split"
+sidebar_label: "GM-010"
+description: "agnix rule GM-010 checks for memorymanager without automemory after v0.40 split in gemini cli files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["GM-010", "memorymanager without automemory after v0.40 split", "gemini cli", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `GM-010`
+- **Severity**: `MEDIUM`
+- **Category**: `Gemini CLI`
+- **Normative Level**: `SHOULD`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-04-29`
+
+## Applicability
+
+- **Tool**: `gemini-cli`
+- **Version Range**: `>=0.40.0`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/google-gemini/gemini-cli/pull/25601
+- https://github.com/google-gemini/gemini-cli/blob/v0.40.0/packages/cli/src/config/settingsSchema.ts
+- https://github.com/google-gemini/gemini-cli/blob/v0.40.0/docs/cli/auto-memory.md
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{"experimental":{"memoryManager":true}}
+```
+
+### Valid
+
+```json
+{"experimental":{"memoryManager":true,"autoMemory":true}}
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `415` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `416` validation rules generated from `knowledge-base/rules.json`.
 `129` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -259,6 +259,7 @@ This section contains all `415` validation rules generated from `knowledge-base/
 | [GM-007](./generated/gm-007.md) | @import File Not Found in GEMINI.md | MEDIUM | Gemini CLI | No |
 | [GM-008](./generated/gm-008.md) | Invalid Context File Name Configuration | LOW | Gemini CLI | Yes (safe) |
 | [GM-009](./generated/gm-009.md) | Settings.json Parse Error | HIGH | Gemini CLI | Yes (safe) |
+| [GM-010](./generated/gm-010.md) | memoryManager Without autoMemory After v0.40 Split | MEDIUM | Gemini CLI | No |
 | [GM-AG-001](./generated/gm-ag-001.md) | Invalid auth block in Gemini agent MCP server | HIGH | Gemini Agents | No |
 | [KIRO-001](./generated/kiro-001.md) | Invalid Steering File Inclusion Mode | HIGH | Kiro Steering | Yes (safe) |
 | [KIRO-002](./generated/kiro-002.md) | Missing Required Fields for Inclusion Mode | HIGH | Kiro Steering | No |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 415,
+  "totalRules": 416,
   "categoryCount": 40,
   "autofixCount": 129,
   "uniqueTools": [


### PR DESCRIPTION
## Summary

- **New rule GM-010** catches the behavior split in Gemini CLI v0.40 (PR [google-gemini/gemini-cli#25601](https://github.com/google-gemini/gemini-cli/pull/25601)): `experimental.memoryManager` used to gate both the Memory Manager subagent and background skill extraction + `/memory inbox`. In v0.40+ it gates only the subagent; the inbox + extraction move to a new `experimental.autoMemory` flag. Users who upgrade with only `memoryManager: true` lose the inbox silently.
- **Four baseline bumps** for tool-release issues whose auto-triage classified them as agnix-irrelevant (or already-covered by existing rules): closes #842, #843, #844, #845.

## GM-010 design

| Aspect | Choice | Why |
|---|---|---|
| Severity | MEDIUM (SHOULD) | Behavior drift, not a parse error |
| Autofix | None | PR #25601 explicitly declined a migration shim; some users may legitimately want only the subagent |
| Version gate | None in the validator | Setting both flags is safe on any version (older Gemini ignores unknown `experimental.*` keys). `rules.json` still records `version_range: ">=0.40.0"` for evidence metadata. |
| Surface | Nested - first time agnix descends into `experimental.*` | Minimal schema addition (`GeminiExperimentalFlags`); does not broaden the top-level-keys allowlist |

Fires when `experimental.memoryManager === true` and `experimental.autoMemory` is missing or false. Suggested action: set `autoMemory: true` alongside to preserve pre-v0.40 behavior.

## Baseline bumps

| Issue | Tool | Versions | Triage verdict |
|---|---|---|---|
| #842 | Claude Code | v2.1.121 → v2.1.123 | OAuth 401 retry-loop fix; no config surface |
| #843 | Cursor | 3.2.11 → 3.2.16 | 3.2 line = Multitask / Worktrees / Multi-root Workspaces; all on Cursor's explicit irrelevant list, no `.code-workspace` schema documented |
| #844 | Gemini CLI | v0.39.1 → v0.40.0 | `memoryManager` split handled by GM-010 above |
| #845 | OpenCode | v1.14.28 → v1.14.29 | One relevant line (`opencode agent create` writing valid `permissions.deny`) is already enforced by OC-008 |

`RESEARCH-TRACKING.md` Last Reviewed stamps bumped to 2026-04-29 for the four affected tools.

## Bookkeeping

- `knowledge-base/rules.json` + `crates/agnix-rules/rules.json` mirror: 415 → **416 rules**
- Count phrases across CLAUDE.md, AGENTS.md, README.md, knowledge-base/, plugin/, skills/, website siteData - all synced via `scripts/sync-rule-bookkeeping.js`
- Locales: `gm_010` added to `en.yml`, `es.yml`, `zh-CN.yml` in both the repo-root and per-crate (`crates/agnix-core/locales/`) locations (rust-i18n reads the per-crate path; the `test_every_rule_locale_key_referenced_in_source_resolves` test enforces parity there)
- VALIDATION-RULES.md footer stats + website doc page regenerated

## Test plan

- [x] `cargo test --workspace` - full suite green (3633 in agnix-core, all other crates unchanged)
- [x] `cargo test -p agnix-core --lib gemini_settings` - 37/37 pass including 6 new GM-010 cases + 3 new schema cases
- [x] `cargo test -p agnix-cli --test rule_parity` - 16/16 pass (GM-010 picked up in all four scanned locations)
- [x] `cargo test -p agnix-cli --test docs_website_parity` - 7/7 pass
- [x] `node scripts/sync-rule-bookkeeping.js --check` - reports no drift
- [x] `cargo check --workspace` - clean
- [ ] CI green including Claude workflow review

Closes #842, closes #843, closes #844, closes #845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)