### PR TITLE
feat(codex): validate managed requirements.toml (CDX-REQ-000/001) [skip changelog]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 423 rules, 75+ sources, rules.json
+knowledge-base/     # 425 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -66,7 +66,7 @@ tests/fixtures/     # Test cases by category
 
 - `parsers/` - Frontmatter, JSON, Markdown parsing
 - `schemas/` - Type definitions (13 schemas: skill, hooks, agent, mcp, cline, roo, etc.)
-- `rules/` - Validators implementing Validator trait (42 validators)
+- `rules/` - Validators implementing Validator trait (43 validators)
 - `config.rs` - LintConfig, LintConfigBuilder, ConfigError, ToolVersions, SpecRevisions
 - `diagnostics.rs` - Diagnostic, Fix, DiagnosticLevel, ValidationOutcome, LintError (= CoreError), LintResult
 - `eval.rs` - Rule efficacy evaluation (precision/recall/F1)
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-423 rules defined in `knowledge-base/rules.json` (source of truth)
+425 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.18.0 - Production-ready with full validation pipeline
-- 423 validation rules across 42 validators
+- 425 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 423 rules, 75+ sources, rules.json
+knowledge-base/     # 425 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -66,7 +66,7 @@ tests/fixtures/     # Test cases by category
 
 - `parsers/` - Frontmatter, JSON, Markdown parsing
 - `schemas/` - Type definitions (13 schemas: skill, hooks, agent, mcp, cline, roo, etc.)
