### PR TITLE
chore(tool-release): bump cline/codex/cursor baselines

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -60,7 +60,7 @@
         "agents_md"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.134.0",
+      "last_known_version": "rust-v0.135.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -203,7 +203,7 @@
         "cline"
       ],
       "github_repo": "cline/cline",
-      "last_known_version": "cli-v3.0.13",
+      "last_known_version": "cli-v3.0.15",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -237,7 +237,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.5.38",
+      "last_known_version": "3.6.21",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {


### PR DESCRIPTION
Triages the three auto-opened release-watch issues; all are agnix-irrelevant.

| Tool | Was | Now | Why irrelevant |
|------|-----|-----|----------------|
| cline | cli-v3.0.13 | cli-v3.0.15 | Cline Hub, Discord, model catalog, symlinked skill *discovery* - no `.clinerules`/skill schema change |
| codex | rust-v0.134.0 | rust-v0.135.0 | doctor/`/status`/vim/`/permissions` UI, SQLite internals; legacy config-profile *removal* (no new config.toml keys to flag) |
| cursor | 3.5.38 | 3.6.21 | source exposes a version marker only |

No validator, rule, `ToolVersions`, or `SpecRevisions` change required. `RESEARCH-TRACKING.md` "Last Reviewed" already 2026-05-30.

closes #1004, closes #1005, closes #1006

[skip changelog] - internal release-tracking, no user-facing change.