### PR TITLE
fix(tool-release): stop watcher crashing on unbound issue_body

### DIFF
--- a/scripts/check-tool-releases.sh
+++ b/scripts/check-tool-releases.sh
@@ -33,6 +33,31 @@ UPDATE_BASELINES="${UPDATE_BASELINES:-false}"
 TOOL_FILTER="${TOOL_FILTER:-}"
 RUN_URL="${RUN_URL:-}"
 
+# triage_has_relevant_changes "<agnix_triage markdown>"
+# Exit 0 -> file the issue: triage flagged agnix-relevant bullets, OR no triage
+#           ran (empty input) so we cannot rule the release out.
+# Exit 1 -> skip the issue: triage ran and its "#### Agnix-relevant changes"
+#           section has no "- " bullets, so the release does not touch anything
+#           agnix validates (perf/UI/billing/model-only). Caller advances the
+#           baseline without opening an issue.
+triage_has_relevant_changes() {
+  local triage="$1"
+  [[ -z "$triage" ]] && return 0
+  grep -q "^#### Agnix-relevant changes" <<<"$triage" || return 0
+  awk '
+    /^#### Agnix-relevant changes/ { in_section = 1; next }
+    /^#### /                       { in_section = 0 }
+    in_section && /^- /            { found = 1 }
+    END                            { exit(found ? 0 : 1) }
+  ' <<<"$triage"
+}
+
+# When sourced with CHECK_TOOL_RELEASES_LIB_ONLY set (the test harness), expose
+# the helper functions above without running the live poll below.
+if [[ -n "${CHECK_TOOL_RELEASES_LIB_ONLY:-}" ]]; then
+  return 0
+fi
+
 if ! jq -e '.tools | type == "object"' "$BASELINES_FILE" > /dev/null; then
   echo "ERROR: invalid $BASELINES_FILE (.tools must be an object)" >&2
   exit 1
@@ -393,14 +418,6 @@ $release_section
 
 ### Action required
 
