### PR TITLE
fix(xml): skip indented markdown code blocks

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -45,7 +45,10 @@ jobs:
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7
         with:
-          toolchain: nightly
+          # cargo-fuzz 0.13.1 currently pulls rustix 0.36.5, which no longer
+          # builds on latest nightly after 2026-05-09. Pin to the last known-good
+          # nightly until cargo-fuzz publishes a compatible release.
+          toolchain: nightly-2026-05-03
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@7be9fd86bd1707236395105d6e9329dd1511a7e1 # v2.79.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **XML-001 false positives inside indented Markdown code blocks** (related to #942). The shared Markdown scanner now skips 4-space and tab-indented code blocks before extracting XML tags, so placeholder syntax such as `<resolved feature dir>` inside indented JSON/YAML examples no longer triggers XML balance diagnostics or safe-fix suggestions. Fenced code blocks and inline code remain skipped as before, and document-level XML is still validated outside code.
 - **AS-014 false positives on shell-escape syntax and backtick-wrapped backslashes** (closes #940). The Windows path-separator detector's loose token regex previously matched any non-whitespace run containing a `\`, so prose like `'I'\''m Groot'` (single-quote shell-escape) and `` `\` `` (markdown documenting the backslash character) tripped a HIGH-confidence safe autofix that rewrote `\` → `/` and corrupted the content. `extract_windows_paths` now requires matched tokens to be path-shaped and keeps standalone regex escapes out of the rule. Plain Windows paths (`foo\bar\baz`, `references\guide.md`, `C:\Users\me\file.txt`) and quoted Windows paths still fire as before. Covered by regression tests; existing AS-014 fixture and safe-fix tests unchanged.
 
 ## [0.27.0] - 2026-05-17

--- a/crates/agnix-core/src/parsers/markdown.rs
+++ b/crates/agnix-core/src/parsers/markdown.rs
@@ -355,12 +355,11 @@ pub fn sanitize_for_pulldown_cmark(s: &str) -> std::borrow::Cow<'_, str> {
 /// * **Inline code spans** – backtick-delimited spans inside a non-fenced line
 ///   are skipped.  We match the opening backtick run and look for the same-
 ///   length closing run to stay correct for ` ``double`` ` spans.
+/// * **Indented code blocks** – lines indented with four or more spaces, or a
+///   leading tab, are skipped as code.
 ///
 /// ### What we do NOT handle
 ///
-/// * Indented code blocks (4-space / tab indent).  These are uncommon in real
-///   agent-config files; omitting them is an acceptable trade-off for
-///   simplicity.
 /// * HTML block scanning.  All non-fenced, non-backtick content is yielded.
 fn scan_non_code_spans(content: &str, mut callback: impl FnMut(&str, usize)) {
     let bytes = content.as_bytes();
@@ -389,7 +388,7 @@ fn scan_non_code_spans(content: &str, mut callback: impl FnMut(&str, usize)) {
             // Check whether this line closes the fence.
             // A closing fence is: up to 3 optional spaces, then ≥ fence_min_len
             // fence_char bytes, then optional spaces, then end-of-line.
-            let line_trimmed = line.trim_end_matches('\n');
+            let line_trimmed = trim_line_ending(line);
             let n_leading = line_trimmed.bytes().take_while(|&b| b == b' ').count();
             if n_leading <= 3 {
                 let after = &line_trimmed[n_leading..];
@@ -409,9 +408,14 @@ fn scan_non_code_spans(content: &str, mut callback: impl FnMut(&str, usize)) {
             continue;
         }
 
+        if is_indented_code_line(line) {
+            pos = line_end;
+            continue;
+        }
+
         // Not in a fenced block.  Check if this line opens a fence.
         {
-            let line_trimmed = line.trim_end_matches('\n');
+            let line_trimmed = trim_line_ending(line);
             let n_leading = line_trimmed.bytes().take_while(|&b| b == b' ').count();
             if n_leading <= 3 {
                 let after = &line_trimmed[n_leading..];
@@ -481,6 +485,15 @@ fn scan_non_code_spans(content: &str, mut callback: impl FnMut(&str, usize)) {
 
         pos = line_end;
     }
+}
+
+fn trim_line_ending(line: &str) -> &str {
+    line.trim_end_matches(['\n', '\r'])
+}
+
+fn is_indented_code_line(line: &str) -> bool {
+    let line = trim_line_ending(line);
+    line.starts_with('\t') || line.bytes().take_while(|&b| b == b' ').count() >= 4
 }
 
 /// Return the byte position of the start of the first backtick run of exactly
@@ -977,6 +990,21 @@ mod tests {
         let content = "```\n<example>test</example>\n```\n";
         let tags = extract_xml_tags(content);
         assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_xml_ignores_indented_code_block() {
+        let content = "    {\n      \"feature_directory\": \"<resolved feature dir>\"\n    }\n";
+        let tags = extract_xml_tags(content);
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_xml_ignores_tab_indented_code_block() {
+        let content = "\t<resolved feature dir>\n<example>real";
+        let tags = extract_xml_tags(content);
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "example");
     }
 
     #[test]

--- a/crates/agnix-core/src/parsers/markdown.rs
+++ b/crates/agnix-core/src/parsers/markdown.rs
@@ -355,8 +355,10 @@ pub fn sanitize_for_pulldown_cmark(s: &str) -> std::borrow::Cow<'_, str> {
 /// * **Inline code spans** – backtick-delimited spans inside a non-fenced line
 ///   are skipped.  We match the opening backtick run and look for the same-
 ///   length closing run to stay correct for ` ``double`` ` spans.
-/// * **Indented code blocks** – lines indented with four or more spaces, or a
-///   leading tab, are skipped as code.
+/// * **Indented code blocks** – lines indented to four or more columns are
+///   skipped when they start at the beginning of a document, follow a blank
+///   line, or continue an existing indented code block. Tabs expand to the next
+///   four-column stop.
 ///
 /// ### What we do NOT handle
 ///
@@ -370,6 +372,8 @@ fn scan_non_code_spans(content: &str, mut callback: impl FnMut(&str, usize)) {
     let mut in_fence = false;
     let mut fence_char: u8 = b'`';
     let mut fence_min_len: usize = 3;
+    let mut in_indented_code = false;
+    let mut can_start_indented_code = true;
 
     while pos < len {
         // Find the end of the current line (pos..line_end) where line_end points
@@ -396,8 +400,9 @@ fn scan_non_code_spans(content: &str, mut callback: impl FnMut(&str, usize)) {
                 if run >= fence_min_len {
                     let rest = &after[run..];
                     if rest.bytes().all(|b| b == b' ') {
-                        // Closing fence found – exit fenced mode
+                        // Closing fence found - exit fenced mode
                         in_fence = false;
+                        can_start_indented_code = true;
                         pos = line_end;
                         continue;
                     }
@@ -408,7 +413,22 @@ fn scan_non_code_spans(content: &str, mut callback: impl FnMut(&str, usize)) {
             continue;
         }
 
-        if is_indented_code_line(line) {
+        let is_blank_line = is_markdown_blank_line(line);
+        let is_indented_line = is_indented_code_line(line);
+
+        if in_indented_code {
+            if is_blank_line || is_indented_line {
+                can_start_indented_code = true;
+                pos = line_end;
+                continue;
+            }
+
+            in_indented_code = false;
+        }
+
+        if can_start_indented_code && is_indented_line {
+            in_indented_code = true;
+            can_start_indented_code = true;
             pos = line_end;
             continue;
         }
@@ -483,6 +503,7 @@ fn scan_non_code_spans(content: &str, mut callback: impl FnMut(&str, usize)) {
             callback(&content[cursor..line_end], cursor);
         }
 
+        can_start_indented_code = is_blank_line;
         pos = line_end;
     }
 }
@@ -491,9 +512,21 @@ fn trim_line_ending(line: &str) -> &str {
     line.trim_end_matches(['\n', '\r'])
 }
 
+fn is_markdown_blank_line(line: &str) -> bool {
+    trim_line_ending(line)
+        .bytes()
+        .all(|b| matches!(b, b' ' | b'\t'))
+}
+
 fn is_indented_code_line(line: &str) -> bool {
-    let line = trim_line_ending(line);
-    line.starts_with('\t') || line.bytes().take_while(|&b| b == b' ').count() >= 4
+    let mut width = 0;
+    for b in line.bytes().take_while(|&b| b == b' ' || b == b'\t') {
+        width += if b == b' ' { 1 } else { 4 - (width % 4) };
+        if width >= 4 {
+            return true;
+        }
+    }
+    false
 }
 
 /// Return the byte position of the start of the first backtick run of exactly
@@ -1002,6 +1035,30 @@ mod tests {
     #[test]
     fn test_xml_ignores_tab_indented_code_block() {
         let content = "\t<resolved feature dir>\n<example>real";
+        let tags = extract_xml_tags(content);
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "example");
+    }
+
+    #[test]
+    fn test_xml_ignores_mixed_space_tab_indented_code_block() {
+        let content = " \t<resolved feature dir>\n<example>real";
+        let tags = extract_xml_tags(content);
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "example");
+    }
+
+    #[test]
+    fn test_xml_scans_indented_paragraph_continuation() {
+        let content = "A paragraph wraps onto\n    <example>real";
+        let tags = extract_xml_tags(content);
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags[0].name, "example");
+    }
+
+    #[test]
+    fn test_xml_scans_indented_list_item_continuation() {
+        let content = "- A list item continues with\n    <example>real";
         let tags = extract_xml_tags(content);
         assert_eq!(tags.len(), 1);
         assert_eq!(tags[0].name, "example");

--- a/crates/agnix-core/src/rules/xml.rs
+++ b/crates/agnix-core/src/rules/xml.rs
@@ -226,6 +226,24 @@ mod tests {
     }
 
     #[test]
+    fn test_xml_001_ignores_indented_code_block_placeholder() {
+        let content = "\
+Persist the resolved path to a file:
+
+    {
+      \"feature_directory\": \"<resolved feature dir>\"
+    }
+";
+        let validator = XmlValidator;
+        let diagnostics = validator.validate(Path::new("test.md"), content, &LintConfig::default());
+        assert!(
+            diagnostics.is_empty(),
+            "XML placeholders inside indented code blocks should not flag; got {:?}",
+            diagnostics
+        );
+    }
+
+    #[test]
     fn test_sized_int_type_parameter_not_flagged() {
         // Rust sized types i32, u64, f32 should be treated as type
         // parameters. Example is outside backticks so the XML


### PR DESCRIPTION
## Summary
- Skip CommonMark-style indented Markdown code blocks in the shared markdown scanner before XML tag extraction
- Keep scanning indented paragraph and list continuations so XML-001 does not miss real tags
- Expand tab indentation to four-column stops and add parser/XML-001 regression coverage for `<resolved feature dir>` examples
- Pin the fuzz workflow to the last known-good nightly because latest nightly breaks `cargo-fuzz@0.13.1` installation before fuzzing starts
- Document the XML fix as related to #942 without closing it, since the exact fenced-code repro still does not reproduce locally

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p agnix-core markdown::tests::test_xml_ -- --nocapture`
- `cargo test -p agnix-core rules::xml::tests::test_xml_001_ignores_indented_code_block_placeholder -- --nocapture`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `git diff --check`
- Manual repro: indented JSON placeholder now reports `No issues found`