### PR TITLE
ci: add stale-issue/PR workflow [skip changelog]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,45 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Mark and close stale items
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          operations-per-run: 100
+          remove-stale-when-updated: true
+
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been inactive for 60 days. It will close in 14 days
+            unless there's new activity. Comment, add more context, or apply an
+            exemption label (e.g. `pinned`, `blocker`, `blocked`, `priority:p0`,
+            `priority:p1`) to keep it open.
+          close-issue-message: >
+            Closing as stale. Reopen with new context if this is still relevant.
+          exempt-issue-labels: >-
+            pinned,blocker,blocked,priority:p0,priority:p1,spec-drift,tool-release
+
+          days-before-pr-stale: 30
+          days-before-pr-close: 10
+          stale-pr-label: stale
+          stale-pr-message: >
+            This pull request has been inactive for 30 days. It will close in
+            10 days unless there's new activity. Push a commit, leave a comment,
+            or apply an exemption label to keep it open.
+          close-pr-message: >
+            Closing as stale. Reopen and rebase if you want to continue.
+          exempt-pr-labels: >-
+            pinned,blocker,priority:p0,priority:p1,dependencies


### PR DESCRIPTION
## Summary

- Adds `actions/stale@v10.2.0` (SHA-pinned) on a daily cron + manual dispatch.
- Issues: 60 days idle then stale, 14 more then close. PRs: 30 / 10.
- Exempt issue labels: `pinned`, `blocker`, `blocked`, `priority:p0`, `priority:p1`, `spec-drift`, `tool-release`. The bare `tool-release` label is applied to every per-tool `tool-release:<id>` issue (see `scripts/check-tool-releases.sh`), so per-tool issues stay exempt too.
- Exempt PR labels: `pinned`, `blocker`, `priority:p0`, `priority:p1`, `dependencies` - so dependabot PRs are not staled.
- `remove-stale-when-updated: true` clears the stale label automatically when activity resumes.

## Test plan

- [ ] Trigger via `workflow_dispatch` once after merge to dry-run against the current backlog (the action posts comments and labels, so review the first run before letting cron run unattended).
- [ ] Confirm an exempt-label issue (e.g. one labeled `priority:p1`) is not touched.
- [ ] Confirm a dependabot PR is not touched.