-  # Conservative skip: if the agnix-triage section exists but has no bullet points under
-  # "Agnix-relevant changes", skip creating the issue (update baseline only).
-  if echo "$issue_body" | grep -q "#### Agnix-relevant changes" && ! echo "$issue_body" | grep -A 30 "#### Agnix-relevant changes" | grep -qE "^- "; then
-    echo "  [skip] No relevant changes to agnix (triage found only irrelevant updates) — updating baseline only"
-    SKIP_COUNT=$((SKIP_COUNT+1))
-    continue
-  fi
-
 1. Review the release notes for changes that may affect agnix validation rules.
 2. Update [\`crates/agnix-core/src/config.rs\`](${file_base}/crates/agnix-core/src/config.rs) (\`ToolVersions\` / \`SpecRevisions\`) if the new version changes a validated field.
 3. Update [\`knowledge-base/RESEARCH-TRACKING.md\`](${file_base}/knowledge-base/RESEARCH-TRACKING.md) "Last Reviewed" for $display_name.
@@ -410,6 +427,17 @@ $release_section
 *Auto-opened by \`.github/workflows/tool-release-watch.yml\`.${RUN_URL:+ Run: $RUN_URL}*
 BODY
 )
+
+  # Conservative skip: when agnix-triage ran but flagged nothing agnix
+  # validates, suppress the issue and let the baseline advance. Avoids daily
+  # noise from perf/UI/billing/model-only releases. Decided here (outside the
+  # heredoc above) so the helper can be unit-tested and the body build can't
+  # self-reference an unbound "$issue_body" under set -u.
+  if ! triage_has_relevant_changes "$agnix_triage"; then
+    echo "  [skip] triage found no agnix-relevant changes - no issue (baseline only)"
+    SKIP_COUNT=$((SKIP_COUNT+1))
+    continue
+  fi
 
   if [[ "$UPDATE_BASELINES" == "true" ]]; then
     echo "  (baseline-update mode: not creating/commenting on issues)"

--- a/scripts/check-tool-releases.test.sh
+++ b/scripts/check-tool-releases.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Unit tests for the pure helpers in scripts/check-tool-releases.sh.
+#
+# Run:
+#   bash scripts/check-tool-releases.test.sh
+#
+# Sources the script with CHECK_TOOL_RELEASES_LIB_ONLY=1 so only the helper
+# functions load (the live release poll is skipped). Locks in the
+# triage_has_relevant_changes contract: a daily release with no agnix-relevant
+# bullets must be skipped, but anything with relevant bullets - or with no
+# triage at all - must still open an issue. Regression guard for the
+# "issue_body: unbound variable" crash that took the watcher down (the skip
+# logic had been wedged inside the issue-body heredoc).
+
+set -uo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+CHECK_TOOL_RELEASES_LIB_ONLY=1 source "$script_dir/check-tool-releases.sh"
+
+pass=0
+fail=0
+
+# assert_relevant <expected: open|skip> <name> <triage text>
+assert_relevant() {
+  local expected="$1" name="$2" triage="$3" actual
+  if triage_has_relevant_changes "$triage"; then
+    actual="open"
+  else
+    actual="skip"
+  fi
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  ok   - $name (expected $expected)"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL - $name (expected $expected, got $actual)"
+    fail=$((fail + 1))
+  fi
+}
+
+relevant_with_bullets=$(printf '%s\n' \
+  '#### Agnix-relevant changes' \
+  '- new MCP server field `transport` (matches: MCP server definition shape)' \
+  '#### Irrelevant changes (not reviewed)' \
+  '- perf improvements')
+
+relevant_empty=$(printf '%s\n' \
+  '#### Agnix-relevant changes' \
+  '#### Irrelevant changes (not reviewed)' \
+  '- perf improvements' \
+  '- UI polish')
+
+# Exact "nothing relevant" marker that scripts/glm-extract.js instructs GLM to emit.
+relevant_says_none=$(printf '%s\n' \
+  '#### Agnix-relevant changes' \
+  '_None - this release is agnix-irrelevant._' \
+  '#### Irrelevant changes (not reviewed)' \
+  '5 items: model additions, UI polish, bug fixes')
+
+relevant_is_last_section=$(printf '%s\n' \
+  '#### Irrelevant changes (not reviewed)' \
+  '- billing copy tweaks' \
+  '#### Agnix-relevant changes' \
+  '- hook event renamed (matches: Hook event names)')
+
+assert_relevant open "bullets under relevant section"            "$relevant_with_bullets"
+assert_relevant skip "relevant section empty"                    "$relevant_empty"
+assert_relevant skip "relevant section says None"                "$relevant_says_none"
+assert_relevant open "relevant section is last, has bullet"      "$relevant_is_last_section"
+assert_relevant open "no triage ran (empty) - cannot rule out"   ""
+assert_relevant open "triage without the relevant heading"       "free-form notes, no headings"
+
+echo ""
+echo "Summary: pass=$pass fail=$fail"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary
- The agnix-triage skip from `3e66f7c` was inserted **inside** the `issue_body=$(cat <<BODY ... BODY)` heredoc. The injected `if` block referenced `$issue_body` mid-assignment, so under `set -u` every `[NEW]` release aborted with `line 412: issue_body: unbound variable`.
- **Tool Release Watch has failed every day since 2026-05-17 and opened no issues.**
- Moved the decision into a pure helper `triage_has_relevant_changes()`, called after the heredoc is built. Opens an issue when triage found agnix-relevant bullets (or no triage ran); skips + advances baseline only when `#### Agnix-relevant changes` has no `- ` bullets. The awk `END { exit }` form also removes the SIGPIPE/pipefail hazard of the old `grep | grep` chain.
- Added `scripts/check-tool-releases.test.sh` (6 cases) sourced via `CHECK_TOOL_RELEASES_LIB_ONLY` so only the helpers load (no live poll).

## Test plan
- [x] `bash -n scripts/check-tool-releases.sh` - syntax clean
- [x] `bash scripts/check-tool-releases.test.sh` - 6/6 pass (relevant bullets -> open; empty / `_None_` marker -> skip; relevant-as-last-section -> open; no triage -> open; no heading -> open)
- [x] Bullet format verified against `scripts/glm-extract.js` prompt (`- ` dash bullets; `_None - ..._` when irrelevant)
- [ ] Post-merge: trigger `tool-release-watch.yml` via `workflow_dispatch` and confirm it opens issues / logs `[skip]` instead of crashing