### PR TITLE
chore(gemini-cli): triage v0.41.2 release - agnix-irrelevant baseline bump

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -336,7 +336,7 @@
         "gemini_ignore"
       ],
       "github_repo": "google-gemini/gemini-cli",
-      "last_known_version": "v0.41.1",
+      "last_known_version": "v0.41.2",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rule count**: 416 -> 418 across all derived locations (rules.json, CLAUDE.md, AGENTS.md, README.md, plugin.json, SKILL.md files, website docs) via `scripts/sync-rule-bookkeeping.js`.
 
 ### Changed
+- **Tool baseline**: `gemini-cli` bumped from `v0.41.1` to `v0.41.2` (closes #885). Upstream v0.41.2 is a single-commit cherry-pick patch on top of v0.41.1 (`cherry-pick 02995ba to release/v0.41.1-pr-26568`, google-gemini/gemini-cli#26589) - no substantive config-surface changes. No existing GM rule (GM-004, GM-009, GM-010) is affected; no validator, `ToolVersions`, or `SpecRevisions` update required. Refreshes gemini cli "Last Reviewed" in `knowledge-base/RESEARCH-TRACKING.md` to 2026-05-08 and updates `.github/tool-release-baselines.json`.
 - **Tool baseline**: `opencode` bumped from `v1.14.37` to `v1.14.41` (closes #886). Four upstream releases span the jump (v1.14.38, v1.14.39, v1.14.40, v1.14.41).
   - Runtime bugfixes: reasoning-block preservation, missing-session errors, CORS-before-auth ordering, ACP/serve/web re-entry, web-terminal CSP, surrogate sanitization, Cloudflare AI Gateway provider options, `/new` workspace handling, editor selection stability, server-overload retries, Mistral Medium 3.5 restoration, compaction-summary ordering.
   - New `.well-known/opencode` config-discovery mechanism (pointer to a remote config file - does not change OpenCode's config schema, only how the file is located).

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -40,7 +40,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-05-06 | GM |
+| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-05-08 | GM |
 
 ### D Tier (no support, nice to have)
 


### PR DESCRIPTION
## Summary
- Triage of upstream Gemini CLI v0.41.2 release.
- Conclusion: agnix-irrelevant - single-commit cherry-pick patch with no substantive config-surface changes.
- Bumps `.github/tool-release-baselines.json` gemini-cli entry `v0.41.1` -> `v0.41.2` and updates gemini cli "Last Reviewed" in `knowledge-base/RESEARCH-TRACKING.md` to 2026-05-08.

Closes #885

## Triage notes
v0.41.2 is a single-commit cherry-pick (`fix(patch): cherry-pick 02995ba to release/v0.41.1-pr-26568 to patch version v0.41.1 and create version 0.41.2`, google-gemini/gemini-cli#26589). The prior v0.41.1 triage (#877) already covered the substantive v0.41.0 changes; this patch release does not add or change any settings-schema surface.

No existing GM rule is affected:
- **GM-004** (tools allow/deny schema)
- **GM-009** (unknown-keys)
- **GM-010** (memoryManager without autoMemory)

No validator, `ToolVersions`, or `SpecRevisions` update required.

## Validation
- `python3 -m json.tool .github/tool-release-baselines.json >/dev/null` - passes
- `node scripts/sync-rule-bookkeeping.js --check --skip-docs` - passes

## Test plan
- [x] Baseline JSON valid
- [x] Rule bookkeeping in sync
- [x] CHANGELOG entry added (Verify Changelog gate)