### PR TITLE
feat(codex): catch up to rust-v0.133.0 config keys [skip changelog]

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-05-15",
+  "last_updated": "2026-05-24",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {

--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -60,7 +60,7 @@
         "agents_md"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.130.0",
+      "last_known_version": "rust-v0.133.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/crates/agnix-core/src/rules/codex.rs
+++ b/crates/agnix-core/src/rules/codex.rs
@@ -136,7 +136,7 @@ const VALID_WINDOWS_SANDBOX_VALUES: &[&str] = &["elevated", "unelevated"];
 // unknown-top-level-key detection. Keep it in sync with KNOWN_TOP_LEVEL_KEYS ∪ KNOWN_TABLE_KEYS
 // in schemas/codex.rs (this set represents the flat union - the JSON/YAML backends don't
 // distinguish scalar top-level keys from TOML `[section]` tables).
-// Sourced from upstream codex-rs/core/config.schema.json @ rust-v0.128.0. Alphabetized.
+// Sourced from upstream codex-rs/core/config.schema.json; last reconciled @ rust-v0.133.0. Alphabetized.
 const KNOWN_CONFIG_TOP_LEVEL_KEYS: &[&str] = &[
     "agents",
     "allow_login_shell",

--- a/crates/agnix-core/src/rules/codex.rs
+++ b/crates/agnix-core/src/rules/codex.rs
@@ -125,6 +125,7 @@ const KNOWN_PERMISSIONS_NETWORK_KEYS: &[&str] = &[
     "denied_domains",
     "enable_socks5",
     "enabled",
+    "mitm",
     "mode",
     "proxy_url",
 ];
@@ -143,6 +144,7 @@ const KNOWN_CONFIG_TOP_LEVEL_KEYS: &[&str] = &[
     "approval_policy",
     "approvals_reviewer",
     "apps",
+    "apps_mcp_product_sku",
     "audio",
     "auto_review",
     "background_terminal_max_timeout",
@@ -152,6 +154,7 @@ const KNOWN_CONFIG_TOP_LEVEL_KEYS: &[&str] = &[
     "commit_attribution",
     "compact_prompt",
     "default_permissions",
+    "desktop",
     "developer_instructions",
     "disable_paste_burst",
     "experimental_compact_prompt_file",
@@ -175,6 +178,7 @@ const KNOWN_CONFIG_TOP_LEVEL_KEYS: &[&str] = &[
     "history",
     "hooks",
     "include_apps_instructions",
+    "include_collaboration_mode_instructions",
     "include_environment_context",
     "include_permissions_instructions",
     "instructions",
@@ -189,6 +193,7 @@ const KNOWN_CONFIG_TOP_LEVEL_KEYS: &[&str] = &[
     "memories",
     "model",
     "model_auto_compact_token_limit",
+    "model_auto_compact_token_limit_scope",
     "model_catalog_json",
     "model_context_window",
     "model_instructions_file",
@@ -259,8 +264,11 @@ const KNOWN_FEATURE_KEYS: &[&str] = &[
     "js_repl_tools_only",
     "memories",
     "memory_tool",
+    "mentions_v2",
     "multi_agent",
+    "network_proxy",
     "personality",
+    "plugin_sharing",
     "plugins",
     "powershell_utf8",
     "prevent_idle_sleep",
@@ -321,6 +329,7 @@ const KNOWN_MCP_SERVER_KEYS: &[&str] = &[
     "env_http_headers",
     "env_vars",
     "http_headers",
+    "oauth",
     "oauth_resource",
     "required",
     "scopes",
@@ -2892,6 +2901,60 @@ name = "test"
         assert!(
             cdx_004.is_empty(),
             "Known table keys should not trigger CDX-004"
+        );
+    }
+
+    #[test]
+    fn test_codex_0_133_0_new_keys_not_flagged() {
+        // Config keys introduced in Codex rust-v0.133.0 (diffed from
+        // codex-rs/core/config.schema.json between rust-v0.129.0 and
+        // rust-v0.133.0). Regression guard against CDX-004 (unknown key) and
+        // CDX-CFG-026 (unknown permissions.network sub-field) false-positives
+        // on valid 0.133 configs. Covers every new allow-list entry:
+        // top-level (apps_mcp_product_sku, desktop, include_collaboration_
+        // mode_instructions, model_auto_compact_token_limit_scope), features
+        // (mentions_v2, network_proxy, plugin_sharing), mcp_servers (oauth),
+        // and permissions.network (mitm). The new [tui] keys (pet/pet_anchor)
+        // are intentionally NOT added - TUI display tweaks are on the codex
+        // changes_of_interest.irrelevant list (matching the v0.129 catch-up).
+        let content = r#"
+apps_mcp_product_sku = "codex-pro"
+include_collaboration_mode_instructions = true
+model_auto_compact_token_limit_scope = "body_after_prefix"
+
+[desktop]
+opaque = "value"
+
+[features]
+mentions_v2 = true
+network_proxy = true
+plugin_sharing = true
+
+[mcp_servers.example]
+command = "example-server"
+oauth = true
+
+[permissions.network]
+mitm = true
+"#;
+        let diagnostics = validate_config(content);
+        let cdx_004: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-004")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert!(
+            cdx_004.is_empty(),
+            "0.133 keys should not trigger CDX-004, got: {cdx_004:?}"
+        );
+        let cdx_cfg_026: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-026")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert!(
+            cdx_cfg_026.is_empty(),
+            "0.133 permissions.network `mitm` should not trigger CDX-CFG-026, got: {cdx_cfg_026:?}"
         );
     }
 

--- a/crates/agnix-core/src/schemas/codex.rs
+++ b/crates/agnix-core/src/schemas/codex.rs
@@ -123,6 +123,15 @@ pub const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     "realtime",
     // Tool suggestions toggle (added in Codex rust-v0.122.0 catch-up)
     "tool_suggest",
+    // Added in Codex rust-v0.133.0 catch-up (sourced from upstream
+    // codex-rs/core/config.schema.json). Scalar top-level keys:
+    // `apps_mcp_product_sku` (product SKU forwarded on host-owned Apps MCP
+    // requests), `include_collaboration_mode_instructions` (inject the
+    // <collaboration_mode> developer block), and
+    // `model_auto_compact_token_limit_scope` (enum total|body_after_prefix).
+    "apps_mcp_product_sku",
+    "include_collaboration_mode_instructions",
+    "model_auto_compact_token_limit_scope",
     // Legacy camelCase keys (backwards compat)
     "approvalMode",
     "fullAutoErrorMode",
@@ -168,6 +177,11 @@ pub const KNOWN_TABLE_KEYS: &[&str] = &[
     // `allow_codex_version_mismatch`, `export_dir`, `load_path`, and
     // `save_fields_resolved_from_model_catalog`).
     "debug",
+    // Added in Codex rust-v0.133.0 catch-up - `[desktop]` table for opaque
+    // desktop settings stored alongside the rest of config.toml
+    // (`additionalProperties: true` upstream, so nested keys are not
+    // enumerated).
+    "desktop",
 ];
 
 /// An unknown key found in config
@@ -690,6 +704,35 @@ save_fields_resolved_from_model_catalog = true
         assert!(
             result.unknown_keys.is_empty(),
             "0.129 `debug` table should not be flagged as unknown, got: {:?}",
+            result
+                .unknown_keys
+                .iter()
+                .map(|u| u.key.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_codex_0_133_0_new_top_level_keys_not_flagged() {
+        // Top-level keys/table introduced in Codex rust-v0.133.0. Regression
+        // guard: if any of these get dropped from KNOWN_TOP_LEVEL_KEYS /
+        // KNOWN_TABLE_KEYS, CDX-004 starts false-positive-ing on valid 0.133
+        // configs. `[desktop]` is an opaque table (additionalProperties:true
+        // upstream) so its nested keys must not be flagged either.
+        let content = r#"
+apps_mcp_product_sku = "codex-pro"
+include_collaboration_mode_instructions = true
+model_auto_compact_token_limit_scope = "body_after_prefix"
+
+[desktop]
+some_opaque_setting = "value"
+nested_number = 42
+"#;
+        let result = parse_codex_toml(content);
+        assert!(result.parse_error.is_none());
+        assert!(
+            result.unknown_keys.is_empty(),
+            "0.133 top-level keys/`[desktop]` table should not be flagged, got: {:?}",
             result
                 .unknown_keys
                 .iter()

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -17,7 +17,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-15 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
-| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-14 | AGM, XP |
+| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-24 | AGM, XP |
 | OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-24 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-05-14 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-05-15
+**Last Updated**: 2026-05-24
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 


### PR DESCRIPTION
## Summary
Closes #959. Diffed upstream `codex-rs/core/config.schema.json` between `rust-v0.129.0` and `rust-v0.133.0` and extended agnix's config-key allow-lists so **CDX-004** (unknown key) and **CDX-CFG-026** (unknown `permissions.network` sub-field) don't false-positive on valid 0.133 configs. Additive only - keys removed upstream are kept for users on older Codex versions.

**New keys added:**
- Top-level: `apps_mcp_product_sku`, `include_collaboration_mode_instructions`, `model_auto_compact_token_limit_scope`, and the new opaque `[desktop]` table.
- `[features]`: `mentions_v2`, `network_proxy`, `plugin_sharing`.
- `[mcp_servers.*]`: `oauth`.
- `[permissions.network]`: `mitm`.

**Intentionally NOT added (deliberate scope calls):**
- New `[tui]` keys `pet` / `pet_anchor` - TUI display tweaks are on the codex `changes_of_interest.irrelevant` list and were deliberately excluded by the v0.129 catch-up (64bd55d). Kept consistent. (Note: the older v0.129 TUI keys e.g. `raw_output_mode` are likewise still absent from `KNOWN_TUI_KEYS` - a `[tui]` backfill could be a separate cleanup if we decide TUI keys should be tracked.)
- Hook events `SubagentStart` / `SubagentStop` / compact `SessionStart` - already in `schemas/hooks.rs` `VALID_EVENTS`.
- FileSystemAccessMode `deny`-canonical change (openai/codex#23493) - agnix has no read/write/none/deny enum to update.
- Per-profile permission keys (`description` / `extends` / `workspace_roots`) - not enumerated by agnix (CDX-CFG-026 only checks root `permissions.network`).
- `requirements.toml` is newly documented (admin-only) but has no agnix validator - tracking separately rather than expanding this PR.

No new CDX- rule required (allow-list extension only, matching the v0.129 template). Baseline `rust-v0.130.0 -> rust-v0.133.0`.

## Test plan
- [x] `cargo test -p agnix-core --lib` - 3754 pass, 0 fail
- [x] New regression tests `test_codex_0_133_0_new_keys_not_flagged` + `test_codex_0_133_0_new_top_level_keys_not_flagged`
- [x] `cargo clippy -p agnix-core` clean
- [x] `.github/tool-release-baselines.json` valid JSON; `RESEARCH-TRACKING.md` Last Reviewed -> 2026-05-24