### PR TITLE
perf: use mimalloc global allocator on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Performance**: the `agnix`, `agnix-lsp`, and `agnix-mcp` binaries now use [mimalloc](https://github.com/microsoft/mimalloc) as the global allocator on Linux. Linting is allocation-heavy (per-file parse trees, diagnostics, parallel rayon workers), and mimalloc reduces allocator contention versus the default system allocator. Gated behind `cfg(target_os = "linux")`, so macOS and Windows builds are unaffected.
 - **Tool baselines**: triaged the release-watch sweep and bumped `cursor` `3.6.31` -> `3.7.12` (closes #1024), `kiro` `2.5.0` -> `2.6.0` (closes #1018), and `gemini-cli` `v0.44.1` -> `v0.45.1` (closes #1017). All three were agnix-irrelevant for current validated config surfaces: Cursor and Gemini publish version markers / patch cherry-picks only, and Kiro 2.6.0's sole config-adjacent change - terminal window titles - is toggled via `/settings display` and is explicitly "not available as a CLI setting" (per the Kiro settings reference), so `.kiro/settings.json` validation is unaffected and the auto-triage `KR-SET-004` candidate was not added. No validator, rule, `ToolVersions`, or `SpecRevisions` change required. `.github/tool-release-baselines.json` and `knowledge-base/RESEARCH-TRACKING.md` updated.
 
 ## [0.30.0] - 2026-06-04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "colored",
  "ctrlc",
  "dirs",
+ "mimalloc",
  "notify",
  "notify-debouncer-mini",
  "predicates",
@@ -66,6 +67,7 @@ dependencies = [
  "agnix-core",
  "anyhow",
  "arc-swap",
+ "mimalloc",
  "rust-i18n",
  "serde",
  "serde_json",
@@ -82,6 +84,7 @@ dependencies = [
  "agnix-core",
  "agnix-rules",
  "anyhow",
+ "mimalloc",
  "rmcp",
  "serde",
  "serde_json",
@@ -1546,6 +1549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1614,6 +1626,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -2790,7 +2811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ keywords = ["agent", "linter", "claude", "skills", "mcp"]
 categories = ["development-tools", "command-line-utilities"]
 
 [workspace.dependencies]
+mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
 agnix-rules = { path = "crates/agnix-rules", version = "0.30.0" }
 agnix-core = { path = "crates/agnix-core", version = "0.30.0" }

--- a/crates/agnix-cli/Cargo.toml
+++ b/crates/agnix-cli/Cargo.toml
@@ -43,6 +43,9 @@ sys-locale = { workspace = true }
 # Optional: HTTP client for telemetry submission
 reqwest = { version = "0.13", features = ["blocking", "json"], optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+mimalloc = { workspace = true }
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/crates/agnix-cli/src/main.rs
+++ b/crates/agnix-cli/src/main.rs
@@ -1,6 +1,13 @@
 #![allow(clippy::collapsible_if, clippy::let_and_return)]
 //! agnix CLI - The nginx of agent configs
 
+#[cfg(target_os = "linux")]
+use mimalloc::MiMalloc;
+
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 rust_i18n::i18n!("locales", fallback = "en");
 
 mod json;

--- a/crates/agnix-cli/src/main.rs
+++ b/crates/agnix-cli/src/main.rs
@@ -2,11 +2,8 @@
 //! agnix CLI - The nginx of agent configs
 
 #[cfg(target_os = "linux")]
-use mimalloc::MiMalloc;
-
-#[cfg(target_os = "linux")]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 rust_i18n::i18n!("locales", fallback = "en");
 

--- a/crates/agnix-lsp/Cargo.toml
+++ b/crates/agnix-lsp/Cargo.toml
@@ -23,5 +23,8 @@ serde_json = { workspace = true }
 rust-i18n = { workspace = true }
 sys-locale = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+mimalloc = { workspace = true }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/agnix-lsp/src/main.rs
+++ b/crates/agnix-lsp/src/main.rs
@@ -1,3 +1,10 @@
+#[cfg(target_os = "linux")]
+use mimalloc::MiMalloc;
+
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 #[tokio::main]
 async fn main() {
     let args: Vec<String> = std::env::args().collect();

--- a/crates/agnix-lsp/src/main.rs
+++ b/crates/agnix-lsp/src/main.rs
@@ -1,9 +1,6 @@
 #[cfg(target_os = "linux")]
-use mimalloc::MiMalloc;
-
-#[cfg(target_os = "linux")]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[tokio::main]
 async fn main() {

--- a/crates/agnix-mcp/Cargo.toml
+++ b/crates/agnix-mcp/Cargo.toml
@@ -24,5 +24,8 @@ anyhow = { workspace = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+mimalloc = { workspace = true }
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/agnix-mcp/src/main.rs
+++ b/crates/agnix-mcp/src/main.rs
@@ -12,11 +12,8 @@
 //! - **Server metadata**: Provides name, version, and usage instructions
 
 #[cfg(target_os = "linux")]
-use mimalloc::MiMalloc;
-
-#[cfg(target_os = "linux")]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use agnix_core::{
     config::LintConfig,

--- a/crates/agnix-mcp/src/main.rs
+++ b/crates/agnix-mcp/src/main.rs
@@ -11,6 +11,13 @@
 //! - **Error handling**: Proper error messages with context
 //! - **Server metadata**: Provides name, version, and usage instructions
 
+#[cfg(target_os = "linux")]
+use mimalloc::MiMalloc;
+
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 use agnix_core::{
     config::LintConfig,
     diagnostics::{Diagnostic, DiagnosticLevel},


### PR DESCRIPTION
## Summary

The `agnix`, `agnix-lsp`, and `agnix-mcp` binaries now use [mimalloc](https://github.com/microsoft/mimalloc) as the global allocator on Linux.

Linting is allocation-heavy: per-file parse trees, diagnostic vectors, and parallel rayon workers all churn the allocator. mimalloc reduces allocator contention versus the default system allocator.

## Details

- Added `mimalloc = { version = "0.1", default-features = false }` to `[workspace.dependencies]`.
- Wired it into each binary crate via a `[target.'cfg(target_os = "linux")'.dependencies]` block, so the dep and the `#[global_allocator]` static are both gated to Linux. macOS and Windows builds are unaffected.

## Testing

- `cargo check --workspace` - clean
- `cargo clippy -p agnix-cli -p agnix-lsp -p agnix-mcp` - clean
- `cargo test -p agnix-cli -p agnix-lsp -p agnix-mcp` - pass

## Changelog

Added under `[Unreleased]`.