### PR TITLE
[skip changelog] Fix CC-MEM-014 example threshold

### DIFF
--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -2612,7 +2612,7 @@
         "autofix": false
       },
       "good_example": "# Project\n\nKeep CLAUDE.md concise and focused.",
-      "bad_example": "# Project\n\n(500+ lines of instructions that exceed recommended limits)"
+      "bad_example": "# Project\n\n(200+ lines of instructions that exceed recommended limits)"
     },
     {
       "id": "CC-PL-001",

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -2612,7 +2612,7 @@
         "autofix": false
       },
       "good_example": "# Project\n\nKeep CLAUDE.md concise and focused.",
-      "bad_example": "# Project\n\n(500+ lines of instructions that exceed recommended limits)"
+      "bad_example": "# Project\n\n(200+ lines of instructions that exceed recommended limits)"
     },
     {
       "id": "CC-PL-001",

--- a/website/docs/rules/generated/cc-mem-014.md
+++ b/website/docs/rules/generated/cc-mem-014.md
@@ -40,7 +40,7 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ```markdown
 # Project
 
-(500+ lines of instructions that exceed recommended limits)
+(200+ lines of instructions that exceed recommended limits)
 ```
 
 ### Valid


### PR DESCRIPTION
## Summary

- Align CC-MEM-014's `bad_example` in `knowledge-base/rules.json` (line 2615) with the documented 200-line CLAUDE.md recommendation. The field referenced "500+ lines" while `crates/agnix-core/src/rules/claude_md.rs` enforces `MAX_RECOMMENDED_LINES = 200` and `knowledge-base/VALIDATION-RULES.md:982-986` documents 200.
- Keep the `crates/agnix-rules/rules.json` rule-metadata mirror in sync.
- Regenerate `website/docs/rules/generated/cc-mem-014.md` (via `python3 scripts/generate-docs-rules.py`) so the published rule page matches the updated `rules.json` — without this, the static site would still show "500+".

Closes #733.

## Test plan

- [x] `jq empty knowledge-base/rules.json` and `jq empty crates/agnix-rules/rules.json` — both valid.
- [x] `node scripts/sync-rule-bookkeeping.js --check` — rule bookkeeping in sync.
- [x] `grep -A 1 '"id": "CC-MEM-014"' knowledge-base/rules.json | grep bad_example` shows `200+`; no `"500+ lines ... exceed recommended limits"` regression.
- [x] `python3 scripts/generate-docs-rules.py` rerun produces no diff against the regenerated `cc-mem-014.md`.
- [x] `cargo test` (`agnix` + `test` workflows on the staging fork PR) — passed.
- [ ] Upstream CI re-run on this PR with secrets / project automation available.

## Notes

- This change does not modify validators, schemas, or any runtime code path that consumes `bad_example`. It is documentation metadata correction.
- Out of scope (per #733): tightening CI parity tests to detect example-string drift between `rules.json` and `VALIDATION-RULES.md` — tracked in #741.
- Other observations surfaced during review (kept out of scope to stay aligned with #733's proposed fix):
  - The `bad_example` text "200+ lines" can be read as "200 or more"; the validator fires only on `non_empty_lines > 200` (strict). #733's "Proposed Change" explicitly requested "200+ lines" matching `VALIDATION-RULES.md`'s "under 200 lines" phrasing, so the wording is preserved as-is. A separate doc-precision pass could tighten this to "more than 200 non-empty lines".
  - `website/versioned_docs/version-*/rules/generated/cc-mem-014.md` snapshots still show "500+"; left unchanged because versioned docs are policy-frozen at release time.
  - `website/docs/rules/generated/mcp-026.md` had pre-existing drift between `rules.json` (`evidence.tests.fixture: true`) and the committed generated doc (`Fixture tests: false`). Discovered while regenerating CC-MEM-014's page; reverted to keep this PR scoped to #733. Worth a separate PR to refresh that page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
