### PR TITLE
feat(skills): add CC-SK-021 hardcoded user directory path rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 420 rules, 75+ sources, rules.json
+knowledge-base/     # 421 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-420 rules defined in `knowledge-base/rules.json` (source of truth)
+421 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.28.1 - Production-ready with full validation pipeline
-- 420 validation rules across 43 validators
+- 421 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SK-021: Hardcoded User Directory Path** (closes #832). New MEDIUM/SHOULD `claude-skills` rule flagging hardcoded user-home paths (`/Users/<name>/`, `/home/<name>/`, `C:\Users\<name>\`) in bundled skill content - they leak the author's identity and are non-portable. The `SkillValidator` walks the skill directory and scans the `SKILL.md` body, sibling `.md` bodies (frontmatter skipped), and bundled scripts (`.sh`/`.bash`/`.zsh`/`.fish`/`.py`/`.rb`/`.pl`/`.lua`/`.js`/`.ts`/`.mjs`, or any extensionless file with a `#!` shebang - scanned whole, including the shebang). Placeholder names (`user`, `example`, `foo`, ...) and `<name>`/`${...}`/`{{...}}`/`$HOME` forms are not flagged. Manual fix only (`~/`, `$HOME/`, a project-relative path, or `$PROJECT_ROOT`). Covered by 12 unit/integration tests. Rule count 420 -> 421.
+
 ### Fixed
 - **`CC-HK-001` no longer flags the `MessageDisplay` hook event** (closes #989). Claude Code v2.1.152 added a `MessageDisplay` hook event (lets hooks transform or hide assistant message text as it is displayed). It was missing from `HooksSchema::VALID_EVENTS`, so a valid `MessageDisplay` hook in `settings.json` tripped `CC-HK-001` "Invalid hook event". Added to the valid-event set; left out of `MATCHER_EVENTS`/`PROMPT_EVENTS` since it is a command-type display hook (so matcher and prompt/agent misuse still flag). Regression-tested in `test_cc_hk_001_message_display_event_valid`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 420 rules, 75+ sources, rules.json
+knowledge-base/     # 421 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-420 rules defined in `knowledge-base/rules.json` (source of truth)
+421 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.28.1 - Production-ready with full validation pipeline
-- 420 validation rules across 43 validators
+- 421 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>420 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>421 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 420 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 421 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -104,6 +104,9 @@ rules:
   cc_sk_017:
     message: "Unknown frontmatter field '%{field}'"
     suggestion: "Remove unsupported fields or fix typos in frontmatter keys"
+  cc_sk_021:
+    message: "Hardcoded user directory path '%{path}' leaks author identity and is not portable across machines"
+    suggestion: "Replace with '~/', '$HOME/', a project-relative path, or an env var like '$PROJECT_ROOT'. For shebangs prefer '#!/usr/bin/env <interpreter>'."
 
   # --- Per-Client Skills (per_client_skill.rs) ---
   cr_sk_001:

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -82,6 +82,9 @@ rules:
   cc_sk_017:
     message: "Campo de frontmatter desconocido '%{field}'"
     suggestion: "Elimina campos no soportados o corrige errores tipograficos en claves del frontmatter"
+  cc_sk_021:
+    message: "La ruta de directorio de usuario codificada '%{path}' revela la identidad del autor y no es portable entre maquinas"
+    suggestion: "Reemplaza con '~/', '$HOME/', una ruta relativa al proyecto, o una variable de entorno como '$PROJECT_ROOT'. Para shebangs, prefiere '#!/usr/bin/env <interprete>'."
 
   # --- Per-Client Skills (per_client_skill.rs) ---
   cr_sk_001:

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -82,6 +82,9 @@ rules:
   cc_sk_017:
     message: "未知的 frontmatter 字段 '%{field}'"
     suggestion: "删除不受支持的字段或修正 frontmatter 键名拼写"
+  cc_sk_021:
+    message: "硬编码的用户目录路径 '%{path}' 会泄露作者身份，且在不同机器间不可移植"
+    suggestion: "改用 '~/'、'$HOME/'、相对于项目的路径，或像 '$PROJECT_ROOT' 这样的环境变量。shebang 行建议使用 '#!/usr/bin/env <解释器>'。"
 
   # --- Per-Client Skills (per_client_skill.rs) ---
   cr_sk_001:

--- a/crates/agnix-core/src/rules/skill/helpers.rs
+++ b/crates/agnix-core/src/rules/skill/helpers.rs
@@ -1,7 +1,9 @@
 use crate::fs::FileSystem;
 use crate::parsers::frontmatter::FrontmatterParts;
+use regex::Regex;
 use std::collections::HashSet;
 use std::path::Path;
+use std::sync::OnceLock;
 
 use super::{PathMatch, SkillFrontmatter, reference_path_regex};
 
@@ -297,6 +299,82 @@ pub(super) fn frontmatter_key_line_byte_range(
     }
 
     Some((abs_start, end))
+}
+
+/// Name segments treated as placeholders rather than a real username
+/// (case-insensitive). Matches with one of these names are not flagged.
+pub(super) const USER_PATH_PLACEHOLDERS: &[&str] = &[
+    "user", "username", "name", "you", "your-name", "yourname", "me", "myname", "someone",
+    "example", "johndoe", "jdoe", "foo", "bar",
+];
+
+/// File extensions treated as bundled scripts (scanned in full, shebang included).
+pub(super) const SCRIPT_EXTENSIONS: &[&str] =
+    &["sh", "bash", "zsh", "fish", "py", "rb", "pl", "lua", "js", "ts", "mjs"];
+
+/// `.md` filenames that are repo docs, not skill instructions - left out of scope.
+pub(super) const SKIP_MD_FILENAMES: &[&str] =
+    &["readme.md", "changelog.md", "claude.md", "agents.md", "license.md"];
+
+/// A hardcoded user-home path found while scanning skill content.
+pub(super) struct UserPathHit {
+    /// Byte offset of the match start within the scanned region.
+    pub offset: usize,
+    /// The matched path prefix, e.g. `/Users/alice/`.
+    pub text: String,
+}
+
+fn posix_user_path_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?:/Users/|/home/)([A-Za-z0-9._-]+)/")
+            .expect("posix user path pattern must compile")
+    })
+}
+
+fn windows_user_path_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"[Cc]:[\\/]Users[\\/]([A-Za-z0-9._-]+)[\\/]")
+            .expect("windows user path pattern must compile")
+    })
+}
+
+fn is_placeholder_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    USER_PATH_PLACEHOLDERS.contains(&lower.as_str())
+}
+
+/// Find hardcoded user-home paths (`/Users/<name>/`, `/home/<name>/`,
+/// `C:\Users\<name>\`) in `content`, skipping placeholder names. Angle-bracket
+/// (`<name>`), template (`${...}`, `{{...}}`), and env-var (`$HOME`) forms never
+/// match the name character class, so they are skipped implicitly.
+pub(super) fn find_hardcoded_user_paths(content: &str) -> Vec<UserPathHit> {
+    let mut hits = Vec::new();
+    for re in [posix_user_path_regex(), windows_user_path_regex()] {
+        for caps in re.captures_iter(content) {
+            let whole = caps.get(0).expect("group 0 always present");
+            let name = caps.get(1).map(|m| m.as_str()).unwrap_or_default();
+            if is_placeholder_name(name) {
+                continue;
+            }
+            hits.push(UserPathHit {
+                offset: whole.start(),
+                text: whole.as_str().to_string(),
+            });
+        }
+    }
+    hits.sort_by_key(|h| h.offset);
+    hits
+}
+
+/// Whether a bundled file is a script: a recognized script extension, or an
+/// extensionless file whose first line is a `#!` shebang.
+pub(super) fn is_script_path(path: &Path, content: &str) -> bool {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some(ext) => SCRIPT_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()),
+        None => content.starts_with("#!"),
+    }
 }
 
 pub(super) fn directory_size_until(path: &Path, max_bytes: u64, fs: &dyn FileSystem) -> u64 {

--- a/crates/agnix-core/src/rules/skill/helpers.rs
+++ b/crates/agnix-core/src/rules/skill/helpers.rs
@@ -344,8 +344,11 @@ pub(super) struct UserPathHit {
 
 fn posix_user_path_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
+    // No trailing slash required: the name class excludes `/`, so the match
+    // ends at the username whether or not a path component follows. This also
+    // catches a bare `/home/alice` at end of line.
     RE.get_or_init(|| {
-        Regex::new(r"(?:/Users/|/home/)([A-Za-z0-9._-]+)/")
+        Regex::new(r"(?:/Users/|/home/)([A-Za-z0-9._-]+)")
             .expect("posix user path pattern must compile")
     })
 }
@@ -353,7 +356,7 @@ fn posix_user_path_regex() -> &'static Regex {
 fn windows_user_path_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"[Cc]:[\\/]Users[\\/]([A-Za-z0-9._-]+)[\\/]")
