### PR TITLE
chore(cursor): triage 3.3.27 release - agnix-irrelevant baseline bump

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -236,7 +236,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.2.21",
+      "last_known_version": "3.3.27",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rule count**: 416 -> 418 across all derived locations (rules.json, CLAUDE.md, AGENTS.md, README.md, plugin.json, SKILL.md files, website docs) via `scripts/sync-rule-bookkeeping.js`.
 
 ### Changed
+- **Tool baseline**: `cursor` bumped from `3.2.21` to `3.3.27` (closes #884). The api2.cursor.sh stable-update endpoint only exposes a version marker; spot-checked cursor.com/changelog for the 3.3 line.
+  - Notable 3.3 features: parallel "Build in Parallel" execution via async subagents, Explore subagent behavior controls (`model: opus` and similar generic model names), Security Reviewer and Vulnerability Scanner agents for PR checks / scheduled codebase scans, context-usage breakdown across rules/skills/MCPs/subagents, enterprise model-access and spend controls.
+  - Triage: none of these changes touch validated config surfaces - `.cursor/rules/**/*.{md,mdc}` frontmatter (CUR-001-009), `.cursor/hooks.json` schema (CUR-010-013, CUR-017-019), `.cursor/agents/**/*.md` subagent frontmatter (CUR-014-015, which already accepts generic model names like `opus` via the alphanumeric id validator), `.cursor/environment.json` (CUR-016), or `.cursor/mcp.json`.
+  - No validator, `ToolVersions`, or `SpecRevisions` update required. `.github/tool-release-baselines.json` and `knowledge-base/RESEARCH-TRACKING.md` ("Last Reviewed" for Cursor) updated.
 - **Tool baseline**: `amp` bumped from `gpt-5.5` to `neo` (closes #882). Major upstream "Neo" rebuild of the Amp CLI.
   - **New**: Plugin system (`.amp/plugins/*.ts`), remote control from ampcode.com, auto-compaction (replacing Handoff), queuing/steering, large performance improvements.
   - **Changed**: Default permission model no longer prompts before tool calls; users who opt back in via `amp.permissions`, `amp.dangerouslyAllowAll: false`, or `amp.guardedFiles.allowlist` keep the old behavior via a built-in permissions plugin.

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -27,7 +27,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-04-22 | COP |
 | Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-05-06 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-05-04 | CUR |
+| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-05-08 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 


### PR DESCRIPTION
## Summary
- Triage of upstream Cursor release span 3.2.21 -> 3.3.27 (entered the 3.3 feature line).
- Conclusion: agnix-irrelevant - no validator, `ToolVersions`, or `SpecRevisions` change required.
- Bumps `.github/tool-release-baselines.json` cursor entry `3.2.21` -> `3.3.27` and updates Cursor "Last Reviewed" in `knowledge-base/RESEARCH-TRACKING.md` to 2026-05-08.

Closes #884

## Triage notes

The auto-populated source (api2.cursor.sh stable update endpoint) only provides a version marker. Spot-checked the 3.3 line via <https://cursor.com/changelog>. Notable new features in the 3.3 series:

- **Parallel subagent execution**: "Build in Parallel" identifies independent parts of a plan and runs them simultaneously using async subagents.
- **Explore subagent controls**: Generic model names like `model: opus` are now supported in subagent frontmatter.
- **Security agents**: Security Reviewer and Vulnerability Scanner as PR check / scheduled codebase scan agents.
- **Context visibility**: Agent context-usage breakdown across rules, skills, MCPs, and subagents.
- **Enterprise controls**: Model-access controls, soft spend limits, granular usage analytics filtering.

### Why agnix-irrelevant

None of these changes touch the config surfaces agnix validates:

- **CUR-001-009**: `.cursor/rules/**/*.{md,mdc}` frontmatter (globs, description, alwaysApply, unknown keys) - no changes to the frontmatter schema.
- **CUR-010-013, CUR-017-019**: `.cursor/hooks.json` schema (hook event names, type values, required fields, timeout/loop_limit/failClosed types, prompt-hook model field) - no changes.
- **CUR-014-015**: `.cursor/agents/**/*.md` subagent frontmatter. The generic-model-name change (`model: opus`) already passes the existing `is_valid_cursor_model_id` validator (non-empty alphanumeric with `-_./: ` allowed), so no regression.
- **CUR-016**: `.cursor/environment.json` schema - no changes.
- **MCP-***: `.cursor/mcp.json` - no changes (MCP validator handles this path).

The parallel execution, security agents, context breakdown, and enterprise controls are all feature-layer or runtime behaviors that do not materialize as schema changes in validated config files.

## Validation
- `python3 -m json.tool .github/tool-release-baselines.json >/dev/null` - passes
- `node scripts/sync-rule-bookkeeping.js --check --skip-docs` - passes

## Test plan
- [x] Baseline JSON valid
- [x] Rule bookkeeping in sync
- [x] CHANGELOG entry added (Verify Changelog gate)