### PR TITLE
chore: ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,8 +54,10 @@ jobs:
       - name: Run security audit
         # RUSTSEC-2025-0067 (libyml) and RUSTSEC-2025-0068 (serde_yml)
         # both transitive via rust-i18n-macro / rust-i18n-support 3.1.2.
-        # No upstream patch yet; tracked in docs/RUSTSEC-ADVISORIES.md.
-        run: cargo audit --deny warnings --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2025-0067 --ignore RUSTSEC-2025-0068
+        # RUSTSEC-2026-0173 (proc-macro-error2 unmaintained) is dev-only via
+        # iai-callgrind; no safe upgrade. No upstream patch yet for any of
+        # these; tracked in docs/RUSTSEC-ADVISORIES.md.
+        run: cargo audit --deny warnings --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2026-0009 --ignore RUSTSEC-2025-0067 --ignore RUSTSEC-2025-0068 --ignore RUSTSEC-2026-0173
 
   # Additional supply chain security with cargo-deny
   deny:

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # Review these periodically - tracked in #346
 ignore = [
     "RUSTSEC-2025-0141", # bincode (via iai-callgrind) - dev-only dependency, low risk
+    "RUSTSEC-2026-0173", # proc-macro-error2 unmaintained (via iai-callgrind) - dev-only dependency, no safe upgrade
 ]
 
 [licenses]

--- a/docs/RUSTSEC-ADVISORIES.md
+++ b/docs/RUSTSEC-ADVISORIES.md
@@ -58,6 +58,30 @@ Related: [Issue #346](https://github.com/agent-sh/agnix/issues/346) (this tracki
 - Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0141
 - iai-callgrind repository: https://github.com/iai-callgrind/iai-callgrind
 
+### RUSTSEC-2026-0173 — `proc-macro-error2` (via `iai-callgrind`)
+
+**Status**: Dev-only dependency used for benchmarks; unmaintained, no safe upgrade
+
+**Details**:
+- Published 2026-06-07. The `proc-macro-error2` author confirmed the crate is unmaintained and recommends migrating away. No patched version exists (`patched = []`).
+- It's only used via `iai-callgrind` -> `iai-callgrind-macros`, which is a dev dependency for benchmarks.
+- Not included in release binaries.
+
+**Risk Level**: Low
+- Dev-only dependency (not in production code)
+- Unmaintained advisory only - no known exploitable vulnerability
+- Not exposed to untrusted input
+
+**Action Items**:
+- Monitor `iai-callgrind` updates for a version that drops `proc-macro-error2` (e.g. migrates to `manyhow` / `proc-macro2-diagnostics`)
+- Remove this advisory ignore from:
+  - `deny.toml` in the `[advisories]` ignore list
+  - `.github/workflows/security.yml` in the `cargo audit` command
+
+**References**:
+- Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0173
+- Announcement: https://github.com/GnomedDev/proc-macro-error-2/issues/17
+
 ### RUSTSEC-2025-0067 — `libyml` (via `rust-i18n-macro`)
 
 **Status**: Waiting for `rust-i18n` to migrate off `serde_yml` / `libyml`


### PR DESCRIPTION
## Summary

`RUSTSEC-2026-0173` was published 2026-06-07, marking `proc-macro-error2` as unmaintained. cargo-deny's `advisories` check now fails on **main and every open PR** (Security Audit + Dependency Check jobs).

## Why ignore

- `proc-macro-error2` is **not a direct dependency**. It reaches the tree only as a dev-only transitive dep: `iai-callgrind` (benchmark harness) -> `iai-callgrind-macros` -> `proc-macro-error2`.
- No safe upgrade is available (`patched = []`).
- Not shipped in any release binary - dev/bench only.
- Identical chain and rationale to the existing `RUSTSEC-2025-0141` ignore (bincode via iai-callgrind) right above it.

```
proc-macro-error2 v2.0.1
└── iai-callgrind-macros v0.6.1
    └── iai-callgrind v0.16.1
        └── (dev) agnix-core
```

## Verification

`cargo deny check advisories` -> `advisories ok`.

`[skip changelog]` - CI/tooling plumbing, no user-facing change.