-- `rules/` - Validators implementing Validator trait (42 validators)
+- `rules/` - Validators implementing Validator trait (43 validators)
 - `config.rs` - LintConfig, LintConfigBuilder, ConfigError, ToolVersions, SpecRevisions
 - `diagnostics.rs` - Diagnostic, Fix, DiagnosticLevel, ValidationOutcome, LintError (= CoreError), LintResult
 - `eval.rs` - Rule efficacy evaluation (precision/recall/F1)
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-423 rules defined in `knowledge-base/rules.json` (source of truth)
+425 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.18.0 - Production-ready with full validation pipeline
-- 423 validation rules across 42 validators
+- 425 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>423 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>425 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 423 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 425 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/crates/agnix-core/src/file_types/detection.rs
+++ b/crates/agnix-core/src/file_types/detection.rs
@@ -479,6 +479,22 @@ pub fn detect_file_type(path: &Path) -> FileType {
         {
             FileType::CodexConfig
         }
+        // Codex CLI managed requirements (admin-written, system location):
+        // `/etc/codex/requirements.toml` (Unix) or
+        // `%ProgramData%\OpenAI\Codex\requirements.toml` (Windows). The parent
+        // dir is `codex`/`Codex` (case-insensitive); the project `.codex/` dir
+        // is deliberately NOT matched - Codex does not read requirements.toml
+        // from there.
+        //
+        // Accepted trade-off: a project that happens to keep an unrelated
+        // `requirements.toml` under a literal `codex/` directory would be
+        // classified here and linted as Codex requirements. Detection is
+        // path-only (no content peek) by design, and this combination is rare,
+        // so we accept it rather than gate on an absolute system path (which
+        // would defeat linting an explicitly-passed file).
+        "requirements.toml" if parent_eq_ignore_ascii_case(parent, "codex") => {
+            FileType::CodexRequirements
+        }
         name if name.ends_with(".md") => {
             // Agent directories take precedence over filename exclusions.
             // Files like agents/README.md should be validated as agent configs.
@@ -1079,6 +1095,30 @@ mod tests {
         assert_eq!(
             detect_file_type(Path::new(".codex/config.yml")),
             FileType::CodexConfig
+        );
+    }
+
+    #[test]
+    fn detect_codex_requirements() {
+        // System (Unix) location: /etc/codex/requirements.toml
+        assert_eq!(
+            detect_file_type(Path::new("/etc/codex/requirements.toml")),
+            FileType::CodexRequirements
+        );
+        // Windows ProgramData location uses a `Codex` parent (case-insensitive)
+        assert_eq!(
+            detect_file_type(Path::new("OpenAI/Codex/requirements.toml")),
+            FileType::CodexRequirements
+        );
+        // Project `.codex/` must NOT match - Codex never reads requirements.toml there
+        assert_ne!(
+            detect_file_type(Path::new(".codex/requirements.toml")),
+            FileType::CodexRequirements
+        );
+        // A bare requirements.toml with no codex parent is not ours
+        assert_ne!(
+            detect_file_type(Path::new("requirements.toml")),
+            FileType::CodexRequirements
         );
     }
 

--- a/crates/agnix-core/src/file_types/types.rs
+++ b/crates/agnix-core/src/file_types/types.rs
@@ -72,6 +72,9 @@ pub enum FileType {
     CodexConfig,
     /// Codex CLI plugin manifest (.codex-plugin/plugin.json)
     CodexPlugin,
+    /// Codex CLI managed requirements (system `codex/requirements.toml` -
+    /// `/etc/codex/` on Unix, `%ProgramData%\OpenAI\Codex\` on Windows)
+    CodexRequirements,
     /// Roo Code rules files (.roorules, .roo/rules/*.md)
     RooRules,
     /// Roo Code custom modes configuration (.roomodes)
@@ -163,6 +166,7 @@ impl fmt::Display for FileType {
             FileType::GeminiIgnore => "GeminiIgnore",
             FileType::CodexConfig => "CodexConfig",
             FileType::CodexPlugin => "CodexPlugin",
+            FileType::CodexRequirements => "CodexRequirements",
             FileType::RooRules => "RooRules",
             FileType::RooModes => "RooModes",
             FileType::RooIgnore => "RooIgnore",
@@ -221,6 +225,7 @@ mod tests {
             (FileType::GeminiIgnore, "GeminiIgnore"),
             (FileType::CodexConfig, "CodexConfig"),
             (FileType::CodexPlugin, "CodexPlugin"),
+            (FileType::CodexRequirements, "CodexRequirements"),
             (FileType::RooRules, "RooRules"),
             (FileType::RooModes, "RooModes"),
             (FileType::RooIgnore, "RooIgnore"),
@@ -278,6 +283,7 @@ mod tests {
             FileType::GeminiIgnore,
             FileType::CodexConfig,
             FileType::CodexPlugin,
+            FileType::CodexRequirements,
             FileType::RooRules,
             FileType::RooModes,
             FileType::RooIgnore,
@@ -349,6 +355,7 @@ mod tests {
             FileType::GeminiIgnore,
             FileType::CodexConfig,
             FileType::CodexPlugin,
+            FileType::CodexRequirements,
             FileType::RooRules,
             FileType::RooModes,
             FileType::RooIgnore,

--- a/crates/agnix-core/src/registry.rs
+++ b/crates/agnix-core/src/registry.rs
@@ -398,7 +398,7 @@ impl ValidatorRegistryBuilder {
 ///
 /// Used by `BuiltinProvider` (via `debug_assert_eq!`) and tests to catch
 /// accidental additions or removals without updating all providers.
-const EXPECTED_BUILTIN_COUNT: usize = 80;
+const EXPECTED_BUILTIN_COUNT: usize = 81;
 
 // -- Category providers -----------------------------------------------------
 //
@@ -764,6 +764,11 @@ impl ValidatorProvider for MiscProvider {
                 codex_plugin_validator,
             ),
             (
+                FileType::CodexRequirements,
+                Some("CodexRequirementsValidator"),
+                codex_requirements_validator,
+            ),
+            (
                 FileType::KiroSteering,
                 Some("KiroSteeringValidator"),
                 kiro_steering_validator,
@@ -967,6 +972,10 @@ fn codex_config_validator() -> Box<dyn Validator> {
 
 fn codex_plugin_validator() -> Box<dyn Validator> {
     Box::new(crate::rules::codex_plugin::CodexPluginValidator)
+}
+
+fn codex_requirements_validator() -> Box<dyn Validator> {
+    Box::new(crate::rules::codex_requirements::CodexRequirementsValidator)
 }
 
 fn roo_validator() -> Box<dyn Validator> {
@@ -1485,6 +1494,7 @@ mod tests {
                 | FileType::GeminiIgnore
                 | FileType::CodexConfig
                 | FileType::CodexPlugin
+                | FileType::CodexRequirements
                 | FileType::RooRules
                 | FileType::RooModes
                 | FileType::RooIgnore
@@ -1989,7 +1999,7 @@ mod tests {
 
     #[test]
     fn misc_provider_count() {
-        assert_eq!(MiscProvider.named_validators().len(), 30);
+        assert_eq!(MiscProvider.named_validators().len(), 31);
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/codex_requirements.rs
+++ b/crates/agnix-core/src/rules/codex_requirements.rs
@@ -1,0 +1,294 @@
+//! Codex CLI managed-requirements validation (CDX-REQ-000, CDX-REQ-001).
+//!
+//! Validates Codex's admin-written `requirements.toml` (system location:
+//! `/etc/codex/requirements.toml` on Unix, `%ProgramData%\OpenAI\Codex\
+//! requirements.toml` on Windows). The file is deserialized upstream by
+//! `ConfigRequirementsToml` (codex-rs/config/src/config_requirements.rs) and,
+//! crucially, has **no** `#[serde(deny_unknown_fields)]` - so a typo in a
+//! top-level key is silently ignored by Codex and the intended constraint is
+//! never enforced. CDX-REQ-001 surfaces those typos; CDX-REQ-000 reports
+//! invalid TOML syntax.
+use crate::{
+    config::PerFileLintConfig,
+    diagnostics::Diagnostic,
+    rules::{Validator, ValidatorMetadata},
+};
+use std::path::Path;
+
+const RULE_IDS: &[&str] = &["CDX-REQ-000", "CDX-REQ-001"];
+
+/// Known top-level keys of `requirements.toml`, sourced from
+/// `ConfigRequirementsToml` @ openai/codex rust-v0.133.0. Both `features`
+/// (serde rename) and `feature_requirements` (serde alias) are accepted on
+/// disk; the network table is only valid as `experimental_network` (serde
+/// rename - the bare `network` field name is not a valid TOML key).
+const KNOWN_REQUIREMENTS_KEYS: &[&str] = &[
+    "allow_managed_hooks_only",
+    "allowed_approval_policies",
+    "allowed_approvals_reviewers",
+    "allowed_permissions",
+    "allowed_sandbox_modes",
+    "allowed_web_search_modes",
+    "apps",
+    "computer_use",
+    "enforce_residency",
+    "experimental_network",
+    "feature_requirements",
+    "features",
+    "guardian_policy_config",
+    "hooks",
+    "mcp_servers",
+    "permissions",
+    "plugins",
+    "remote_sandbox_config",
+    "rules",
+];
+
+pub struct CodexRequirementsValidator;
+
+impl Validator for CodexRequirementsValidator {
+    fn metadata(&self) -> ValidatorMetadata {
+        ValidatorMetadata {
+            name: self.name(),
+            rule_ids: RULE_IDS,
+        }
+    }
+
+    fn validate_per_file(
+        &self,
+        path: &Path,
+        content: &str,
+        config: &PerFileLintConfig<'_>,
+    ) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        if !config.rules().codex {
+            return diagnostics;
+        }
+
+        // CDX-REQ-000: TOML syntax. Parse as a top-level table (stable across
+        // toml crate versions, unlike `toml::Value` document parsing).
+        let table: toml::Table = match toml::from_str::<toml::Table>(content) {
+            Ok(table) => table,
+            Err(error) => {
+                let (line, column) = toml_error_location(content, &error);
+                if config.is_rule_enabled("CDX-REQ-000") {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            path.to_path_buf(),
+                            line,
+                            column,
+                            "CDX-REQ-000",
+                            format!("Invalid TOML in requirements.toml: {}", error.message()),
+                        )
+                        .with_suggestion("Fix the TOML syntax error."),
+                    );
+                }
+                return diagnostics;
+            }
+        };
+
+        // CDX-REQ-001: unknown top-level key. requirements.toml has no
+        // deny_unknown_fields upstream, so a typo'd key is silently dropped.
+        if config.is_rule_enabled("CDX-REQ-001") {
+            for key in table.keys() {
+                if !KNOWN_REQUIREMENTS_KEYS.contains(&key.as_str()) {
+                    diagnostics.push(
+                        Diagnostic::warning(
+                            path.to_path_buf(),
+                            find_toml_key_line(content, key).unwrap_or(1),
+                            0,
+                            "CDX-REQ-001",
+                            format!(
+                                "Unknown requirements.toml key '{key}'. Codex silently ignores unknown keys, so this constraint will not be enforced. Known keys: {}",
+                                KNOWN_REQUIREMENTS_KEYS.join(", ")
+                            ),
+                        )
+                        .with_suggestion(
+                            "Remove or rename the key (Codex does not reject unknown keys, so typos go unnoticed).",
+                        ),
+                    );
+                }
+            }
+        }
+
+        diagnostics
+    }
+}
+
+/// Convert a `toml` parse error's byte span into a 1-indexed (line, column).
+fn toml_error_location(content: &str, error: &toml::de::Error) -> (usize, usize) {
+    error
+        .span()
+        .map(|span| {
+            let mut line = 1usize;
+            let mut column = 1usize;
+            for (idx, ch) in content.char_indices() {
+                if idx >= span.start {
+                    break;
+                }
+                if ch == '\n' {
+                    line += 1;
+                    column = 1;
+                } else {
+                    column += 1;
+                }
+            }
+            (line, column)
+        })
+        .unwrap_or((1, 0))
+}
+
+/// Find the 1-indexed line of a top-level TOML key, matching both the
+/// `key = ...` form and the `[key]` / `[key.sub]` table-header form.
+fn find_toml_key_line(content: &str, key: &str) -> Option<usize> {
+    let quoted = format!("\"{key}\"");
+    for (idx, line) in content.lines().enumerate() {
+        let trimmed = line.trim_start();
+        // Table header: [key] or [key.sub] or [[key]]
+        let header = trimmed
+            .strip_prefix("[[")
+            .or_else(|| trimmed.strip_prefix('['));
+        if let Some(rest) = header {
+            let name = rest.trim_start();
+            if name.strip_prefix(key).is_some_and(|after| {
+                let a = after.trim_start();
+                a.starts_with('.') || a.starts_with(']')
+            }) || name.strip_prefix(&quoted).is_some_and(|after| {
+                let a = after.trim_start();
+                a.starts_with('.') || a.starts_with(']')
+            }) {
+                return Some(idx + 1);
+            }
+            continue;
+        }
+        // Scalar/array/inline-table assignment: key = ... or "key" = ...
+        if let Some(after) = trimmed
+            .strip_prefix(key)
+            .or_else(|| trimmed.strip_prefix(&quoted))
+        {
+            if after.trim_start().starts_with('=') {
+                return Some(idx + 1);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::LintConfig;
+    use std::path::PathBuf;
+
+    fn validate(content: &str) -> Vec<Diagnostic> {
+        let config = LintConfig::builder().build().expect("config");
+        let per_file = config.for_path(&PathBuf::from("/etc/codex/requirements.toml"));
+        CodexRequirementsValidator.validate_per_file(
+            &PathBuf::from("/etc/codex/requirements.toml"),
+            content,
+            &per_file,
+        )
+    }
+
+    fn rules(content: &str, code: &str) -> Vec<String> {
+        validate(content)
+            .into_iter()
+            .filter(|d| d.rule == code)
+            .map(|d| d.message)
+            .collect()
+    }
+
+    #[test]
+    fn parse_error_flagged() {
+        let diags = rules("allowed_sandbox_modes = [unclosed", "CDX-REQ-000");
+        assert_eq!(diags.len(), 1, "expected one CDX-REQ-000, got: {diags:?}");
+    }
+
+    #[test]
+    fn known_keys_not_flagged() {
+        // A realistic managed requirements.toml exercising scalar, array, and
+        // table forms plus the `experimental_network` rename and a permission
+        // profile sub-table.
+        let content = r#"
+allow_managed_hooks_only = true
+allowed_sandbox_modes = ["read-only", "workspace-write"]
+allowed_permissions = ["locked"]
+enforce_residency = "us"
+guardian_policy_config = "deny everything"
+
+[computer_use]
+allow_locked_computer_use = false
+
+[features]
+some_feature = true
+
+[mcp_servers.docs]
+command = "docs-server"
+
+[apps.example]
+enabled = true
+
+[rules]
+prefix_rules = []
+
+[experimental_network]
+enabled = true
+
+[permissions.locked]
+description = "locked profile"
+"#;
+        let diags = rules(content, "CDX-REQ-001");
+        assert!(
+            diags.is_empty(),
+            "known keys should not be flagged: {diags:?}"
+        );
+        assert!(rules(content, "CDX-REQ-000").is_empty());
+    }
+
+    #[test]
+    fn feature_requirements_alias_accepted() {
+        let diags = rules("[feature_requirements]\nx = true\n", "CDX-REQ-001");
+        assert!(
+            diags.is_empty(),
+            "feature_requirements alias is valid: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_scalar_key_flagged() {
+        // Typo of allowed_sandbox_modes - silently ignored by Codex.
+        let diags = rules("allowed_sandbox_mode = [\"read-only\"]\n", "CDX-REQ-001");
+        assert_eq!(
+            diags.len(),
+            1,
+            "typo'd scalar key should be flagged: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_table_key_flagged_with_line() {
+        // `network` is the old name; the on-disk key was renamed to
+        // experimental_network, so a bare [network] table is unknown.
+        let content = "allow_managed_hooks_only = true\n\n[network]\nenabled = true\n";
+        let diags = validate(content);
+        let req001: Vec<_> = diags.iter().filter(|d| d.rule == "CDX-REQ-001").collect();
+        assert_eq!(req001.len(), 1, "renamed [network] table should be flagged");
+        assert_eq!(
+            req001[0].line, 3,
+            "should point at the [network] header line"
+        );
+    }
+
+    #[test]
+    fn disabled_when_codex_rules_off() {
+        let mut config = LintConfig::builder().build().expect("config");
+        config.rules_mut().codex = false;
+        let per_file = config.for_path(&PathBuf::from("/etc/codex/requirements.toml"));
+        let diags = CodexRequirementsValidator.validate_per_file(
+            &PathBuf::from("/etc/codex/requirements.toml"),
+            "totally_unknown_key = true\n",
+            &per_file,
+        );
+        assert!(diags.is_empty(), "no diagnostics when codex rules disabled");
+    }
+}

--- a/crates/agnix-core/src/rules/codex_requirements.rs
+++ b/crates/agnix-core/src/rules/codex_requirements.rs
@@ -111,11 +111,16 @@ impl Validator for CodexRequirementsValidator {
             }
         }
 
+        // `toml::Table` is a BTreeMap, so `keys()` yields keys in lexical
+        // order rather than file order. Sort so diagnostics read top-to-bottom.
+        diagnostics.sort_by_key(|d| (d.line, d.column));
         diagnostics
     }
 }
 
-/// Convert a `toml` parse error's byte span into a 1-indexed (line, column).
+/// Convert a `toml` parse error's byte span into a (line, column). The line is
+/// 1-indexed and the column 1-indexed when a span is available; the fallback
+/// `(1, 0)` (column 0) is used only when the error carries no span.
 fn toml_error_location(content: &str, error: &toml::de::Error) -> (usize, usize) {
     error
         .span()
@@ -138,35 +143,39 @@ fn toml_error_location(content: &str, error: &toml::de::Error) -> (usize, usize)
         .unwrap_or((1, 0))
 }
 
-/// Find the 1-indexed line of a top-level TOML key, matching both the
-/// `key = ...` form and the `[key]` / `[key.sub]` table-header form.
+/// Find the 1-indexed line of a top-level TOML key. Matches the table-header
+/// form (`[key]`, `[key.sub]`, `[[key]]`), the plain assignment (`key = ...`),
+/// and the dotted-key assignment (`key.sub = ...`). Inline comments are
+/// stripped before matching so a trailing `# ...` cannot interfere.
 fn find_toml_key_line(content: &str, key: &str) -> Option<usize> {
     let quoted = format!("\"{key}\"");
     for (idx, line) in content.lines().enumerate() {
-        let trimmed = line.trim_start();
-        // Table header: [key] or [key.sub] or [[key]]
+        let trimmed = line.split('#').next().unwrap_or("").trim();
+        // Table header: [key], [key.sub], or [[key]]
         let header = trimmed
             .strip_prefix("[[")
             .or_else(|| trimmed.strip_prefix('['));
         if let Some(rest) = header {
             let name = rest.trim_start();
-            if name.strip_prefix(key).is_some_and(|after| {
+            let is_header = |after: &str| {
                 let a = after.trim_start();
                 a.starts_with('.') || a.starts_with(']')
-            }) || name.strip_prefix(&quoted).is_some_and(|after| {
-                let a = after.trim_start();
-                a.starts_with('.') || a.starts_with(']')
-            }) {
+            };
+            if name.strip_prefix(key).is_some_and(is_header)
+                || name.strip_prefix(&quoted).is_some_and(is_header)
+            {
                 return Some(idx + 1);
             }
             continue;
         }
-        // Scalar/array/inline-table assignment: key = ... or "key" = ...
+        // Plain or dotted-key assignment: `key = ...`, `"key" = ...`, or
+        // `key.sub = ...`.
         if let Some(after) = trimmed
             .strip_prefix(key)
             .or_else(|| trimmed.strip_prefix(&quoted))
         {
-            if after.trim_start().starts_with('=') {
+            let a = after.trim_start();
+            if a.starts_with('=') || a.starts_with('.') {
                 return Some(idx + 1);
             }
         }
@@ -277,6 +286,32 @@ description = "locked profile"
             req001[0].line, 3,
             "should point at the [network] header line"
         );
+    }
+
+    #[test]
+    fn unknown_dotted_key_flagged_with_line() {
+        // Dotted-key assignment: `unknown.enabled = true` parses to top-level
+        // key `unknown`. The line-finder must locate the dotted form, not fall
+        // back to line 1.
+        let content = "allow_managed_hooks_only = true\nunknown.enabled = true\n";
+        let diags = validate(content);
+        let req001: Vec<_> = diags.iter().filter(|d| d.rule == "CDX-REQ-001").collect();
+        assert_eq!(req001.len(), 1, "dotted unknown key should be flagged");
+        assert_eq!(req001[0].line, 2, "should point at the dotted-key line");
+    }
+
+    #[test]
+    fn diagnostics_sorted_by_line() {
+        // Keys chosen so BTreeMap order (alpha) differs from file order:
+        // `zzz_unknown` sorts after `aaa_unknown` but appears first in the file.
+        let content = "zzz_unknown = 1\naaa_unknown = 2\n";
+        let diags = validate(content);
+        let lines: Vec<usize> = diags
+            .iter()
+            .filter(|d| d.rule == "CDX-REQ-001")
+            .map(|d| d.line)
+            .collect();
+        assert_eq!(lines, vec![1, 2], "diagnostics should be in file order");
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/mod.rs
+++ b/crates/agnix-core/src/rules/mod.rs
@@ -9,6 +9,7 @@ pub mod claude_settings;
 pub mod cline;
 pub mod codex;
 pub mod codex_plugin;
+pub mod codex_requirements;
 pub mod copilot;
 pub mod cross_platform;
 pub mod cursor;

--- a/crates/agnix-core/tests/api_contract.rs
+++ b/crates/agnix-core/tests/api_contract.rs
@@ -287,6 +287,7 @@ fn file_type_enum_covers_all_variants() {
         agnix_core::FileType::GeminiIgnore,
         agnix_core::FileType::CodexConfig,
         agnix_core::FileType::CodexPlugin,
+        agnix_core::FileType::CodexRequirements,
         agnix_core::FileType::RooRules,
         agnix_core::FileType::RooModes,
         agnix_core::FileType::RooIgnore,
@@ -308,7 +309,7 @@ fn file_type_enum_covers_all_variants() {
 
     assert_eq!(
         variants.len(),
-        46,
+        47,
         "A new FileType variant may have been added or removed. Please update this test's variant list and the match statement below."
     );
 
@@ -343,6 +344,7 @@ fn file_type_enum_covers_all_variants() {
             agnix_core::FileType::GeminiIgnore => {}
             agnix_core::FileType::CodexConfig => {}
             agnix_core::FileType::CodexPlugin => {}
+            agnix_core::FileType::CodexRequirements => {}
             agnix_core::FileType::RooRules => {}
             agnix_core::FileType::RooModes => {}
             agnix_core::FileType::RooIgnore => {}

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 423,
-  "last_updated": "2026-05-13",
+  "total_rules": 425,
+  "last_updated": "2026-05-24",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -5402,6 +5402,64 @@
       },
       "good_example": "[agents]\nmax_threads = 4\n\n[features]\n# multi_agent_v2 omitted or false",
       "bad_example": "[agents]\nmax_threads = 4\n\n[features]\nmulti_agent_v2 = true"
+    },
+    {
+      "id": "CDX-REQ-000",
+      "name": "Codex requirements.toml TOML Parse Error",
+      "severity": "HIGH",
+      "category": "codex",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/config_requirements.rs",
+          "https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/loader/mod.rs"
+        ],
+        "verified_on": "2026-05-24",
+        "applies_to": {
+          "tool": "codex",
+          "version_range": ">=0.133.0"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "allow_managed_hooks_only = true",
+      "bad_example": "allowed_sandbox_modes = [unclosed"
+    },
+    {
+      "id": "CDX-REQ-001",
+      "name": "Unknown Codex requirements.toml Key",
+      "severity": "MEDIUM",
+      "category": "codex",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/config_requirements.rs",
+          "https://github.com/openai/codex/blob/rust-v0.133.0/docs/config.md"
+        ],
+        "verified_on": "2026-05-24",
+        "applies_to": {
+          "tool": "codex",
+          "version_range": ">=0.133.0"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "allowed_sandbox_modes = [\"read-only\"]",
+      "bad_example": "allowed_sandbox_mode = [\"read-only\"]"
     },
     {
       "id": "CL-SK-001",
@@ -11754,7 +11812,7 @@
     },
     "codex": {
       "prefix": "CDX",
-      "count": 60,
+      "count": 62,
       "description": "Codex CLI configuration validation"
     },
     "roo-code": {

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -101,7 +101,7 @@ knowledge-base/
 | Claude Skills | 20 | 11 | 8 | 1 | 13 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
-| Codex CLI | 60 | 30 | 25 | 5 | 10 |
+| Codex CLI | 62 | 31 | 26 | 5 | 10 |
 | Codex Skills | 1 | 0 | 1 | 0 | 1 |
 | GitHub Copilot | 25 | 13 | 9 | 3 | 11 |
 | Copilot Skills | 1 | 0 | 1 | 0 | 1 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **425** | **215** | **180** | **28** | **129** |
+| **TOTAL** | **425** | **216** | **181** | **28** | **129** |
 
 
 ---

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 423 validation rules across 40 categories, sourced from 75+ references
+> 425 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 423 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 425 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (423 rules)
+├── VALIDATION-RULES.md             # Master validation reference (425 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **423 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **425 rules** |
 
 
 ### Validation Rules by Category
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **423** | **215** | **180** | **28** | **129** |
+| **TOTAL** | **425** | **215** | **180** | **28** | **129** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 423 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 425 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     423 rules
+Validation Rules:     425 rules
 Auto-Fixable Rules:   96 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 423 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 425 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -3416,7 +3416,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Claude Skills | 20 | 11 | 8 | 1 | 13 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
-| Codex CLI | 60 | 30 | 25 | 5 | 10 |
+| Codex CLI | 62 | 31 | 26 | 5 | 10 |
 | Codex Skills | 1 | 0 | 1 | 0 | 1 |
 | GitHub Copilot | 25 | 13 | 9 | 3 | 11 |
 | Copilot Skills | 1 | 0 | 1 | 0 | 1 |
@@ -3443,7 +3443,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **423** | **215** | **180** | **28** | **129** |
+| **TOTAL** | **425** | **216** | **181** | **28** | **129** |
 
 
 ---

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -2648,6 +2648,24 @@ Rules for local Gemini agent markdown files at `.gemini/agents/*.md`. These defi
 
 ---
 
+### Codex Requirements Rules (CDX-REQ)
+
+Validates Codex's admin-written managed `requirements.toml` (system location: `/etc/codex/requirements.toml` on Unix, `%ProgramData%\OpenAI\Codex\requirements.toml` on Windows). Codex does not reject unknown keys in this file, so typo'd constraints are silently dropped - hence the unknown-key check.
+
+### CDX-REQ-000 [HIGH] Codex requirements.toml TOML Parse Error
+**Requirement**: `requirements.toml` MUST be syntactically valid TOML
+**Detection**: Parse the file as a TOML table; report the parse error location on failure
+**Fix**: No auto-fix (correct the TOML syntax)
+**Source**: github.com/openai/codex (codex-rs/config/src/config_requirements.rs, codex-rs/config/src/loader/mod.rs @ rust-v0.133.0)
+
+### CDX-REQ-001 [MEDIUM] Unknown Codex requirements.toml Key
+**Requirement**: Top-level keys SHOULD be recognized members of `ConfigRequirementsToml`; Codex silently ignores unknown keys (no `deny_unknown_fields`), so a typo is never enforced
+**Detection**: Compare each top-level key against the known set (`allow_managed_hooks_only`, `allowed_approval_policies`, `allowed_approvals_reviewers`, `allowed_permissions`, `allowed_sandbox_modes`, `allowed_web_search_modes`, `apps`, `computer_use`, `enforce_residency`, `experimental_network`, `features`/`feature_requirements`, `guardian_policy_config`, `hooks`, `mcp_servers`, `permissions`, `plugins`, `remote_sandbox_config`, `rules`)
+**Fix**: No auto-fix (remove or rename the key)
+**Source**: github.com/openai/codex (codex-rs/config/src/config_requirements.rs @ rust-v0.133.0, docs/config.md)
+
+---
+
 ## ROO CODE RULES
 
 <a id="roo-001"></a>
@@ -3455,8 +3473,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 423 validation rules across 40 categories
+**Total Coverage**: 425 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 215 HIGH, 180 MEDIUM, 28 LOW
+**Certainty**: 216 HIGH, 181 MEDIUM, 28 LOW
 **Auto-Fixable**: 129 rules (30%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 423,
-  "last_updated": "2026-05-13",
+  "total_rules": 425,
+  "last_updated": "2026-05-24",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -5402,6 +5402,64 @@
       },
       "good_example": "[agents]\nmax_threads = 4\n\n[features]\n# multi_agent_v2 omitted or false",
       "bad_example": "[agents]\nmax_threads = 4\n\n[features]\nmulti_agent_v2 = true"
+    },
+    {
+      "id": "CDX-REQ-000",
+      "name": "Codex requirements.toml TOML Parse Error",
+      "severity": "HIGH",
+      "category": "codex",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/config_requirements.rs",
+          "https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/loader/mod.rs"
+        ],
+        "verified_on": "2026-05-24",
+        "applies_to": {
+          "tool": "codex",
+          "version_range": ">=0.133.0"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "allow_managed_hooks_only = true",
+      "bad_example": "allowed_sandbox_modes = [unclosed"
+    },
+    {
+      "id": "CDX-REQ-001",
+      "name": "Unknown Codex requirements.toml Key",
+      "severity": "MEDIUM",
+      "category": "codex",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/config_requirements.rs",
+          "https://github.com/openai/codex/blob/rust-v0.133.0/docs/config.md"
+        ],
+        "verified_on": "2026-05-24",
+        "applies_to": {
+          "tool": "codex",
+          "version_range": ">=0.133.0"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "allowed_sandbox_modes = [\"read-only\"]",
+      "bad_example": "allowed_sandbox_mode = [\"read-only\"]"
     },
     {
       "id": "CL-SK-001",
@@ -11754,7 +11812,7 @@
     },
     "codex": {
       "prefix": "CDX",
-      "count": 60,
+      "count": 62,
       "description": "Codex CLI configuration validation"
     },
     "roo-code": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.27.1",
-  "description": "Lint agent configurations before they break your workflow. 423 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 425 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "[email protected]",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 423 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 425 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 423 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 425 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 423 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 425 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/rules/generated/cdx-req-000.md
+++ b/website/docs/rules/generated/cdx-req-000.md
@@ -1,0 +1,49 @@
+---
+id: cdx-req-000
+title: "CDX-REQ-000: Codex requirements.toml TOML Parse Error"
+sidebar_label: "CDX-REQ-000"
+description: "agnix rule CDX-REQ-000 checks for codex requirements.toml toml parse error in codex cli files. Severity: HIGH. See examples and fix guidance."
+keywords: ["CDX-REQ-000", "codex requirements.toml toml parse error", "codex cli", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CDX-REQ-000`
+- **Severity**: `HIGH`
+- **Category**: `Codex CLI`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-05-24`
+
+## Applicability
+
+- **Tool**: `codex`
+- **Version Range**: `>=0.133.0`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/config_requirements.rs
+- https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/loader/mod.rs
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```toml
+allowed_sandbox_modes = [unclosed
+```
+
+### Valid
+
+```toml
+allow_managed_hooks_only = true
+```

--- a/website/docs/rules/generated/cdx-req-001.md
+++ b/website/docs/rules/generated/cdx-req-001.md
@@ -1,0 +1,49 @@
+---
+id: cdx-req-001
+title: "CDX-REQ-001: Unknown Codex requirements.toml Key - Codex CLI"
+sidebar_label: "CDX-REQ-001"
+description: "agnix rule CDX-REQ-001 checks for unknown codex requirements.toml key in codex cli files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CDX-REQ-001", "unknown codex requirements.toml key", "codex cli", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CDX-REQ-001`
+- **Severity**: `MEDIUM`
+- **Category**: `Codex CLI`
+- **Normative Level**: `SHOULD`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-05-24`
+
+## Applicability
+
+- **Tool**: `codex`
+- **Version Range**: `>=0.133.0`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/openai/codex/blob/rust-v0.133.0/codex-rs/config/src/config_requirements.rs
+- https://github.com/openai/codex/blob/rust-v0.133.0/docs/config.md
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```toml
+allowed_sandbox_mode = ["read-only"]
+```
+
+### Valid
+
+```toml
+allowed_sandbox_modes = ["read-only"]
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `423` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `425` validation rules generated from `knowledge-base/rules.json`.
 `129` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -198,6 +198,8 @@ This section contains all `423` validation rules generated from `knowledge-base/
 | [CDX-CFG-027](./generated/cdx-cfg-027.md) | Invalid Windows Sandbox Value | LOW | Codex CLI | Yes (unsafe) |
 | [CDX-CFG-028](./generated/cdx-cfg-028.md) | Unsupported Inline MCP bearer_token Field | HIGH | Codex CLI | No |
 | [CDX-CFG-029](./generated/cdx-cfg-029.md) | Incompatible agents.max_threads with multi_agent_v2 | HIGH | Codex CLI | No |
+| [CDX-REQ-000](./generated/cdx-req-000.md) | Codex requirements.toml TOML Parse Error | HIGH | Codex CLI | No |
+| [CDX-REQ-001](./generated/cdx-req-001.md) | Unknown Codex requirements.toml Key | MEDIUM | Codex CLI | No |
 | [CL-SK-001](./generated/cl-sk-001.md) | Cline Skill Uses Unsupported Field | MEDIUM | Cline Skills | Yes (safe/unsafe) |
 | [CL-SK-002](./generated/cl-sk-002.md) | Missing Skill Name | HIGH | Cline Skills | Yes (safe) |
 | [CL-SK-003](./generated/cl-sk-003.md) | Missing Skill Description | HIGH | Cline Skills | No |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 423,
+  "totalRules": 425,
   "categoryCount": 40,
   "autofixCount": 129,
   "uniqueTools": [


### PR DESCRIPTION
## Summary
Closes #965. Adds the first validator for Codex's admin-written managed `requirements.toml` (system location: `/etc/codex/requirements.toml` on Unix, `%ProgramData%\OpenAI\Codex\requirements.toml` on Windows) - a surface agnix had no coverage for.

**Why an unknown-key check is the high-ROI wedge:** upstream `ConfigRequirementsToml` (`codex-rs/config/src/config_requirements.rs` @ `rust-v0.133.0`) has **no** `#[serde(deny_unknown_fields)]`. Codex silently drops a typo'd top-level key, so the intended managed constraint is never enforced and there is no other signal. The linter is the only catch - which is also why CDX-REQ-001 is a warning, not info (same rationale as CDX-004 for config.toml).

### Rules
- **CDX-REQ-000** (HIGH): invalid TOML syntax.
- **CDX-REQ-001** (MEDIUM): unknown top-level key, checked against the 19 documented keys. Both the `features` rename and the `feature_requirements` alias are accepted; the network table is valid only as `experimental_network` (rename-only, bare `network` is not a valid on-disk key).

### Plumbing
- New `FileType::CodexRequirements`, detected for `requirements.toml` under a `codex`/`Codex` parent (case-insensitive). The project `.codex/` dir is deliberately **not** matched - Codex never reads requirements.toml there.
- New `CodexRequirementsValidator` (modeled on `codex_plugin`), registered in `MiscProvider`, gated on the existing `codex` rule toggle.

### Scope & follow-ups (deliberate MVP)
- This PR is **parse + unknown-key only**. Cross-field invariants (`allowed_sandbox_modes` must include `read-only`; `enforce_residency` enum = `"us"`; the `experimental_network.domains` vs legacy `allowed_domains` mutex; reserved `[permissions.filesystem]` name) are genuinely high-value (load-failing) but each is its own evidence chain - will file a follow-up.
- `requirements.toml` is a **system-wide** file, so `agnix .` in a project tree won't normally encounter it; users will pass the path explicitly. Accepted low-probability trade-off: an unrelated `requirements.toml` under a literal lowercase `codex/` dir would be classified here (detection is path-only by design; documented in `detection.rs`).

## Test plan
- [x] `cargo test -p agnix-core` - all pass (incl. rules.json↔VALIDATION-RULES parity, api_contract exhaustiveness, CLAUDE/AGENTS byte-parity)
- [x] 7 unit tests: parse error, known-keys-clean, `feature_requirements` alias accepted, unknown scalar flagged, renamed `[network]` table flagged with correct line, disabled-when-codex-off
- [x] Detection test (Unix `/etc/codex/`, Windows `OpenAI/Codex/`, `.codex/` excluded, bare file excluded)
- [x] CLI smoke test: typo'd `allowed_sandbox_mode` + `[netwrk]` flagged at correct lines; valid keys clean
- [x] `cargo clippy` clean, `cargo fmt --check` clean
- [x] Rule bookkeeping synced (`--check` clean): 425 rules, 43 validators