### PR TITLE
fix(codex): drop stale config allow-list keys after schema audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Codex config allow-list audited against the upstream schema** (closes #969). Diffed `KNOWN_TOP_LEVEL_KEYS` ∪ `KNOWN_TABLE_KEYS` against `codex-rs/core/config.schema.json` for rust-v0.129.0 through rust-v0.134.0-alpha.3. No upstream key was missing (so no false positives), but three entries appeared in **no** audited schema and are not `[features]` sub-keys, so they were dropped: `include_apply_patch_tool` (also removed from `KNOWN_FEATURE_KEYS` - it is neither a top-level scalar nor a feature toggle in any schema), `js_repl_node_path`, and `js_repl_node_module_dirs`. Keys that a real version once shipped but a newer schema dropped (`commit_attribution`, `experimental_use_freeform_apply_patch`, `windows_wsl_setup_acknowledged`, `experimental_thread_store_endpoint` - all present in rust-v0.129.0, gone by rust-v0.133.0) are deliberately **kept** for older-version tolerance; the list documents this policy inline. Net effect: `CDX-004` / `CDX-CFG-006` now flag the three stale keys as unknown (a typo-detection improvement), with no new false positives.
+- **Codex config allow-list audited against the upstream schema** (closes #969). Audited the Codex top-level allow-list against `codex-rs/core/config.schema.json` (rust-v0.129.0 through rust-v0.134.0-alpha.3); no valid upstream key was missing, so there are no new false positives.
+  - Dropped three keys that appear in no audited schema and are not `[features]` sub-keys: `include_apply_patch_tool` (also removed from the feature-key list), `js_repl_node_path`, and `js_repl_node_module_dirs`.
+  - Kept keys that an older Codex version shipped but a newer schema dropped (e.g. `commit_attribution`) for backwards compatibility; the rationale is now documented inline on the list.
+  - Net effect: `CDX-004` / `CDX-CFG-006` now flag the dropped keys as unknown, a small typo-detection improvement.
 
 ## [0.28.0] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Codex config allow-list audited against the upstream schema** (closes #969). Diffed `KNOWN_TOP_LEVEL_KEYS` ∪ `KNOWN_TABLE_KEYS` against `codex-rs/core/config.schema.json` for rust-v0.129.0 through rust-v0.134.0-alpha.3. No upstream key was missing (so no false positives), but three entries appeared in **no** audited schema and are not `[features]` sub-keys, so they were dropped: `include_apply_patch_tool` (also removed from `KNOWN_FEATURE_KEYS` - it is neither a top-level scalar nor a feature toggle in any schema), `js_repl_node_path`, and `js_repl_node_module_dirs`. Keys that a real version once shipped but a newer schema dropped (`commit_attribution`, `experimental_use_freeform_apply_patch`, `windows_wsl_setup_acknowledged`, `experimental_thread_store_endpoint` - all present in rust-v0.129.0, gone by rust-v0.133.0) are deliberately **kept** for older-version tolerance; the list documents this policy inline. Net effect: `CDX-004` / `CDX-CFG-006` now flag the three stale keys as unknown (a typo-detection improvement), with no new false positives.
+
 ## [0.28.0] - 2026-05-24
 
 ### Removed

--- a/crates/agnix-core/src/rules/codex.rs
+++ b/crates/agnix-core/src/rules/codex.rs
@@ -3697,6 +3697,20 @@ hide_full_access_warning = true
                 .filter(|d| d.rule == "CDX-004" || d.rule == "CDX-CFG-006")
                 .collect::<Vec<_>>()
         );
+
+        // #969: the dropped `include_apply_patch_tool` must now be flagged as
+        // unknown on the JSON backend too, mirroring the TOML-side check in
+        // schemas/codex.rs::test_codex_stale_js_repl_keys_flagged - the two
+        // backends stay in sync (#966), now agreeing on "unknown".
+        let stale = validate_config_at_path(
+            ".codex/config.json",
+            r#"{ "include_apply_patch_tool": true }"#,
+        );
+        assert!(
+            stale.iter().any(|d| d.rule == "CDX-CFG-006"),
+            "dropped include_apply_patch_tool should be flagged (CDX-CFG-006) on the JSON path, got: {:?}",
+            stale.iter().map(|d| d.rule.as_str()).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/codex.rs
+++ b/crates/agnix-core/src/rules/codex.rs
@@ -150,7 +150,6 @@ const KNOWN_FEATURE_KEYS: &[&str] = &[
     "experimental_use_unified_exec_tool",
     "experimental_windows_sandbox",
     "fast_mode",
-    "include_apply_patch_tool",
     "js_repl",
     "js_repl_tools_only",
     "memories",
@@ -3684,7 +3683,9 @@ hide_full_access_warning = true
         // v0.129 catch-up) because it lived only in the TOML schema list.
         // Both backends now share schemas/codex.rs::is_known_top_level_key, so
         // `debug` is accepted as JSON/YAML too.
-        let json = r#"{ "debug": {}, "include_apply_patch_tool": true }"#;
+        // (`include_apply_patch_tool` was dropped from the allow-list in #969 -
+        // never in any audited schema as a top-level key or `[features]` sub-key.)
+        let json = r#"{ "debug": {} }"#;
         let diags = validate_config_at_path(".codex/config.json", json);
         assert!(
             diags

--- a/crates/agnix-core/src/schemas/codex.rs
+++ b/crates/agnix-core/src/schemas/codex.rs
@@ -33,19 +33,26 @@ pub const AGENTS_MD_MAX_SIZE: usize = 100_000;
 /// Known valid top-level keys for .codex/config.toml
 ///
 /// Sourced from the upstream JSON schema at
-/// <https://github.com/openai/codex/blob/rust-v0.128.0/codex-rs/core/config.schema.json>
-/// (see also <https://developers.openai.com/codex/> for the prose overview).
+/// `codex-rs/core/config.schema.json`; current baseline is `rust-v0.133.0`
+/// (see `.github/tool-release-baselines.json`). Prose overview:
+/// <https://developers.openai.com/codex/>.
 ///
 /// When catching up to a new Codex release, regenerate this list by diffing
 /// `codex-rs/core/config.schema.json` against these constants.
 ///
-/// The list is intentionally a lenient superset: keys that a real upstream
-/// version once shipped but a newer schema dropped are kept for older-version
-/// tolerance (e.g. `commit_attribution`, `experimental_use_freeform_apply_patch`,
-/// `windows_wsl_setup_acknowledged`, `experimental_thread_store_endpoint` were in
-/// rust-v0.129.0, removed by rust-v0.133.0). Leniency only weakens typo
-/// detection, never false-positives. Keys that no audited schema ever contained
-/// are removed instead (see #969).
+/// The list is intentionally a lenient superset, with two classes of entries
+/// that are *not* in the current schema and are kept deliberately:
+/// 1. Older-version tolerance - keys a real version once shipped but a newer
+///    schema dropped (e.g. `commit_attribution`,
+///    `experimental_use_freeform_apply_patch`, `windows_wsl_setup_acknowledged`,
+///    `experimental_thread_store_endpoint` were in `rust-v0.129.0`, removed by
+///    `rust-v0.133.0`).
+/// 2. Legacy camelCase keys (`approvalMode`, `fullAutoErrorMode`) - never in the
+///    (snake_case) schema, accepted from early Codex configs.
+///
+/// Leniency only weakens typo detection, never false-positives. Keys that no
+/// audited schema ever contained and have no such backwards-compat reason are
+/// removed instead (see #969).
 pub const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     // Core model settings (alphabetized within block)
     "log_dir",
@@ -772,14 +779,9 @@ nested_number = 42
             "js_repl_node_path = \"/usr/bin/node\"\njs_repl_node_module_dirs = [\"/x\"]\n";
         let result = parse_codex_toml(content);
         assert!(result.parse_error.is_none());
-        let flagged: Vec<&str> = result
-            .unknown_keys
-            .iter()
-            .map(|u| u.key.as_str())
-            .collect();
+        let flagged: Vec<&str> = result.unknown_keys.iter().map(|u| u.key.as_str()).collect();
         assert!(
-            flagged.contains(&"js_repl_node_path")
-                && flagged.contains(&"js_repl_node_module_dirs"),
+            flagged.contains(&"js_repl_node_path") && flagged.contains(&"js_repl_node_module_dirs"),
             "stale js_repl_* keys should now be flagged on the TOML path, got: {flagged:?}"
         );
     }

--- a/crates/agnix-core/src/schemas/codex.rs
+++ b/crates/agnix-core/src/schemas/codex.rs
@@ -38,6 +38,14 @@ pub const AGENTS_MD_MAX_SIZE: usize = 100_000;
 ///
 /// When catching up to a new Codex release, regenerate this list by diffing
 /// `codex-rs/core/config.schema.json` against these constants.
+///
+/// The list is intentionally a lenient superset: keys that a real upstream
+/// version once shipped but a newer schema dropped are kept for older-version
+/// tolerance (e.g. `commit_attribution`, `experimental_use_freeform_apply_patch`,
+/// `windows_wsl_setup_acknowledged`, `experimental_thread_store_endpoint` were in
+/// rust-v0.129.0, removed by rust-v0.133.0). Leniency only weakens typo
+/// detection, never false-positives. Keys that no audited schema ever contained
+/// are removed instead (see #969).
 pub const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     // Core model settings (alphabetized within block)
     "log_dir",
@@ -59,7 +67,6 @@ pub const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     "compact_prompt",
     "developer_instructions",
     "experimental_compact_prompt_file",
-    "include_apply_patch_tool",
     "instructions",
     "model_instructions_file",
     // Notifications
@@ -132,11 +139,8 @@ pub const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     "apps_mcp_product_sku",
     "include_collaboration_mode_instructions",
     "model_auto_compact_token_limit_scope",
-    // Unified from the former rules/codex.rs JSON/YAML allow-list (js_repl
-    // node-resolution scalars) so the TOML and JSON/YAML backends agree.
-    "js_repl_node_module_dirs",
-    "js_repl_node_path",
-    // Legacy camelCase keys (backwards compat)
+    // Legacy camelCase keys: never in `config.schema.json` (which is snake_case)
+    // but accepted from very early Codex configs for backwards compatibility.
     "approvalMode",
     "fullAutoErrorMode",
 ];
@@ -756,24 +760,27 @@ nested_number = 42
     }
 
     #[test]
-    fn test_codex_unified_allowlist_fixes_toml_drift() {
-        // Drift fix (issue #966): before unifying the top-level allow-list, the
-        // TOML path flagged `js_repl_node_path` / `js_repl_node_module_dirs`
-        // because they lived only in the JSON/YAML list on the rules side.
-        // They are now part of KNOWN_TOP_LEVEL_KEYS, so the TOML path accepts
-        // them too.
+    fn test_codex_stale_js_repl_keys_flagged() {
+        // Audit (issue #969): `js_repl_node_path` / `js_repl_node_module_dirs`
+        // were never present in any audited Codex schema (rust-v0.129.0 through
+        // rust-v0.134.0-alpha.3) and are not `[features]` sub-keys - they were a
+        // stale agnix allow-list entry. They were dropped from
+        // KNOWN_TOP_LEVEL_KEYS, so both backends now flag them. (The TOML and
+        // JSON/YAML paths still agree, which was the #966 invariant - they just
+        // agree on "unknown" now.)
         let content =
             "js_repl_node_path = \"/usr/bin/node\"\njs_repl_node_module_dirs = [\"/x\"]\n";
         let result = parse_codex_toml(content);
         assert!(result.parse_error.is_none());
+        let flagged: Vec<&str> = result
+            .unknown_keys
+            .iter()
+            .map(|u| u.key.as_str())
+            .collect();
         assert!(
-            result.unknown_keys.is_empty(),
-            "js_repl_* keys should not be flagged on the TOML path, got: {:?}",
-            result
-                .unknown_keys
-                .iter()
-                .map(|u| u.key.as_str())
-                .collect::<Vec<_>>()
+            flagged.contains(&"js_repl_node_path")
+                && flagged.contains(&"js_repl_node_module_dirs"),
+            "stale js_repl_* keys should now be flagged on the TOML path, got: {flagged:?}"
         );
     }
 


### PR DESCRIPTION
Closes #969.

## Audit
Diffed `KNOWN_TOP_LEVEL_KEYS` ∪ `KNOWN_TABLE_KEYS` (`schemas/codex.rs`) against upstream `codex-rs/core/config.schema.json` across rust-v0.129.0, rust-v0.133.0 (baseline), and rust-v0.134.0-alpha.3.

| Result | Keys |
|---|---|
| **Upstream keys missing from our list** (would false-positive) | **none** |
| Kept - shipped in a real version, dropped upstream later (older-version tolerance) | `commit_attribution`, `experimental_use_freeform_apply_patch`, `windows_wsl_setup_acknowledged`, `experimental_thread_store_endpoint` (all in 0.129, gone by 0.133) |
| Kept - legacy camelCase, never in (snake_case) schema | `approvalMode`, `fullAutoErrorMode` |
| **Dropped - in no audited schema, not a `[features]` sub-key** | `include_apply_patch_tool`, `js_repl_node_path`, `js_repl_node_module_dirs` |

## Changes
- Removed the 3 stale keys from `KNOWN_TOP_LEVEL_KEYS`.
- Removed `include_apply_patch_tool` from `KNOWN_FEATURE_KEYS` too (resolves the #969 dual-location question: it is neither a top-level scalar nor a `[features]` toggle in any schema - the real neighbours are `apply_patch_freeform` / `apply_patch_streaming_events`).
- Documented the lenient-superset / version-tolerance policy inline on `KNOWN_TOP_LEVEL_KEYS`.
- Repointed the two #966 drift regression tests (TOML one now asserts the dropped `js_repl_*` keys are flagged; JSON one keeps the `debug` unification check).

Net effect: `CDX-004` / `CDX-CFG-006` now flag the 3 stale keys as unknown (a typo-detection improvement) with **no new false positives**, since none of them is a valid key in any audited Codex version.

## Test plan
- [x] `cargo test -p agnix-core` -> 3749+ pass, 0 fail
- [x] `cargo clippy -p agnix-core --all-targets -- -D warnings` clean
- [x] Renamed `test_codex_stale_js_repl_keys_flagged` + edited `test_codex_unified_allowlist_fixes_json_toml_drift` pass