### PR TITLE
fix(scripts): sync-versions reads [workspace.package] version

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -122,9 +122,12 @@ the job will:
 
 1. Regenerate `website/src/data/siteData.json` and rule docs from `rules.json`
 2. Cut a Docusaurus versioned docs snapshot for the release
-3. Commit and push the changes to `main`
+3. Open a `docs/version-X.Y.Z` PR against `main` (labeled `documentation` +
+   `skip-changelog`) with the snapshot - it does **not** push to `main`
+   directly. Merge that PR to land the docs.
 
-The docs-site workflow then deploys automatically on push to main.
+The docs-site workflow then deploys automatically once the docs PR is merged
+to main.
 
 After release, verify at https://agentskills.io that:
 - New version docs are live in the version dropdown

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -10,11 +10,15 @@ set -euo pipefail
 if [ -n "${1:-}" ]; then
   VERSION="$1"
 else
-  VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+  # Read the [workspace.package] version, not the first `version = ` in the file.
+  # The root [package] (agnix-workspace-tests) is pinned at 0.0.0 and appears
+  # first, so a naive `head -1` would pick that up. Pass an explicit version arg
+  # to skip this (release.yml does: `sync-versions.sh "$TAG_VERSION"`).
+  VERSION=$(awk '/^\[workspace\.package\]/{f=1; next} /^\[/{f=0} f && /^version = /{gsub(/version = "|"/, ""); print; exit}' Cargo.toml)
 fi
 
 if [ -z "$VERSION" ]; then
-  echo "Error: Could not extract version from Cargo.toml"
+  echo "Error: Could not extract version from [workspace.package] in Cargo.toml"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- `scripts/sync-versions.sh` no-arg run synced all editor/npm manifests to `0.0.0`: it did `grep '^version = ' | head -1`, which matches the root `agnix-workspace-tests` package (pinned `0.0.0`) before `[workspace.package]`. Now reads the `[workspace.package]` version via awk. `release.yml` is unaffected - it passes the tag version explicitly.
- Fix `docs/RELEASING.md` drift: the `version-docs` job opens a `docs/version-X.Y.Z` PR (labeled `documentation` + `skip-changelog`); it does **not** push to `main` directly. Docs deploy once that PR merges.

Both surfaced during the v0.28.0 release pre-flight. Internal tooling/docs only - no user-facing change, hence `skip-changelog`.

## Test plan
- [x] `awk` extracts `0.28.0` from `[workspace.package]`
- [x] `bash scripts/sync-versions.sh` (no arg) reports `Syncing all manifests to version: 0.28.0` (was `0.0.0`)
- [x] Explicit-arg path unchanged