### PR TITLE
chore: update amp baseline from opus-4.7 to gpt-5.5

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-05-04",
+  "last_updated": "2026-05-06",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -303,7 +303,7 @@
       "html_url": "https://ampcode.com/news.rss",
       "version_regex": "https://ampcode\\.com/news/[a-zA-Z0-9._-]+",
       "notes_extractor": "rss_cdata",
-      "last_known_version": "opus-4.7",
+      "last_known_version": "gpt-5.5",
       "tracked": true,
       "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed)."
     },

--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -305,7 +305,25 @@
       "notes_extractor": "rss_cdata",
       "last_known_version": "gpt-5.5",
       "tracked": true,
-      "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed)."
+      "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed).",
+      "changes_of_interest": {
+        "config_surfaces": [
+          ".amp/settings.json",
+          ".agents/checks/*.md",
+          "AGENTS.md"
+        ],
+        "relevant": [
+          "New or renamed keys in .amp/settings.json",
+          "Changes to check frontmatter schema (name, description, severity-default, tools)",
+          "Changes to AGENTS.md glob pattern parsing or frontmatter"
+        ],
+        "irrelevant": [
+          "Model additions (e.g. GPT-5.5, Opus 4.x)",
+          "Performance improvements and bug fixes",
+          "TUI/Vim/WSL integration tweaks",
+          "Theme or notification changes"
+        ]
+      }
     },
     "gemini-cli": {
       "tier": "c",

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -34,7 +34,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Roo Code | `.roomodes`, `.rooignore`, `.roorules`, `.roo/rules/*.md`, `.roo/rules-{slug}/*.md`, `.roo/mcp.json` | https://github.com/RooCodeInc/Roo-Code | Automated (tool-release-watch.yml) | Quarterly | 2026-04-25 | ROO |
-| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-04-28 | AMP, AMP-SK |
+| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-05-06 | AMP, AMP-SK |
 
 ### C Tier (community reports fixes only)
 


### PR DESCRIPTION
## Summary
- Triage #868: amp (Sourcegraph) released GPT-5.5 model replacing GPT-5.4
- Model-level change with **no config surface or schema impact** on  or 
- Updated  from  to  in tool-release-baselines.json
- Updated  date and Last Reviewed date in RESEARCH-TRACKING.md

## Changes
- : version bump + date update
- : Last Reviewed date update

## Related Issues
Closes #868