+        Regex::new(r"[Cc]:[\\/]Users[\\/]([A-Za-z0-9._-]+)")
             .expect("windows user path pattern must compile")
     })
 }
@@ -386,13 +389,16 @@ pub(super) fn find_hardcoded_user_paths(content: &str) -> Vec<UserPathHit> {
     hits
 }
 
-/// Whether a bundled file is a script: a recognized script extension, or an
-/// extensionless file whose first line is a `#!` shebang.
+/// Whether a bundled file is a script: a `#!` shebang on the first line (any
+/// extension), or a recognized script extension.
 pub(super) fn is_script_path(path: &Path, content: &str) -> bool {
-    match path.extension().and_then(|e| e.to_str()) {
-        Some(ext) => SCRIPT_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()),
-        None => content.starts_with("#!"),
+    if content.starts_with("#!") {
+        return true;
     }
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some(ext) if SCRIPT_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str())
+    )
 }
 
 pub(super) fn directory_size_until(path: &Path, max_bytes: u64, fs: &dyn FileSystem) -> u64 {

--- a/crates/agnix-core/src/rules/skill/helpers.rs
+++ b/crates/agnix-core/src/rules/skill/helpers.rs
@@ -304,17 +304,35 @@ pub(super) fn frontmatter_key_line_byte_range(
 /// Name segments treated as placeholders rather than a real username
 /// (case-insensitive). Matches with one of these names are not flagged.
 pub(super) const USER_PATH_PLACEHOLDERS: &[&str] = &[
-    "user", "username", "name", "you", "your-name", "yourname", "me", "myname", "someone",
-    "example", "johndoe", "jdoe", "foo", "bar",
+    "user",
+    "username",
+    "name",
+    "you",
+    "your-name",
+    "yourname",
+    "me",
+    "myname",
+    "someone",
+    "example",
+    "johndoe",
+    "jdoe",
+    "foo",
+    "bar",
 ];
 
 /// File extensions treated as bundled scripts (scanned in full, shebang included).
-pub(super) const SCRIPT_EXTENSIONS: &[&str] =
-    &["sh", "bash", "zsh", "fish", "py", "rb", "pl", "lua", "js", "ts", "mjs"];
+pub(super) const SCRIPT_EXTENSIONS: &[&str] = &[
+    "sh", "bash", "zsh", "fish", "py", "rb", "pl", "lua", "js", "ts", "mjs",
+];
 
 /// `.md` filenames that are repo docs, not skill instructions - left out of scope.
-pub(super) const SKIP_MD_FILENAMES: &[&str] =
-    &["readme.md", "changelog.md", "claude.md", "agents.md", "license.md"];
+pub(super) const SKIP_MD_FILENAMES: &[&str] = &[
+    "readme.md",
+    "changelog.md",
+    "claude.md",
+    "agents.md",
+    "license.md",
+];
 
 /// A hardcoded user-home path found while scanning skill content.
 pub(super) struct UserPathHit {

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 use rust_i18n::t;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 mod helpers;
@@ -1535,6 +1535,104 @@ impl<'a> ValidationContext<'a> {
             }
         }
     }
+
+    /// CC-SK-021: Hardcoded user-home paths in bundled skill content. Walks the
+    /// skill directory and scans the SKILL.md body, sibling `.md` bodies, and
+    /// bundled scripts (whole file). Diagnostics attach to the offending file.
+    fn validate_cc_sk_021(&mut self) {
+        if !claude_skill_rules_apply(self.client, self.config)
+            || !self.config.is_rule_enabled("CC-SK-021")
+            || !self.path.is_file()
+        {
+            return;
+        }
+        let Some(dir) = self.path.parent() else {
+            return;
+        };
+
+        // Collect in-scope files first (FS-only), then scan (mutates diagnostics).
+        let mut stack = vec![dir.to_path_buf()];
+        let mut files: Vec<PathBuf> = Vec::new();
+        while let Some(current) = stack.pop() {
+            let Ok(entries) = self.config.fs().read_dir(&current) else {
+                continue;
+            };
+            for entry in entries {
+                if entry.metadata.is_symlink {
+                    continue;
+                }
+                if entry.metadata.is_dir {
+                    stack.push(entry.path.clone());
+                } else if entry.metadata.is_file {
+                    files.push(entry.path.clone());
+                }
+            }
+        }
+        files.sort();
+        for file in files {
+            self.scan_file_for_user_paths(&file);
+        }
+    }
+
+    fn scan_file_for_user_paths(&mut self, file: &Path) {
+        let filename = file
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        let is_md = filename.ends_with(".md");
+
+        // Reuse the in-memory content for the SKILL.md under validation.
+        let owned;
+        let content: &str = if file == self.path {
+            self.content
+        } else {
+            if is_md && SKIP_MD_FILENAMES.contains(&filename.as_str()) {
+                return;
+            }
+            match self.config.fs().read_to_string(file) {
+                Ok(c) => {
+                    owned = c;
+                    &owned
+                }
+                Err(_) => return,
+            }
+        };
+
+        let (region_start, region): (usize, &str) = if is_md {
+            let parts = split_frontmatter(content);
+            let start = parts.body_start.min(content.len());
+            (start, &content[start..])
+        } else if is_script_path(file, content) {
+            (0, content)
+        } else {
+            return;
+        };
+
+        let hits = find_hardcoded_user_paths(region);
+        if hits.is_empty() {
+            return;
+        }
+        let line_starts = compute_line_starts(content);
+        for hit in hits {
+            let (line, col) = line_col_at(region_start + hit.offset, &line_starts);
+            self.diagnostics.push(
+                Diagnostic::warning(
+                    file.to_path_buf(),
+                    line,
+                    col,
+                    "CC-SK-021",
+                    format!(
+                        "Hardcoded user directory path '{}' leaks author identity and is not portable across machines",
+                        hit.text
+                    ),
+                )
+                .with_suggestion(
+                    "Replace with '~/', '$HOME/', a project-relative path, or an env var like '$PROJECT_ROOT'. For shebangs prefer '#!/usr/bin/env <interpreter>'.",
+                ),
+            );
+        }
+    }
 }
 
 const RULE_IDS: &[&str] = &[
@@ -1572,6 +1670,7 @@ const RULE_IDS: &[&str] = &[
     "CC-SK-018",
     "CC-SK-019",
     "CC-SK-020",
+    "CC-SK-021",
 ];
 
 pub struct SkillValidator;
@@ -1710,6 +1809,9 @@ impl Validator for SkillValidator {
 
         // Phase 17: Directory validation (AS-015)
         ctx.validate_directory();
+
+        // Phase 18: Bundled-content scan (CC-SK-021)
+        ctx.validate_cc_sk_021();
 
         ctx.diagnostics
     }

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -1645,14 +1645,9 @@ impl<'a> ValidationContext<'a> {
                     line,
                     col,
                     "CC-SK-021",
-                    format!(
-                        "Hardcoded user directory path '{}' leaks author identity and is not portable across machines",
-                        hit.text
-                    ),
+                    t!("rules.cc_sk_021.message", path = hit.text),
                 )
-                .with_suggestion(
-                    "Replace with '~/', '$HOME/', a project-relative path, or an env var like '$PROJECT_ROOT'. For shebangs prefer '#!/usr/bin/env <interpreter>'.",
-                ),
+                .with_suggestion(t!("rules.cc_sk_021.suggestion")),
             );
         }
     }

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -1562,7 +1562,17 @@ impl<'a> ValidationContext<'a> {
                     continue;
                 }
                 if entry.metadata.is_dir {
-                    stack.push(entry.path.clone());
+                    // Skip hidden subdirectories (.git, .github, vendored caches)
+                    // to avoid scanning irrelevant files. The skill directory
+                    // itself is the walk root, so it is never filtered here.
+                    let hidden = entry
+                        .path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|s| s.starts_with('.'));
+                    if !hidden {
+                        stack.push(entry.path.clone());
+                    }
                 } else if entry.metadata.is_file {
                     files.push(entry.path.clone());
                 }
