### PR TITLE
[skip changelog] triage: update OpenCode baseline to v1.14.33 (agnix-irrelevant)

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-04-29",
+  "last_updated": "2026-05-04",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {

--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.14.29",
+      "last_known_version": "v1.14.33",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-04-29
+**Last Updated**: 2026-05-04
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -18,7 +18,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-29 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
 | Codex CLI | `AGENTS.md`, `codex.toml` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-25 | AGM, XP |
-| OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-29 | AGM, XP, OC |
+| OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-04 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/powers/*/POWER.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-04-25 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK |
 
 ### A Tier (test on major changes)


### PR DESCRIPTION
## Summary

Bumps OpenCode baseline from **v1.14.29** to **v1.14.33**.

All three releases (v1.14.30, v1.14.31, v1.14.33) are **agnix-irrelevant**:
- v1.14.30: Desktop session path fixes, model plumbing, TUI tweaks
- v1.14.31: Azure setup UX, child session permissions, MCP URL error messaging
- v1.14.33: Custom agents in plugins loading fix, docs, nix fix

No changes to validated config surfaces, no new rule candidates.

## Changes

-  - bump  to 
-  - update Last Reviewed to 

---

Closes #849