### PR TITLE
bump Gemini CLI baseline: v0.40.0 -> v0.40.1 [skip changelog]

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -316,7 +316,7 @@
         "gemini_ignore"
       ],
       "github_repo": "google-gemini/gemini-cli",
-      "last_known_version": "v0.40.0",
+      "last_known_version": "v0.40.1",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -40,7 +40,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-04-29 | GM |
+| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-05-04 | GM |
 
 ### D Tier (no support, nice to have)
 


### PR DESCRIPTION
Bump Gemini CLI baseline from v0.40.0 to v0.40.1.

This is a patch-only release (cherry-pick commit 2194da2) with no changes to config surfaces, frontmatter schemas, or anything agnix validates.

Closes #852