### PR TITLE
ci: auto-label dependabot PRs with skip-changelog [skip changelog]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       - "avifenesh"
     labels:
       - "dependencies"
+      - "skip-changelog"
     commit-message:
       prefix: "chore(deps):"
 
@@ -21,5 +22,6 @@ updates:
       - "avifenesh"
     labels:
       - "dependencies"
+      - "skip-changelog"
     commit-message:
       prefix: "chore(deps):"


### PR DESCRIPTION
## Summary

- Dependabot PRs never modify `CHANGELOG.md`, so the `Verify Changelog` check fails them by default.
- Until now, every dependabot PR has needed the `skip-changelog` label applied by hand (latest example: PRs #926-#931, all hand-labeled on 2026-05-16).
- Dependabot's `labels:` config supports arbitrary labels at PR creation. Adding `skip-changelog` alongside the existing `dependencies` for both ecosystems.

## Test plan

- [ ] Next dependabot run opens PRs already carrying both `dependencies` and `skip-changelog`
- [ ] `Verify Changelog` skips automatically; no manual labeling needed