### PR TITLE
[skip changelog] chore: update Claude Code baseline to v2.1.126 (closes #850)

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.123",
+      "last_known_version": "v2.1.126",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -16,7 +16,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-29 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-04 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL |
 | Codex CLI | `AGENTS.md`, `codex.toml` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-04-25 | AGM, XP |
 | OpenCode | `AGENTS.md`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-04 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/powers/*/POWER.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-04-25 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK |


### PR DESCRIPTION
## Summary

Update Claude Code baseline from v2.1.123 to v2.1.126.

Auto-triage found no agnix-relevant changes (all 32 release items are UI/auth/runtime fixes with no config schema impact).

## Changes

-  - bump  v2.1.123 → v2.1.126
-  - update Last Reviewed to 2026-05-04

Closes #850
