### PR TITLE
fix(hooks): recognize Claude Code MessageDisplay event; triage tool releases

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-05-24",
+  "last_updated": "2026-05-30",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.142",
+      "last_known_version": "v2.1.152",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -60,7 +60,7 @@
         "agents_md"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.133.0",
+      "last_known_version": "rust-v0.134.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.15.10",
+      "last_known_version": "v1.15.11",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -203,7 +203,7 @@
         "cline"
       ],
       "github_repo": "cline/cline",
-      "last_known_version": "cli-v3.0.3",
+      "last_known_version": "cli-v3.0.13",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -237,7 +237,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.5.33",
+      "last_known_version": "3.5.38",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`CC-HK-001` no longer flags the `MessageDisplay` hook event** (closes #989). Claude Code v2.1.152 added a `MessageDisplay` hook event (lets hooks transform or hide assistant message text as it is displayed). It was missing from `HooksSchema::VALID_EVENTS`, so a valid `MessageDisplay` hook in `settings.json` tripped `CC-HK-001` "Invalid hook event". Added to the valid-event set; left out of `MATCHER_EVENTS`/`PROMPT_EVENTS` since it is a command-type display hook (so matcher and prompt/agent misuse still flag). Regression-tested in `test_cc_hk_001_message_display_event_valid`.
+
+### Changed
+- **Tool baselines**: triaged the auto-opened release-watch issues and bumped `claude-code` `v2.1.142` -> `v2.1.152` (closes #989), `codex` `rust-v0.133.0` -> `rust-v0.134.0` (closes #990), `opencode` `v1.15.10` -> `v1.15.11` (closes #992), `cline` `cli-v3.0.3` -> `cli-v3.0.13` (closes #988), and `cursor` `3.5.33` -> `3.5.38` (closes #991). Aside from the Claude Code `MessageDisplay` fix above, the changes were agnix-irrelevant: Codex `mcp` `oauth`/`env_vars` keys and `profile` config are already covered; OpenCode `headerTimeout`/`modalities` sit under `provider.*` (not the OC-004 top-level allow-list); Cline was TUI-only; Cursor exposes only a version marker. No further validator, rule, `ToolVersions`, or `SpecRevisions` change required. `.github/tool-release-baselines.json` and `knowledge-base/RESEARCH-TRACKING.md` updated.
+
 ## [0.28.1] - 2026-05-24
 
 ### Changed

--- a/crates/agnix-core/src/rules/hooks/tests.rs
+++ b/crates/agnix-core/src/rules/hooks/tests.rs
@@ -832,6 +832,35 @@ fn test_cc_hk_001_valid_event_name() {
 }
 
 #[test]
+fn test_cc_hk_001_message_display_event_valid() {
+    // MessageDisplay hook event added in Claude Code v2.1.152: lets hooks
+    // transform or hide assistant message text as it is displayed.
+    let content = r#"{
+            "hooks": {
+                "MessageDisplay": [
+                    {
+                        "hooks": [
+                            { "type": "command", "command": "echo 'test'" }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+
+    let diagnostics = validate(content);
+    let cc_hk_001: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-HK-001")
+        .collect();
+
+    assert_eq!(
+        cc_hk_001.len(),
+        0,
+        "MessageDisplay is a valid Claude Code hook event and must not flag CC-HK-001"
+    );
+}
+
+#[test]
 fn test_cc_hk_001_multiple_invalid_events() {
     let content = r#"{
             "hooks": {

--- a/crates/agnix-core/src/schemas/hooks.rs
+++ b/crates/agnix-core/src/schemas/hooks.rs
@@ -193,6 +193,7 @@ impl HooksSchema {
         "PostToolUse",
         "PostToolUseFailure",
         "Notification",
+        "MessageDisplay",
         "UserPromptSubmit",
         "Stop",
         "SubagentStart",

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -16,9 +16,9 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-15 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
-| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-24 | AGM, XP |
-| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-24 | AGM, XP, OC |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-30 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
+| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-30 | AGM, XP |
+| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-05-30 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-05-14 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 
 ### A Tier (test on major changes)
@@ -26,8 +26,8 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-04-22 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-05-15 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-05-24 | CUR |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-05-30 | CLN, CL-SK |
+| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-05-30 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 


### PR DESCRIPTION
## Summary

Addresses the five open tool-release tracker issues (#988–#992) opened by `tool-release-watch.yml`. Triaged each release against agnix's validated config surfaces; one introduced a real false positive, the rest were agnix-irrelevant.

### Fixed (user-facing)
- **`CC-HK-001` no longer flags the `MessageDisplay` hook event** (closes #989). Claude Code v2.1.152 added a `MessageDisplay` hook event (transform/hide assistant message text as displayed). It was missing from `HooksSchema::VALID_EVENTS`, so a valid `MessageDisplay` hook in `settings.json` tripped `CC-HK-001` "Invalid hook event". Added to the valid-event set; deliberately **not** added to `MATCHER_EVENTS`/`PROMPT_EVENTS` since it is a command-type display hook (matcher and prompt/agent misuse still correctly flag). Regression test: `test_cc_hk_001_message_display_event_valid`.

### Changed (baselines)
Bumped `.github/tool-release-baselines.json` and refreshed `RESEARCH-TRACKING.md` "Last Reviewed":

| Tool | Was | Now | Validator impact |
|------|-----|-----|------------------|
| claude-code | v2.1.142 | v2.1.152 | `MessageDisplay` fix above |
| codex | rust-v0.133.0 | rust-v0.134.0 | none — `mcp` `oauth`/`env_vars` + `profile` already covered |
| opencode | v1.15.10 | v1.15.11 | none — `headerTimeout`/`modalities` sit under `provider.*`, not the OC-004 top-level allow-list |
| cline | cli-v3.0.3 | cli-v3.0.13 | none — TUI-only (loading dialog, `/clear` speedup) |
| cursor | 3.5.33 | 3.5.38 | none — source exposes a version marker only |

### Triage notes (why the other four are irrelevant)
- **Codex**: new MCP per-server env + OAuth options map to `env_vars`/`oauth` keys already in the codex MCP allow-list; legacy profile-v1 removal does not change the validated `profile` string check.
- **OpenCode**: `headerTimeout` is `provider.*.options.headerTimeout` and `modalities` is `provider.*.models.*.modalities` (verified against opencode.ai/config.json) — agnix only checks top-level keys (OC-004) and `provider.options.apiKey` (OC-CFG-005), so neither false-positives.
- Skill/slash-command `disallowed-tools` (also new in Claude Code v2.1.152) needs no change: Claude Code skills already accept all extension fields, and agnix does not validate slash-command frontmatter.

## Test plan
- [x] `cargo test -p agnix-core --lib hooks` (303 passed)
- [x] New `test_cc_hk_001_message_display_event_valid` passes
- [x] `cargo test -p agnix-cli --test research_docs` (6 passed)
- [x] `.github/tool-release-baselines.json` parses as valid JSON