### PR TITLE
ci: auto-label release docs PR with skip-changelog [skip changelog]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,6 +586,7 @@ jobs:
                 --head "$BRANCH" \
                 --title "docs: version ${{ steps.version.outputs.version }} docs" \
                 --body "Auto-generated versioned docs snapshot for v${{ steps.version.outputs.version }}, including updated rule docs and site data." \
-                --label "documentation"
+                --label "documentation" \
+                --label "skip-changelog"
             fi
           fi


### PR DESCRIPTION
## Summary

- The release workflow's `version-docs` job opens a PR containing only `website/versioned_docs/version-X.Y.Z/**` snapshots and never touches `CHANGELOG.md`. The repo's `Verify Changelog` check requires either a CHANGELOG change, `[skip changelog]` in the PR title, or the `skip-changelog` label.
- The auto-PR sets `documentation` but not `skip-changelog`, so `Verify Changelog` fails on every release. v0.27.0's [#936](https://github.com/agent-sh/agnix/pull/936) had to be hand-labeled before it could merge.
- Fix: pass `--label "skip-changelog"` alongside `--label "documentation"` at PR creation time.

## Test plan

- [ ] Next release auto-PR has both `documentation` and `skip-changelog` labels and Verify Changelog skips