### PR TITLE
chore: triage amp, Cursor, and OpenCode release issues

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.14.49",
+      "last_known_version": "v1.14.50",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -237,7 +237,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.4.16",
+      "last_known_version": "3.4.17",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {
@@ -305,7 +305,7 @@
       "html_url": "https://ampcode.com/news.rss",
       "version_regex": "https://ampcode\\.com/news/[a-zA-Z0-9._-]+",
       "notes_extractor": "rss_cdata",
-      "last_known_version": "neo",
+      "last_known_version": "npm-package-changes",
       "tracked": true,
       "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed).",
       "changes_of_interest": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Symlink resolution**: `for_path` retries `strip_prefix` once via the configured `FileSystem::canonicalize` when the direct path remains absolute (typical for dotfile-manager symlinks like `~/.claude/` → mackup/stow/chezmoi stores). Non-symlinked paths pay no syscall cost.
   - Covered by 27 unit tests (12 schema + 3 wiring + 12 matching + symlink regression) and 8 end-to-end integration tests via `validate_project` (CC-MEM-005 carve-out, AGM-006 full + partial, XP-004 full + partial, VER-001). Documented in `docs/CONFIGURATION.md` and `SPEC.md`.
 
+### Changed
+- **Tool baselines**: triaged the three open release-watch issues and bumped baselines for `amp` `neo` -> `npm-package-changes` (#916), `cursor` `3.4.16` -> `3.4.17` (#917), and `opencode` `v1.14.49` -> `v1.14.50` (#918). All three are agnix-irrelevant for current validated config surfaces: Amp changed npm packaging and package names only, Cursor's stable endpoint exposed only a version marker, and OpenCode v1.14.50 contains runtime/SDK/TUI fixes already covered by existing config validators. No validator, `ToolVersions`, or `SpecRevisions` update required.
+
 ## [0.26.0] - 2026-05-14
 
 ### Added

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-05-08
+**Last Updated**: 2026-05-14
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -34,7 +34,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Roo Code | `.roomodes`, `.rooignore`, `.roorules`, `.roo/rules/*.md`, `.roo/rules-{slug}/*.md`, `.roo/mcp.json` | https://github.com/RooCodeInc/Roo-Code | Automated (tool-release-watch.yml) | Quarterly | 2026-04-25 | ROO |
-| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-05-08 | AMP, AMP-SK |
+| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-05-14 | AMP, AMP-SK |
 
 ### C Tier (community reports fixes only)
 


### PR DESCRIPTION
## Summary
- triage amp npm-package-changes, Cursor 3.4.17, and OpenCode v1.14.50 against current validated surfaces
- bump the three tool-release baselines so the watcher is quiet again
- refresh amp research tracking and document that no validator/ToolVersions/SpecRevisions changes are required

## Triage
- amp: npm package delivery and package-name changes only; no `.amp/settings.json` or `.agents/checks/*.md` surface change
- Cursor: stable update endpoint reports `3.4.17` only; no published config-surface release notes found for this patch
- OpenCode: v1.14.50 is runtime/TUI/SDK fixes; `small_model` is already a known key and already covered by OC-CFG-001

## Verification
- `jq empty .github/tool-release-baselines.json`
- `UPDATE_BASELINES=true GITHUB_STEP_SUMMARY=$(mktemp) bash scripts/check-tool-releases.sh` -> `ok=11 new=0 skipped=0`
- `cargo fmt --check`
- `cargo test -p agnix-core --lib`
- `cargo run -q -p agnix-cli --bin agnix -- .` -> 0 errors, 0 warnings, 1 existing info

Closes #916.
Closes #917.
Closes #918.