### PR TITLE
ci: skip Verify Changelog for dependabot PRs [skip changelog]

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,8 +15,10 @@ jobs:
   changelog:
     name: Verify Changelog
     runs-on: ubuntu-latest
-    # Skip for dependabot (security PRs bypass dependabot.yml labels) and for
-    # PRs with [skip changelog] in the title or the skip-changelog label.
+    # Skip for any dependabot PR - the label-based skip is not reliable
+    # (security PRs in particular open without honoring dependabot.yml
+    # labels) - and for PRs with [skip changelog] in the title or the
+    # skip-changelog label.
     if: |
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       !contains(github.event.pull_request.title, '[skip changelog]') &&

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,8 +15,10 @@ jobs:
   changelog:
     name: Verify Changelog
     runs-on: ubuntu-latest
-    # Skip if PR has [skip changelog] in title or the skip-changelog label
+    # Skip for dependabot (security PRs bypass dependabot.yml labels) and for
+    # PRs with [skip changelog] in the title or the skip-changelog label.
     if: |
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
       !contains(github.event.pull_request.title, '[skip changelog]') &&
       !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
     steps:


### PR DESCRIPTION
## Summary

- Verify Changelog fails on dependabot security PRs (e.g. #944 — npm/website group) because they bypass `dependabot.yml` and don't get the `skip-changelog` label. Only `cargo` and `github-actions` ecosystems are configured there.
- Skip the job whenever the PR author is `dependabot[bot]`, in addition to the existing title/label exits.

## Test plan

- [ ] After merge, re-run Verify Changelog on #944 and confirm it skips (or rebase #944 onto main).
- [ ] Next dependabot PR opens with Verify Changelog skipped without needing a label.