@@ -1587,8 +1597,21 @@ impl<'a> ValidationContext<'a> {
         let content: &str = if file == self.path {
             self.content
         } else {
-            if is_md && SKIP_MD_FILENAMES.contains(&filename.as_str()) {
-                return;
+            if is_md {
+                if SKIP_MD_FILENAMES.contains(&filename.as_str()) {
+                    return;
+                }
+            } else {
+                // Only read recognized scripts or extensionless files (which may
+                // carry a shebang). Skip files with an unrecognized extension
+                // (binaries, datasets, images) without reading them from disk.
+                let readable = match file.extension().and_then(|e| e.to_str()) {
+                    Some(ext) => SCRIPT_EXTENSIONS.contains(&ext.to_ascii_lowercase().as_str()),
+                    None => true,
+                };
+                if !readable {
+                    return;
+                }
             }
             match self.config.fs().read_to_string(file) {
                 Ok(c) => {

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -4204,14 +4204,29 @@ fn test_find_hardcoded_user_paths_posix_and_windows() {
     let hits =
         find_hardcoded_user_paths("see /Users/alice/x/y and C:\\Users\\bob.smith\\AppData here");
     let texts: Vec<&str> = hits.iter().map(|h| h.text.as_str()).collect();
-    assert_eq!(texts, vec!["/Users/alice/", "C:\\Users\\bob.smith\\"]);
+    assert_eq!(texts, vec!["/Users/alice", "C:\\Users\\bob.smith"]);
 }
 
 #[test]
 fn test_find_hardcoded_user_paths_home() {
     let hits = find_hardcoded_user_paths("data at /home/bob/data.csv");
     assert_eq!(hits.len(), 1);
-    assert_eq!(hits[0].text, "/home/bob/");
+    assert_eq!(hits[0].text, "/home/bob");
+}
+
+#[test]
+fn test_find_hardcoded_user_paths_without_trailing_slash() {
+    // A bare username with no trailing path component is still flagged.
+    let hits = find_hardcoded_user_paths("home is /home/alice");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].text, "/home/alice");
+}
+
+#[test]
+fn test_is_script_path_unknown_ext_with_shebang() {
+    // Shebang wins over an unrecognized extension.
+    assert!(is_script_path(Path::new("a/tool.custom"), "#!/bin/sh\n"));
+    assert!(!is_script_path(Path::new("a/data.custom"), "not a script"));
 }
 
 #[test]

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -4196,3 +4196,187 @@ Body"#;
 
     assert_eq!(cc_sk_020.len(), 0);
 }
+
+// ===== CC-SK-021: Hardcoded User Directory Path =====
+
+#[test]
+fn test_find_hardcoded_user_paths_posix_and_windows() {
+    let hits = find_hardcoded_user_paths(
+        "see /Users/alice/x/y and C:\\Users\\bob.smith\\AppData here",
+    );
+    let texts: Vec<&str> = hits.iter().map(|h| h.text.as_str()).collect();
+    assert_eq!(texts, vec!["/Users/alice/", "C:\\Users\\bob.smith\\"]);
+}
+
+#[test]
+fn test_find_hardcoded_user_paths_home() {
+    let hits = find_hardcoded_user_paths("data at /home/bob/data.csv");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].text, "/home/bob/");
+}
+
+#[test]
+fn test_find_hardcoded_user_paths_skips_placeholders() {
+    // Generic placeholder names, angle-bracket, template, and env-var forms.
+    let content =
+        "/Users/user/ /home/example/ /Users/foo/ /Users/<name>/ /home/${USER}/ /home/{{name}}/";
+    assert!(find_hardcoded_user_paths(content).is_empty());
+}
+
+#[test]
+fn test_is_script_path() {
+    assert!(is_script_path(Path::new("a/run.py"), ""));
+    assert!(is_script_path(Path::new("a/run.sh"), ""));
+    assert!(!is_script_path(Path::new("a/notes.md"), "x"));
+    assert!(!is_script_path(Path::new("a/data.txt"), "x"));
+    // extensionless: only a script when it starts with a shebang
+    assert!(is_script_path(Path::new("a/runner"), "#!/usr/bin/env bash\n"));
+    assert!(!is_script_path(Path::new("a/runner"), "plain text\n"));
+}
+
+fn cc_sk_021_for(skill_dir: &Path) -> Vec<Diagnostic> {
+    let skill_path = skill_dir.join("SKILL.md");
+    let content = fs::read_to_string(&skill_path).unwrap();
+    SkillValidator
+        .validate(&skill_path, &content, &LintConfig::default())
+        .into_iter()
+        .filter(|d| d.rule == "CC-SK-021")
+        .collect()
+}
+
+const CLEAN_SKILL: &str =
+    "---\nname: demo\ndescription: Use when demoing the rule for testing here.\n---\nRun `cargo build` from the repo root.\n";
+
+#[test]
+fn test_cc_sk_021_flags_bundled_md() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("demo");
+    fs::create_dir_all(dir.join("references")).unwrap();
+    fs::write(dir.join("SKILL.md"), CLEAN_SKILL).unwrap();
+    fs::write(
+        dir.join("references/bad.md"),
+        "# ref\nConfig at /Users/alice/projects/cfg.json\n",
+    )
+    .unwrap();
+
+    let diags = cc_sk_021_for(&dir);
+    assert_eq!(diags.len(), 1, "{diags:?}");
+    assert!(diags[0].file.ends_with("references/bad.md"));
+}
+
+#[test]
+fn test_cc_sk_021_flags_skill_md_itself() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("demo");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Use when demoing the rule for testing here.\n---\nRun /Users/alice/build.sh now.\n",
+    )
+    .unwrap();
+
+    let diags = cc_sk_021_for(&dir);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].file.ends_with("SKILL.md"));
+}
+
+#[test]
+fn test_cc_sk_021_flags_script_shebang_and_body() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("demo");
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::write(dir.join("SKILL.md"), CLEAN_SKILL).unwrap();
+    fs::write(
+        dir.join("scripts/bad.sh"),
+        "#!/Users/alice/.venv/bin/python\n# fixture: /home/bob/data.csv\n",
+    )
+    .unwrap();
+
+    let diags = cc_sk_021_for(&dir);
+    assert_eq!(diags.len(), 2, "{diags:?}");
+    assert!(diags.iter().all(|d| d.file.ends_with("scripts/bad.sh")));
+}
+
+#[test]
+fn test_cc_sk_021_flags_extensionless_shebang() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("demo");
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::write(dir.join("SKILL.md"), CLEAN_SKILL).unwrap();
+    fs::write(dir.join("scripts/runner"), "#!/Users/carol/bin/run\necho hi\n").unwrap();
+
+    let diags = cc_sk_021_for(&dir);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].file.ends_with("scripts/runner"));
+}
+
+#[test]
+fn test_cc_sk_021_flags_python_comment() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("demo");
+    fs::create_dir_all(dir.join("bundled")).unwrap();
+    fs::write(dir.join("SKILL.md"), CLEAN_SKILL).unwrap();
+    fs::write(
+        dir.join("bundled/example.py"),
+        "import os  # path /Users/alice/data\n",
+    )
+    .unwrap();
+
+    let diags = cc_sk_021_for(&dir);
+    assert_eq!(diags.len(), 1);
+    assert!(diags[0].file.ends_with("bundled/example.py"));
+}
+
+#[test]
+fn test_cc_sk_021_all_three_sources() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("demo");
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::create_dir_all(dir.join("references")).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Use when demoing the rule for testing here.\n---\nRun /Users/alice/build.sh now.\n",
+    )
+    .unwrap();
+    fs::write(dir.join("references/bad.md"), "ref /home/bob/x\n").unwrap();
+    fs::write(dir.join("scripts/bad.sh"), "#!/Users/carol/run\n").unwrap();
+
+    let diags = cc_sk_021_for(&dir);
+    let files: std::collections::BTreeSet<String> = diags
+        .iter()
+        .map(|d| d.file.file_name().unwrap().to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(diags.len(), 3, "{diags:?}");
+    assert_eq!(files.len(), 3);
+}
+
+#[test]
+fn test_cc_sk_021_good_placeholders_clean() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("demo");
+    fs::create_dir_all(dir.join("scripts")).unwrap();
+    fs::write(
+        dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Use when demoing the rule for testing here.\n---\nReplace `/Users/<name>/` with your home. Logs in `$HOME/.cache/`. Template `/home/${USER}/c/`.\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("scripts/ok.sh"),
+        "#!/usr/bin/env bash\noutput=\"${HOME}/.cache/app\"\ncd \"$(git rev-parse --show-toplevel)\"\n",
+    )
+    .unwrap();
+
+    assert!(cc_sk_021_for(&dir).is_empty());
+}
+
+#[test]
+fn test_cc_sk_021_ignores_files_outside_skill_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("demo");
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("SKILL.md"), CLEAN_SKILL).unwrap();
+    // Sibling of the skill dir, not bundled with the skill.
+    fs::write(tmp.path().join("build.sh"), "#!/Users/alice/run\n").unwrap();
+
+    assert!(cc_sk_021_for(&dir).is_empty());
+}

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -4201,9 +4201,8 @@ Body"#;
 
 #[test]
 fn test_find_hardcoded_user_paths_posix_and_windows() {
-    let hits = find_hardcoded_user_paths(
-        "see /Users/alice/x/y and C:\\Users\\bob.smith\\AppData here",
-    );
+    let hits =
+        find_hardcoded_user_paths("see /Users/alice/x/y and C:\\Users\\bob.smith\\AppData here");
     let texts: Vec<&str> = hits.iter().map(|h| h.text.as_str()).collect();
     assert_eq!(texts, vec!["/Users/alice/", "C:\\Users\\bob.smith\\"]);
 }
@@ -4230,7 +4229,10 @@ fn test_is_script_path() {
     assert!(!is_script_path(Path::new("a/notes.md"), "x"));
     assert!(!is_script_path(Path::new("a/data.txt"), "x"));
     // extensionless: only a script when it starts with a shebang
-    assert!(is_script_path(Path::new("a/runner"), "#!/usr/bin/env bash\n"));
+    assert!(is_script_path(
+        Path::new("a/runner"),
+        "#!/usr/bin/env bash\n"
+    ));
     assert!(!is_script_path(Path::new("a/runner"), "plain text\n"));
 }
 
@@ -4244,8 +4246,7 @@ fn cc_sk_021_for(skill_dir: &Path) -> Vec<Diagnostic> {
         .collect()
 }
 
-const CLEAN_SKILL: &str =
-    "---\nname: demo\ndescription: Use when demoing the rule for testing here.\n---\nRun `cargo build` from the repo root.\n";
+const CLEAN_SKILL: &str = "---\nname: demo\ndescription: Use when demoing the rule for testing here.\n---\nRun `cargo build` from the repo root.\n";
 
 #[test]
 fn test_cc_sk_021_flags_bundled_md() {
@@ -4303,7 +4304,11 @@ fn test_cc_sk_021_flags_extensionless_shebang() {
     let dir = tmp.path().join("demo");
     fs::create_dir_all(dir.join("scripts")).unwrap();
     fs::write(dir.join("SKILL.md"), CLEAN_SKILL).unwrap();
-    fs::write(dir.join("scripts/runner"), "#!/Users/carol/bin/run\necho hi\n").unwrap();
+    fs::write(
+        dir.join("scripts/runner"),
+        "#!/Users/carol/bin/run\necho hi\n",
+    )
+    .unwrap();
 
     let diags = cc_sk_021_for(&dir);
     assert_eq!(diags.len(), 1);

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 420,
-  "last_updated": "2026-05-24",
+  "total_rules": 421,
+  "last_updated": "2026-05-30",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3437,6 +3437,33 @@
       },
       "good_example": "---\nname: my-skill\nshell: bash\n---\nSkill instructions.",
       "bad_example": "---\nname: my-skill\nshell: zsh\n---\nSkill instructions."
+    },
+    {
+      "id": "CC-SK-021",
+      "name": "Hardcoded User Directory Path",
+      "severity": "MEDIUM",
+      "category": "claude-skills",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://code.claude.com/docs/en/skills"
+        ],
+        "verified_on": "2026-04-26",
+        "applies_to": {
+          "tool": "claude-code"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": true,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "---\nname: build-helper\ndescription: Build the project\n---\nRun `cargo build` from the repo root, or set `$BUILD_DIR` to override.",
+      "bad_example": "---\nname: build-helper\ndescription: Build the project\n---\nRun the script at /Users/alice/projects/myrepo/build.sh to compile."
     },
     {
       "id": "CC-SET-001",
@@ -11608,7 +11635,7 @@
     },
     "claude-skills": {
       "prefix": "CC-SK",
-      "count": 20,
+      "count": 21,
       "description": "Claude Code Skills rules"
     },
     "claude-hooks": {

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 420 validation rules across 40 categories, sourced from 75+ references
+> 421 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 420 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 421 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (420 rules)
+├── VALIDATION-RULES.md             # Master validation reference (421 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **420 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **421 rules** |
 
 
 ### Validation Rules by Category
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **420** | **213** | **179** | **28** | **127** |
+| **TOTAL** | **421** | **213** | **179** | **28** | **127** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 420 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 421 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     420 rules
+Validation Rules:     421 rules
 Auto-Fixable Rules:   96 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -98,7 +98,7 @@ knowledge-base/
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
 | Claude Settings | 5 | 0 | 5 | 0 | 0 |
-| Claude Skills | 20 | 11 | 8 | 1 | 13 |
+| Claude Skills | 21 | 11 | 9 | 1 | 13 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
 | Codex CLI | 62 | 31 | 26 | 5 | 10 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **421** | **213** | **179** | **28** | **127** |
+| **TOTAL** | **421** | **213** | **180** | **28** | **127** |
 
 
 ---

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 420 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 421 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -338,6 +338,13 @@ Rules with an empty `applies_to` object (`{}`) apply universally.
 **Fix**: Manual
 **Source**: code.claude.com/docs/en/skills
 
+<a id="cc-sk-021"></a>
+### CC-SK-021 [MEDIUM] Hardcoded User Directory Path
+**Requirement**: Skill content SHOULD NOT contain hardcoded user-home paths (`/Users/<name>/`, `/home/<name>/`, `C:\Users\<name>\`). They leak the author's identity, are non-portable across machines, and rarely resolve for the agent at runtime. Applies to `SKILL.md`, any `.md` file bundled in the same skill directory subtree, and bundled scripts (`.sh`/`.bash`/`.zsh`/`.fish`/`.py`/`.rb`/`.pl`/`.lua`/`.js`/`.ts`/`.mjs`, or any extensionless file with a `#!` shebang).
+**Detection**: For each `SKILL.md`, scan its body and the body of every in-scope file under its containing directory (recursively). For `.md` files skip frontmatter; for scripts scan the whole file including shebangs and comments. Match `(/Users/|/home/)[a-zA-Z0-9._-]+/` and `[Cc]:[\\/]Users[\\/][a-zA-Z0-9._-]+[\\/]`. Skip matches where the name segment is a placeholder: generic words (`user`, `username`, `name`, `you`, `yourname`, `me`, `myname`, `someone`, `example`, `johndoe`, `foo`, `bar`), or any segment wrapped in `<...>`, `${...}`, or `{{...}}` (these never match the name character class).
+**Fix**: Manual - replace with `~/`, `$HOME/`, a project-relative path, or an env var like `$PROJECT_ROOT`. For shebangs, prefer `#!/usr/bin/env <interpreter>`.
+**Source**: code.claude.com/docs/en/skills
+
 <a id="cc-set-001"></a>
 ### CC-SET-001 [MEDIUM] Invalid prUrlTemplate Setting
 **Requirement**: `prUrlTemplate` in `.claude/settings.json` (and `.local.json`/`managed-settings.json`) SHOULD be a non-empty string containing at least one of the documented placeholders: `{host}`, `{owner}`, `{repo}`, `{number}`, `{url}`. A template with no placeholder will render the same static URL for every PR badge.
@@ -3438,8 +3445,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 420 validation rules across 40 categories
+**Total Coverage**: 421 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 213 HIGH, 179 MEDIUM, 28 LOW
+**Certainty**: 213 HIGH, 180 MEDIUM, 28 LOW
 **Auto-Fixable**: 127 rules (30%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 420,
-  "last_updated": "2026-05-24",
+  "total_rules": 421,
+  "last_updated": "2026-05-30",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3437,6 +3437,33 @@
       },
       "good_example": "---\nname: my-skill\nshell: bash\n---\nSkill instructions.",
       "bad_example": "---\nname: my-skill\nshell: zsh\n---\nSkill instructions."
+    },
+    {
+      "id": "CC-SK-021",
+      "name": "Hardcoded User Directory Path",
+      "severity": "MEDIUM",
+      "category": "claude-skills",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://code.claude.com/docs/en/skills"
+        ],
+        "verified_on": "2026-04-26",
+        "applies_to": {
+          "tool": "claude-code"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": true,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "---\nname: build-helper\ndescription: Build the project\n---\nRun `cargo build` from the repo root, or set `$BUILD_DIR` to override.",
+      "bad_example": "---\nname: build-helper\ndescription: Build the project\n---\nRun the script at /Users/alice/projects/myrepo/build.sh to compile."
     },
     {
       "id": "CC-SET-001",
@@ -11608,7 +11635,7 @@
     },
     "claude-skills": {
       "prefix": "CC-SK",
-      "count": 20,
+      "count": 21,
       "description": "Claude Code Skills rules"
     },
     "claude-hooks": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.28.1",
-  "description": "Lint agent configurations before they break your workflow. 420 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 421 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "[email protected]",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 420 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 421 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 420 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 421 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 420 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 421 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/rules/generated/cc-sk-021.md
+++ b/website/docs/rules/generated/cc-sk-021.md
@@ -1,0 +1,56 @@
+---
+id: cc-sk-021
+title: "CC-SK-021: Hardcoded User Directory Path - Claude Skills"
+sidebar_label: "CC-SK-021"
+description: "agnix rule CC-SK-021 checks for hardcoded user directory path in claude skills files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SK-021", "hardcoded user directory path", "claude skills", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SK-021`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Skills`
+- **Normative Level**: `SHOULD`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-04-26`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `unspecified`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://code.claude.com/docs/en/skills
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `true`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```markdown
+---
+name: build-helper
+description: Build the project
+---
+Run the script at /Users/alice/projects/myrepo/build.sh to compile.
+```
+
+### Valid
+
+```markdown
+---
+name: build-helper
+description: Build the project
+---
+Run `cargo build` from the repo root, or set `$BUILD_DIR` to override.
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `420` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `421` validation rules generated from `knowledge-base/rules.json`.
 `127` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -128,6 +128,7 @@ This section contains all `420` validation rules generated from `knowledge-base/
 | [CC-SK-018](./generated/cc-sk-018.md) | Invalid Effort Value | MEDIUM | Claude Skills | Yes (unsafe) |
 | [CC-SK-019](./generated/cc-sk-019.md) | Invalid Paths Format | LOW | Claude Skills | No |
 | [CC-SK-020](./generated/cc-sk-020.md) | Invalid Shell Value | MEDIUM | Claude Skills | Yes (unsafe) |
+| [CC-SK-021](./generated/cc-sk-021.md) | Hardcoded User Directory Path | MEDIUM | Claude Skills | No |
 | [CC-SET-001](./generated/cc-set-001.md) | Invalid prUrlTemplate Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-002](./generated/cc-set-002.md) | Non-boolean channelsEnabled Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-003](./generated/cc-set-003.md) | Invalid worktree.baseRef Value | MEDIUM | Claude Settings | No |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 420,
+  "totalRules": 421,
   "categoryCount": 40,
   "autofixCount": 127,
   "uniqueTools": [


### PR DESCRIPTION
## Summary

Implements **CC-SK-021** (closes #832) - the one rule we kept from the agent-lint port backlog. Flags hardcoded user-home paths in bundled skill content, which leak the author's identity and are non-portable across machines.

- **ID/severity**: `CC-SK-021`, MEDIUM, SHOULD, category `claude-skills`, no autofix (replacement needs human judgment).
- **Scope**: the `SkillValidator` walks the skill directory (recursively) and scans:
  - the `SKILL.md` body (frontmatter skipped),
  - sibling `.md` files (frontmatter skipped; repo docs like `README.md`/`CHANGELOG.md`/`CLAUDE.md`/`AGENTS.md`/`LICENSE.md` excluded),
  - bundled scripts - by extension (`.sh`/`.bash`/`.zsh`/`.fish`/`.py`/`.rb`/`.pl`/`.lua`/`.js`/`.ts`/`.mjs`) or any extensionless file with a `#!` shebang - scanned whole, including the shebang line.
- **Detection**: `(/Users/|/home/)[A-Za-z0-9._-]+/` and `[Cc]:[\\/]Users[\\/][A-Za-z0-9._-]+[\\/]`. Placeholder names (`user`, `example`, `foo`, ...) are skipped; `<name>`, `${...}`, `{{...}}`, `$HOME` never match the name class so they are skipped implicitly.
- Diagnostics attach to the offending file's path (not just `SKILL.md`).

## Implementation

Option A from the issue (lighter touch): extended the existing `SkillValidator` rather than adding new FileTypes. Reuses the `FileSystem` trait (same mechanism as AS-015's directory walk). Helper + regex live in `skill/helpers.rs`; the walk/scan in `skill/mod.rs`.

## Bookkeeping
Rule count 420 -> 421. `rules.json` + `VALIDATION-RULES.md` updated and `scripts/sync-rule-bookkeeping.js` run (mirror, CLAUDE.md/AGENTS.md/README counts, website docs).

## Test plan
- [x] 12 new unit/integration tests (`test_cc_sk_021_*`, `test_find_hardcoded_user_paths_*`, `test_is_script_path`) - POSIX/Windows hits, placeholder/env/angle skips, bundled `.md`, SKILL.md itself, script shebang+body, extensionless shebang, python comment, all-three=3 diagnostics, good placeholders clean, out-of-scope sibling not flagged.
- [x] `cargo test -p agnix-core --lib` (3762 passed)
- [x] `cargo test -p agnix-cli --test rule_parity` (16 passed - SARIF/impl/fixture-coverage/integrity)
- [x] `cargo clippy -p agnix-core --lib` clean
- [x] `agnix eval tests/eval.yaml` (61 cases pass - no new false positives)
- [x] CLAUDE.md == AGENTS.md