### PR TITLE
Address release-watch issues

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-06-11",
+  "last_updated": "2026-06-16",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.169",
+      "last_known_version": "v2.1.178",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -60,7 +60,7 @@
         "agents_md"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.138.0",
+      "last_known_version": "rust-v0.140.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.15.13",
+      "last_known_version": "v1.17.7",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -203,7 +203,7 @@
         "cline"
       ],
       "github_repo": "cline/cline",
-      "last_known_version": "v3.88.1",
+      "last_known_version": "cli-v3.0.24",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -237,7 +237,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.7.27",
+      "last_known_version": "3.7.42",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 423 rules, 75+ sources, rules.json
+knowledge-base/     # 424 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-423 rules defined in `knowledge-base/rules.json` (source of truth)
+424 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.29.0 - Production-ready with full validation pipeline
-- 423 validation rules across 43 validators
+- 424 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SET-007: Non-boolean enforceAvailableModels Setting** (closes #1039). Claude Code v2.1.175 added the managed `enforceAvailableModels` setting for the `availableModels` allowlist. New MEDIUM `claude-settings` rule warns when the key is present with a non-boolean value in `settings.json`, `settings.local.json`, or `managed-settings.json`; strict `true`/`false` values, `null`, and absent keys are accepted. Claude Code v2.1.178 also added parameter-scoped tool examples such as `Agent(model:opus)`, so the Claude agent and skill tool allow-lists now accept the `Agent` tool in those forms. Rule count 423 -> 424.
+
+### Changed
+- **Tool baseline**: `codex` bumped `rust-v0.138.0` -> `rust-v0.140.0` (closes #1048). Diffed upstream `codex-rs/core/config.schema.json`; rust-v0.140.0 added the top-level `experimental_realtime_webrtc_call_base_url` key and `apps._default.approvals_reviewer`. The Codex config allow-list and `CDX-CFG-024` validation now cover both without false positives.
+- **Tool baseline**: `opencode` bumped `v1.15.13` -> `v1.17.7` (closes #1041). OpenCode v1.17.4 added optional local MCP server `cwd`; `OC-CFG-007` now validates that `cwd`, when present, is a non-empty string while keeping the existing local `command` and remote `url` checks.
+- **Tool baselines**: triaged `cline` `v3.88.1` -> `cli-v3.0.24` (closes #1040) and `cursor` `3.7.27` -> `3.7.42` (closes #1047) as agnix-irrelevant for the current validated config surfaces. `.github/tool-release-baselines.json` and `knowledge-base/RESEARCH-TRACKING.md` updated.
+
 ## [0.32.0] - 2026-06-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 423 rules, 75+ sources, rules.json
+knowledge-base/     # 424 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-423 rules defined in `knowledge-base/rules.json` (source of truth)
+424 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.29.0 - Production-ready with full validation pipeline
-- 423 validation rules across 43 validators
+- 424 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>423 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>424 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 423 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 424 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -828,6 +828,9 @@ rules:
   cc_set_006:
     message: "disableBundledSkills must be a boolean when present (got %{actual}); Claude Code 2.1.169+ documents only strict true/false for this setting"
     suggestion: "Set disableBundledSkills to an unquoted true or false, or set the CLAUDE_CODE_DISABLE_BUNDLED_SKILLS environment variable to 1 instead."
+  cc_set_007:
+    message: "enforceAvailableModels must be a boolean when present (got %{actual}); Claude Code 2.1.175+ documents this managed setting as a strict true/false toggle"
+    suggestion: "Set enforceAvailableModels to an unquoted true or false so the managed availableModels allowlist is enforced predictably."
   cdx_ag_001:
     message: "AGENTS.md is empty"
     suggestion: "Add concrete repository-specific operating instructions"

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -716,6 +716,9 @@ rules:
   cc_set_006:
     message: "disableBundledSkills debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.169+ solo documenta true/false estrictos para esta configuracion"
     suggestion: "Establece disableBundledSkills en true o false sin comillas, o en su lugar establece la variable de entorno CLAUDE_CODE_DISABLE_BUNDLED_SKILLS en 1."
+  cc_set_007:
+    message: "enforceAvailableModels debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.175+ documenta esta configuracion administrada como un interruptor true/false estricto"
+    suggestion: "Establece enforceAvailableModels en true o false sin comillas para que la lista administrada availableModels se aplique de forma predecible."
 
   # --- Version (lib.rs) ---
   ver_001:

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -716,6 +716,9 @@ rules:
   cc_set_006:
     message: "disableBundledSkills 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.169+ 对该设置只记录严格的 true/false"
     suggestion: "将 disableBundledSkills 设置为不带引号的 true 或 false，或改为将环境变量 CLAUDE_CODE_DISABLE_BUNDLED_SKILLS 设置为 1。"
+  cc_set_007:
+    message: "enforceAvailableModels 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.175+ 将该托管设置记录为严格的 true/false 开关"
+    suggestion: "将 enforceAvailableModels 设置为不带引号的 true 或 false，以便可预测地强制执行托管 availableModels 允许列表。"
 
   # --- Version (lib.rs) ---
   ver_001:

--- a/crates/agnix-core/src/rules/agent.rs
+++ b/crates/agnix-core/src/rules/agent.rs
@@ -105,6 +105,7 @@ const KNOWN_AGENT_FIELDS: &[&str] = &[
 
 /// Known Claude Code tools for CC-AG-009 and CC-AG-010
 const KNOWN_AGENT_TOOLS: &[&str] = &[
+    "Agent",
     "Bash",
     "Read",
     "Write",
@@ -3032,6 +3033,31 @@ Agent instructions"#;
     }
 
     #[test]
+    fn test_cc_ag_010_parameter_scoped_agent_tool_valid() {
+        // Claude Code v2.1.178 added Tool(param:value) permission syntax;
+        // the base tool still needs to be recognized after stripping the
+        // parameter clause.
+        let content = r#"---
+name: my-agent
+description: A test agent
+disallowedTools:
+  - Agent(model:opus)
+---
+Agent instructions"#;
+
+        let diagnostics = validate(content);
+        let cc_ag_010: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-AG-010")
+            .collect();
+        assert_eq!(
+            cc_ag_010.len(),
+            0,
+            "Agent(model:opus) should be accepted in disallowedTools"
+        );
+    }
+
+    #[test]
     fn test_cc_ag_009_mcp_case_sensitive() {
         let content = r#"---
 name: my-agent
@@ -3051,6 +3077,28 @@ Agent instructions"#;
             cc_ag_009.len(),
             2,
             "MCP prefix is case-sensitive: MCP__ and Mcp__ should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_cc_ag_009_parameter_scoped_agent_tool_valid() {
+        let content = r#"---
+name: my-agent
+description: A test agent
+tools:
+  - Agent(model:opus)
+---
+Agent instructions"#;
+
+        let diagnostics = validate(content);
+        let cc_ag_009: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-AG-009")
+            .collect();
+        assert_eq!(
+            cc_ag_009.len(),
+            0,
+            "Agent(model:opus) should be accepted in tools"
         );
     }
 

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -11,6 +11,7 @@
 //! - `sandbox.bwrapPath`/`sandbox.socatPath` type check (CC-SET-004, added in Claude Code v2.1.133).
 //! - `parentSettingsBehavior` enum check (CC-SET-005, added in Claude Code v2.1.133).
 //! - `disableBundledSkills` boolean check (CC-SET-006, added in Claude Code v2.1.169).
+//! - `enforceAvailableModels` boolean check (CC-SET-007, added in Claude Code v2.1.175).
 //!
 //! Runs on FileType::Hooks (which covers `.claude/settings.json` -
 //! see `file_types/detection.rs`). Skips non-Claude Code settings paths
@@ -31,6 +32,7 @@ const RULE_IDS: &[&str] = &[
     "CC-SET-004",
     "CC-SET-005",
     "CC-SET-006",
+    "CC-SET-007",
 ];
 
 /// Allowed values for `worktree.baseRef` per Claude Code v2.1.133 release notes.
@@ -97,6 +99,10 @@ impl Validator for ClaudeSettingsValidator {
 
         if config.is_rule_enabled("CC-SET-006") {
             validate_disable_bundled_skills(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-007") {
+            validate_enforce_available_models(path, content, &value, &mut diagnostics);
         }
 
         diagnostics
@@ -508,6 +514,45 @@ fn validate_disable_bundled_skills(
             t!("rules.cc_set_006.message", actual = actual),
         )
         .with_suggestion(t!("rules.cc_set_006.suggestion")),
+    );
+}
+
+/// CC-SET-007: Validate `enforceAvailableModels`. Claude Code 2.1.175
+/// added this managed setting so an admin-provided `availableModels`
+/// allowlist also constrains the Default model and cannot be widened by
+/// user/project settings. The release note documents enablement as a
+/// strict boolean - quoted strings, numbers, arrays, or objects are not
+/// a documented opt-in.
+///
+/// Missing field is fine: Claude Code keeps the existing allowlist
+/// behavior. `null` is treated as "field absent" by JSON convention,
+/// consistent with the other CC-SET boolean rules.
+fn validate_enforce_available_models(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(field_value) = value.get("enforceAvailableModels") else {
+        return;
+    };
+
+    if field_value.is_boolean() || field_value.is_null() {
+        return;
+    }
+
+    let actual = describe_json_type(field_value);
+    let line = find_key_line(content, "enforceAvailableModels").unwrap_or(1);
+
+    diagnostics.push(
+        Diagnostic::warning(
+            path.to_path_buf(),
+            line,
+            0,
+            "CC-SET-007",
+            t!("rules.cc_set_007.message", actual = actual),
+        )
+        .with_suggestion(t!("rules.cc_set_007.suggestion")),
     );
 }
 
@@ -1399,5 +1444,102 @@ mod tests {
         let diagnostics = validate(content);
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-002"));
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-006"));
+    }
+
+    // ===== CC-SET-007: enforceAvailableModels =====
+
+    #[test]
+    fn test_enforce_available_models_absent_is_fine() {
+        let content = r#"{"availableModels": ["claude-sonnet-4-5"]}"#;
+        assert!(validate(content).iter().all(|d| d.rule != "CC-SET-007"));
+    }
+
+    #[test]
+    fn test_enforce_available_models_boolean_values_are_fine() {
+        assert!(
+            validate(r#"{"enforceAvailableModels": true}"#)
+                .iter()
+                .all(|d| d.rule != "CC-SET-007")
+        );
+        assert!(
+            validate(r#"{"enforceAvailableModels": false}"#)
+                .iter()
+                .all(|d| d.rule != "CC-SET-007")
+        );
+    }
+
+    #[test]
+    fn test_enforce_available_models_null_is_not_flagged() {
+        let content = r#"{"enforceAvailableModels": null}"#;
+        assert!(validate(content).iter().all(|d| d.rule != "CC-SET-007"));
+    }
+
+    #[test]
+    fn test_enforce_available_models_quoted_string_flags() {
+        let content = r#"{"enforceAvailableModels": "true"}"#;
+        let diagnostics = validate(content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-007")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].level, crate::diagnostics::DiagnosticLevel::Warning);
+        assert!(hits[0].message.to_lowercase().contains("boolean"));
+        assert!(hits[0].message.to_lowercase().contains("string"));
+    }
+
+    #[test]
+    fn test_enforce_available_models_number_flags() {
+        let content = r#"{"enforceAvailableModels": 1}"#;
+        let diagnostics = validate(content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-007")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].message.to_lowercase().contains("number"));
+    }
+
+    #[test]
+    fn test_enforce_available_models_object_flags() {
+        let content = r#"{"enforceAvailableModels": {"enabled": true}}"#;
+        let diagnostics = validate(content);
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter(|d| d.rule == "CC-SET-007")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_enforce_available_models_runs_on_managed_settings() {
+        let content = r#"{"enforceAvailableModels": "true"}"#;
+        let diagnostics = validate_at(".claude/managed-settings.json", content);
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-007"));
+    }
+
+    #[test]
+    fn test_enforce_available_models_line_points_at_key() {
+        let content = "{\n  \"availableModels\": [\"claude-sonnet-4-5\"],\n  \"enforceAvailableModels\": \"true\"\n}";
+        let diagnostics = validate(content);
+        let hit = diagnostics
+            .iter()
+            .find(|d| d.rule == "CC-SET-007")
+            .expect("CC-SET-007 diagnostic");
+        assert_eq!(hit.line, 3);
+    }
+
+    #[test]
+    fn test_enforce_available_models_can_be_disabled() {
+        let mut builder = LintConfig::builder();
+        builder.disable_rule("CC-SET-007");
+        let config = builder.build().unwrap();
+        let validator = ClaudeSettingsValidator;
+        let path = PathBuf::from(".claude/settings.json");
+        let content = r#"{"enforceAvailableModels": "true"}"#;
+        let diagnostics = validator.validate(&path, content, &config);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-007"));
     }
 }

--- a/crates/agnix-core/src/rules/codex.rs
+++ b/crates/agnix-core/src/rules/codex.rs
@@ -272,7 +272,12 @@ const KNOWN_MCP_SERVER_KEYS: &[&str] = &[
     "url",
 ];
 
-const KNOWN_APPS_DEFAULT_KEYS: &[&str] = &["enabled", "destructive_enabled", "open_world_enabled"];
+const KNOWN_APPS_DEFAULT_KEYS: &[&str] = &[
+    "approvals_reviewer",
+    "enabled",
+    "destructive_enabled",
+    "open_world_enabled",
+];
 const KNOWN_APP_CONFIG_KEYS: &[&str] = &[
     "approvals_reviewer",
     "enabled",
@@ -1831,6 +1836,49 @@ fn validate_codex_config_rules(
         if let Some(apps_obj) = apps.as_object() {
             for (app_name, app_value) in apps_obj {
                 if app_name == "_default" {
+                    if config.is_rule_enabled("CDX-CFG-024")
+                        && let Some(default_obj) = app_value.as_object()
+                        && let Some(reviewer) = default_obj.get("approvals_reviewer")
+                    {
+                        if let Some(reviewer_str) = reviewer.as_str() {
+                            if !VALID_APPROVALS_REVIEWER.contains(&reviewer_str) {
+                                diagnostics.push(
+                                    Diagnostic::warning(
+                                        path.to_path_buf(),
+                                        line_for("approvals_reviewer"),
+                                        0,
+                                        "CDX-CFG-024",
+                                        format!(
+                                            "Invalid apps._default.approvals_reviewer value '{}'. Must be one of: {}",
+                                            reviewer_str,
+                                            VALID_APPROVALS_REVIEWER.join(", ")
+                                        ),
+                                    )
+                                    .with_suggestion(format!(
+                                        "Set apps._default.approvals_reviewer to one of: {}.",
+                                        VALID_APPROVALS_REVIEWER.join(", ")
+                                    )),
+                                );
+                            }
+                        } else if !reviewer.is_null() {
+                            diagnostics.push(
+                                Diagnostic::warning(
+                                    path.to_path_buf(),
+                                    line_for("approvals_reviewer"),
+                                    0,
+                                    "CDX-CFG-024",
+                                    format!(
+                                        "apps._default.approvals_reviewer must be a string, not {}",
+                                        value_type_name(reviewer)
+                                    ),
+                                )
+                                .with_suggestion(format!(
+                                    "Set apps._default.approvals_reviewer to one of: {}.",
+                                    VALID_APPROVALS_REVIEWER.join(", ")
+                                )),
+                            );
+                        }
+                    }
                     continue;
                 }
                 let Some(app_obj) = app_value.as_object() else {
@@ -3568,6 +3616,44 @@ excluded_tool_namespaces = ["browser"]
     }
 
     #[test]
+    fn test_codex_0_140_0_new_top_level_key_not_flagged_toml() {
+        // rust-v0.140.0 added `experimental_realtime_webrtc_call_base_url`
+        // to the upstream config schema. The TOML path uses CDX-004 for
+        // unknown top-level keys.
+        let diagnostics = validate_config(
+            "experimental_realtime_webrtc_call_base_url = \"https://realtime.example.com/call\"",
+        );
+        let unexpected: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-004" || d.rule == "CDX-CFG-006")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "0.140 realtime WebRTC key should not be flagged on TOML path, got: {unexpected:?}"
+        );
+    }
+
+    #[test]
+    fn test_codex_0_140_0_new_top_level_key_not_flagged_json() {
+        // JSON/YAML path uses CDX-CFG-006 for unknown top-level keys.
+        let diagnostics = validate_config_json(
+            r#"{
+  "experimental_realtime_webrtc_call_base_url": "https://realtime.example.com/call"
+}"#,
+        );
+        let unexpected: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-006")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "0.140 realtime WebRTC key should not be flagged on JSON path, got: {unexpected:?}"
+        );
+    }
+
+    #[test]
     fn test_cdx_cfg_012_invalid_cli_auth_store() {
         let diagnostics = validate_config("cli_auth_credentials_store = \"vault\"");
         assert!(diagnostics.iter().any(|d| d.rule == "CDX-CFG-012"));
@@ -4104,6 +4190,24 @@ approvals_reviewer = "auto_review"
     }
 
     #[test]
+    fn test_cdx_cfg_024_valid_app_default_approvals_reviewer_auto_review() {
+        let diagnostics = validate_config(
+            r#"[apps._default]
+approvals_reviewer = "auto_review"
+"#,
+        );
+        let unexpected: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-006" || d.rule == "CDX-CFG-024")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "apps._default.approvals_reviewer should not be flagged when valid, got: {unexpected:?}"
+        );
+    }
+
+    #[test]
     fn test_cdx_cfg_024_invalid_app_approvals_reviewer() {
         let diagnostics = validate_config(
             r#"[apps.browser]
@@ -4127,6 +4231,41 @@ approvals_reviewer = "approve"
     fn test_cdx_cfg_024_app_approvals_reviewer_type_error() {
         let diagnostics = validate_config(
             r#"[apps.browser]
+approvals_reviewer = 42
+"#,
+        );
+        let cdx_024: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-024")
+            .collect();
+        assert_eq!(cdx_024.len(), 1);
+        assert!(cdx_024[0].message.contains("string"));
+    }
+
+    #[test]
+    fn test_cdx_cfg_024_invalid_app_default_approvals_reviewer() {
+        let diagnostics = validate_config(
+            r#"[apps._default]
+approvals_reviewer = "approve"
+"#,
+        );
+        let cdx_024: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-024")
+            .collect();
+        assert_eq!(cdx_024.len(), 1);
+        assert!(
+            cdx_024[0]
+                .message
+                .contains("apps._default.approvals_reviewer")
+        );
+        assert!(cdx_024[0].message.contains("approve"));
+    }
+
+    #[test]
+    fn test_cdx_cfg_024_app_default_approvals_reviewer_type_error() {
+        let diagnostics = validate_config(
+            r#"[apps._default]
 approvals_reviewer = 42
 "#,
         );

--- a/crates/agnix-core/src/rules/opencode.rs
+++ b/crates/agnix-core/src/rules/opencode.rs
@@ -703,6 +703,27 @@ impl Validator for OpenCodeValidator {
                                                     );
                                                 }
                                             }
+                                            if let Some(cwd_val) = srv.get("cwd") {
+                                                let valid_cwd = cwd_val
+                                                    .as_str()
+                                                    .is_some_and(|cwd| !cwd.trim().is_empty());
+
+                                                if !valid_cwd {
+                                                    diagnostics.push(
+                                                        Diagnostic::error(
+                                                            path.to_path_buf(),
+                                                            find_key_line(content, srv_name).unwrap_or(1),
+                                                            0,
+                                                            "OC-CFG-007",
+                                                            "Local MCP server 'cwd' must be a non-empty string when present".to_string(),
+                                                        )
+                                                        .with_suggestion(
+                                                            "Set cwd to a workspace-relative or absolute path string, or remove it"
+                                                                .to_string(),
+                                                        ),
+                                                    );
+                                                }
+                                            }
                                         } else if srv_type == "remote" {
                                             if !srv.contains_key("url") {
                                                 diagnostics.push(
@@ -2929,6 +2950,28 @@ mod tests {
     #[test]
     fn test_oc_cfg_007_local_command_type_check() {
         let diagnostics = validate(r#"{"mcp": {"srv": {"type": "local", "command": "node"}}}"#);
+        assert!(diagnostics.iter().any(|d| d.rule == "OC-CFG-007"));
+    }
+
+    #[test]
+    fn test_oc_cfg_007_local_cwd_string_ok() {
+        let diagnostics = validate(
+            r#"{"mcp": {"srv": {"type": "local", "command": ["node"], "cwd": "plugins/sub"}}}"#,
+        );
+        assert!(!diagnostics.iter().any(|d| d.rule == "OC-CFG-007"));
+    }
+
+    #[test]
+    fn test_oc_cfg_007_local_cwd_empty_flags() {
+        let diagnostics =
+            validate(r#"{"mcp": {"srv": {"type": "local", "command": ["node"], "cwd": ""}}}"#);
+        assert!(diagnostics.iter().any(|d| d.rule == "OC-CFG-007"));
+    }
+
+    #[test]
+    fn test_oc_cfg_007_local_cwd_non_string_flags() {
+        let diagnostics =
+            validate(r#"{"mcp": {"srv": {"type": "local", "command": ["node"], "cwd": 42}}}"#);
         assert!(diagnostics.iter().any(|d| d.rule == "OC-CFG-007"));
     }
 

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -1232,6 +1232,30 @@ Body"#;
 }
 
 #[test]
+fn test_cc_sk_008_parameter_scoped_agent_tool_valid() {
+    let content = r#"---
+name: test-skill
+description: Use when testing
+allowed-tools: Agent(model:opus) Read
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(Path::new("test.md"), content, &LintConfig::default());
+
+    let cc_sk_008: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-008")
+        .collect();
+
+    assert_eq!(
+        cc_sk_008.len(),
+        0,
+        "Agent(model:opus) should be accepted as a scoped Claude tool"
+    );
+}
+
+#[test]
 fn test_cc_sk_008_multiple_unknown_tools() {
     let content = r#"---
 name: test-skill

--- a/crates/agnix-core/src/schemas/codex.rs
+++ b/crates/agnix-core/src/schemas/codex.rs
@@ -117,6 +117,7 @@ pub const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     "suppress_unstable_features_warning",
     // Experimental (alphabetized)
     "experimental_realtime_start_instructions",
+    "experimental_realtime_webrtc_call_base_url",
     "experimental_realtime_ws_backend_prompt",
     "experimental_realtime_ws_base_url",
     "experimental_realtime_ws_model",
@@ -758,6 +759,26 @@ nested_number = 42
         assert!(
             result.unknown_keys.is_empty(),
             "0.133 top-level keys/`[desktop]` table should not be flagged, got: {:?}",
+            result
+                .unknown_keys
+                .iter()
+                .map(|u| u.key.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_codex_0_140_0_new_top_level_key_not_flagged() {
+        // Top-level key introduced in Codex rust-v0.140.0. Regression guard
+        // against CDX-004 false positives on valid realtime WebRTC configs.
+        let content = r#"
+experimental_realtime_webrtc_call_base_url = "https://realtime.example.com/call"
+"#;
+        let result = parse_codex_toml(content);
+        assert!(result.parse_error.is_none());
+        assert!(
+            result.unknown_keys.is_empty(),
+            "0.140 realtime WebRTC key should not be flagged, got: {:?}",
             result
                 .unknown_keys
                 .iter()

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 423,
-  "last_updated": "2026-06-11",
+  "total_rules": 424,
+  "last_updated": "2026-06-16",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3635,6 +3635,35 @@
       "bad_example": "{\n  \"disableBundledSkills\": \"true\"\n}"
     },
     {
+      "id": "CC-SET-007",
+      "name": "Non-boolean enforceAvailableModels Setting",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.175",
+          "https://code.claude.com/docs/en/settings"
+        ],
+        "verified_on": "2026-06-16",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.175"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"enforceAvailableModels\": true\n}",
+      "bad_example": "{\n  \"enforceAvailableModels\": \"true\"\n}"
+    },
+    {
       "id": "CDX-000",
       "name": "TOML Parse Error",
       "severity": "HIGH",
@@ -5186,9 +5215,10 @@
       "evidence": {
         "source_type": "vendor_code",
         "source_urls": [
-          "https://github.com/openai/codex/blob/rust-v0.137.0/codex-rs/core/config.schema.json"
+          "https://github.com/openai/codex/blob/rust-v0.137.0/codex-rs/core/config.schema.json",
+          "https://github.com/openai/codex/blob/rust-v0.140.0/codex-rs/core/config.schema.json"
         ],
-        "verified_on": "2026-06-04",
+        "verified_on": "2026-06-16",
         "applies_to": {
           "tool": "codex"
         },
@@ -5203,8 +5233,8 @@
         "autofix": true,
         "fix_safety": "unsafe"
       },
-      "good_example": "approvals_reviewer = \"auto_review\"\n\n[apps.browser]\napprovals_reviewer = \"user\"",
-      "bad_example": "approvals_reviewer = \"approve\"\n\n[apps.browser]\napprovals_reviewer = 42"
+      "good_example": "approvals_reviewer = \"auto_review\"\n\n[apps.browser]\napprovals_reviewer = \"user\"\n\n[apps._default]\napprovals_reviewer = \"guardian_subagent\"",
+      "bad_example": "approvals_reviewer = \"approve\"\n\n[apps.browser]\napprovals_reviewer = 42\n\n[apps._default]\napprovals_reviewer = \"approve\""
     },
     {
       "id": "CDX-CFG-025",
@@ -10840,15 +10870,16 @@
     },
     {
       "id": "OC-CFG-007",
-      "name": "MCP Server Missing Command or URL",
+      "name": "Invalid MCP Server Command, URL, or cwd",
       "severity": "HIGH",
       "category": "opencode",
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://opencode.ai/docs/config"
+          "https://opencode.ai/docs/config",
+          "https://github.com/sst/opencode/pull/30676"
         ],
-        "verified_on": "2026-04-23",
+        "verified_on": "2026-06-16",
         "applies_to": {
           "tool": "opencode"
         },
@@ -10862,8 +10893,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\n  \"mcp\": { \"server\": { \"type\": \"local\", \"command\": [\"node\"] } }\n}",
-      "bad_example": "{\n  \"mcp\": { \"server\": { \"type\": \"local\" } }\n}"
+      "good_example": "{\n  \"mcp\": { \"server\": { \"type\": \"local\", \"command\": [\"node\"], \"cwd\": \"plugins/sub\" } }\n}",
+      "bad_example": "{\n  \"mcp\": { \"server\": { \"type\": \"local\", \"command\": [\"node\"], \"cwd\": 42 } }\n}"
     },
     {
       "id": "OC-AG-001",
@@ -11877,7 +11908,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 6,
+      "count": 7,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 423 validation rules across 40 categories, sourced from 75+ references
+> 424 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 423 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 424 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (423 rules)
+├── VALIDATION-RULES.md             # Master validation reference (424 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **423 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **424 rules** |
 
 
 ### Validation Rules by Category
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **423** | **213** | **180** | **28** | **127** |
+| **TOTAL** | **424** | **213** | **180** | **28** | **127** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 423 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 424 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     423 rules
+Validation Rules:     424 rules
 Auto-Fixable Rules:   96 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 423 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 424 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -16,9 +16,9 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-11 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
-| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-11 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
-| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-02 | AGM, XP, OC |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-16 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
+| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-16 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
+| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-16 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-06-08 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 
 ### A Tier (test on major changes)
@@ -26,8 +26,8 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-04-22 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-06-11 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-06-11 | CUR |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-06-16 | CLN, CL-SK |
+| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-06-16 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -387,6 +387,13 @@ Rules with an empty `applies_to` object (`{}`) apply universally.
 **Fix**: Manual - set `disableBundledSkills` to an unquoted `true` or `false`, or use the `CLAUDE_CODE_DISABLE_BUNDLED_SKILLS` environment variable.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.169 (added `disableBundledSkills`), code.claude.com/docs/en/settings
 
+<a id="cc-set-007"></a>
+### CC-SET-007 [MEDIUM] Non-boolean enforceAvailableModels Setting
+**Requirement**: `enforceAvailableModels` in `.claude/settings.json` / `.local.json` / `managed-settings.json` MUST be a boolean when present (Claude Code 2.1.175+). `true` enforces the managed `availableModels` allowlist for users; only strict `true`/`false` is documented.
+**Detection**: Parse settings.json; look up top-level `enforceAvailableModels`; flag (warning) non-boolean types (string, number, array, object). `null` values and absent keys are not flagged.
+**Fix**: Manual - set `enforceAvailableModels` to an unquoted `true` or `false`.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.175 (added `enforceAvailableModels`), code.claude.com/docs/en/settings
+
 ---
 
 ## PER-CLIENT SKILL RULES
@@ -1896,11 +1903,11 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 **Source**: opencode.ai/docs/config
 
 <a id="oc-cfg-007"></a>
-### OC-CFG-007 [HIGH] MCP Server Missing Command or URL
-**Requirement**: Local MCP servers MUST have `command`, remote MUST have `url`
-**Detection**: Parse JSON, validate `mcp` server requirements
+### OC-CFG-007 [HIGH] Invalid MCP Server Command, URL, or cwd
+**Requirement**: Local MCP servers MUST have `command` as a non-empty array of non-empty strings. When local MCP servers set optional `cwd` (OpenCode v1.17.4+), it MUST be a non-empty string. Remote MCP servers MUST have `url` as a non-empty `http://` or `https://` URL.
+**Detection**: Parse JSON, validate `mcp` server requirements and local `cwd` type
 **Fix**: No auto-fix
-**Source**: opencode.ai/docs/config
+**Source**: opencode.ai/docs/config, github.com/sst/opencode/pull/30676
 
 <a id="oc-ag-001"></a>
 ### OC-AG-001 [HIGH] Invalid Agent Mode Value
@@ -2443,10 +2450,10 @@ Rules for local Gemini agent markdown files at `.gemini/agents/*.md`. These defi
 
 <a id="cdx-cfg-024"></a>
 ### CDX-CFG-024 [MEDIUM] Invalid Approvals Reviewer Value
-**Requirement**: `approvals_reviewer` and `apps.<app_id>.approvals_reviewer` SHOULD be one of `user|auto_review|guardian_subagent`
-**Detection**: Parse config and validate top-level and app-level `approvals_reviewer` enum values
+**Requirement**: `approvals_reviewer`, `apps.<app_id>.approvals_reviewer`, and `apps._default.approvals_reviewer` SHOULD be one of `user|auto_review|guardian_subagent`
+**Detection**: Parse config and validate top-level, app-level, and app-default `approvals_reviewer` enum values
 **Fix**: Manual
-**Source**: github.com/openai/codex (codex-rs/core/config.schema.json @ rust-v0.137.0)
+**Source**: github.com/openai/codex (codex-rs/core/config.schema.json @ rust-v0.137.0 and rust-v0.140.0)
 
 <a id="cdx-cfg-025"></a>
 ### CDX-CFG-025 [MEDIUM] Invalid Service Tier Value
@@ -3459,8 +3466,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 423 validation rules across 40 categories
+**Total Coverage**: 424 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 213 HIGH, 182 MEDIUM, 28 LOW
+**Certainty**: 213 HIGH, 183 MEDIUM, 28 LOW
 **Auto-Fixable**: 127 rules (30%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 423,
-  "last_updated": "2026-06-11",
+  "total_rules": 424,
+  "last_updated": "2026-06-16",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3635,6 +3635,35 @@
       "bad_example": "{\n  \"disableBundledSkills\": \"true\"\n}"
     },
     {
+      "id": "CC-SET-007",
+      "name": "Non-boolean enforceAvailableModels Setting",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.175",
+          "https://code.claude.com/docs/en/settings"
+        ],
+        "verified_on": "2026-06-16",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.175"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"enforceAvailableModels\": true\n}",
+      "bad_example": "{\n  \"enforceAvailableModels\": \"true\"\n}"
+    },
+    {
       "id": "CDX-000",
       "name": "TOML Parse Error",
       "severity": "HIGH",
@@ -5186,9 +5215,10 @@
       "evidence": {
         "source_type": "vendor_code",
         "source_urls": [
-          "https://github.com/openai/codex/blob/rust-v0.137.0/codex-rs/core/config.schema.json"
+          "https://github.com/openai/codex/blob/rust-v0.137.0/codex-rs/core/config.schema.json",
+          "https://github.com/openai/codex/blob/rust-v0.140.0/codex-rs/core/config.schema.json"
         ],
-        "verified_on": "2026-06-04",
+        "verified_on": "2026-06-16",
         "applies_to": {
           "tool": "codex"
         },
@@ -5203,8 +5233,8 @@
         "autofix": true,
         "fix_safety": "unsafe"
       },
-      "good_example": "approvals_reviewer = \"auto_review\"\n\n[apps.browser]\napprovals_reviewer = \"user\"",
-      "bad_example": "approvals_reviewer = \"approve\"\n\n[apps.browser]\napprovals_reviewer = 42"
+      "good_example": "approvals_reviewer = \"auto_review\"\n\n[apps.browser]\napprovals_reviewer = \"user\"\n\n[apps._default]\napprovals_reviewer = \"guardian_subagent\"",
+      "bad_example": "approvals_reviewer = \"approve\"\n\n[apps.browser]\napprovals_reviewer = 42\n\n[apps._default]\napprovals_reviewer = \"approve\""
     },
     {
       "id": "CDX-CFG-025",
@@ -10840,15 +10870,16 @@
     },
     {
       "id": "OC-CFG-007",
-      "name": "MCP Server Missing Command or URL",
+      "name": "Invalid MCP Server Command, URL, or cwd",
       "severity": "HIGH",
       "category": "opencode",
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://opencode.ai/docs/config"
+          "https://opencode.ai/docs/config",
+          "https://github.com/sst/opencode/pull/30676"
         ],
-        "verified_on": "2026-04-23",
+        "verified_on": "2026-06-16",
         "applies_to": {
           "tool": "opencode"
         },
@@ -10862,8 +10893,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\n  \"mcp\": { \"server\": { \"type\": \"local\", \"command\": [\"node\"] } }\n}",
-      "bad_example": "{\n  \"mcp\": { \"server\": { \"type\": \"local\" } }\n}"
+      "good_example": "{\n  \"mcp\": { \"server\": { \"type\": \"local\", \"command\": [\"node\"], \"cwd\": \"plugins/sub\" } }\n}",
+      "bad_example": "{\n  \"mcp\": { \"server\": { \"type\": \"local\", \"command\": [\"node\"], \"cwd\": 42 } }\n}"
     },
     {
       "id": "OC-AG-001",
@@ -11877,7 +11908,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 6,
+      "count": 7,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.32.0",
-  "description": "Lint agent configurations before they break your workflow. 423 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 424 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "[email protected]",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 423 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 424 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 423 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 424 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 423 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 424 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/rules/generated/cc-set-007.md
+++ b/website/docs/rules/generated/cc-set-007.md
@@ -1,0 +1,53 @@
+---
+id: cc-set-007
+title: "CC-SET-007: Non-boolean enforceAvailableModels Setting"
+sidebar_label: "CC-SET-007"
+description: "agnix rule CC-SET-007 checks for non-boolean enforceavailablemodels setting in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-007", "non-boolean enforceavailablemodels setting", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-007`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-06-16`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.175`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.175
+- https://code.claude.com/docs/en/settings
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "enforceAvailableModels": "true"
+}
+```
+
+### Valid
+
+```json
+{
+  "enforceAvailableModels": true
+}
+```

--- a/website/docs/rules/generated/cdx-cfg-024.md
+++ b/website/docs/rules/generated/cdx-cfg-024.md
@@ -13,7 +13,7 @@ keywords: ["CDX-CFG-024", "invalid approvals reviewer value", "codex cli", "vali
 - **Category**: `Codex CLI`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `Yes (unsafe)`
-- **Verified On**: `2026-06-04`
+- **Verified On**: `2026-06-16`
 
 ## Applicability
 
@@ -24,6 +24,7 @@ keywords: ["CDX-CFG-024", "invalid approvals reviewer value", "codex cli", "vali
 ## Evidence Sources
 
 - https://github.com/openai/codex/blob/rust-v0.137.0/codex-rs/core/config.schema.json
+- https://github.com/openai/codex/blob/rust-v0.140.0/codex-rs/core/config.schema.json
 
 ## Test Coverage Metadata
 
@@ -42,6 +43,9 @@ approvals_reviewer = "approve"
 
 [apps.browser]
 approvals_reviewer = 42
+
+[apps._default]
+approvals_reviewer = "approve"
 ```
 
 ### Valid
@@ -51,4 +55,7 @@ approvals_reviewer = "auto_review"
 
 [apps.browser]
 approvals_reviewer = "user"
+
+[apps._default]
+approvals_reviewer = "guardian_subagent"
 ```

--- a/website/docs/rules/generated/oc-cfg-007.md
+++ b/website/docs/rules/generated/oc-cfg-007.md
@@ -1,9 +1,9 @@
 ---
 id: oc-cfg-007
-title: "OC-CFG-007: MCP Server Missing Command or URL - OpenCode"
+title: "OC-CFG-007: Invalid MCP Server Command, URL, or cwd"
 sidebar_label: "OC-CFG-007"
-description: "agnix rule OC-CFG-007 checks for mcp server missing command or url in opencode files. Severity: HIGH. See examples and fix guidance."
-keywords: ["OC-CFG-007", "mcp server missing command or url", "opencode", "validation", "agnix", "linter"]
+description: "agnix rule OC-CFG-007 checks for invalid mcp server command, url, or cwd in opencode files. Severity: HIGH. See examples and fix guidance."
+keywords: ["OC-CFG-007", "invalid mcp server command, url, or cwd", "opencode", "validation", "agnix", "linter"]
 ---
 
 ## Summary
@@ -13,7 +13,7 @@ keywords: ["OC-CFG-007", "mcp server missing command or url", "opencode", "valid
 - **Category**: `OpenCode`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-04-23`
+- **Verified On**: `2026-06-16`
 
 ## Applicability
 
@@ -24,6 +24,7 @@ keywords: ["OC-CFG-007", "mcp server missing command or url", "opencode", "valid
 ## Evidence Sources
 
 - https://opencode.ai/docs/config
+- https://github.com/sst/opencode/pull/30676
 
 ## Test Coverage Metadata
 
@@ -39,7 +40,7 @@ The following examples demonstrate what triggers this rule and how to fix it.
 
 ```json
 {
-  "mcp": { "server": { "type": "local" } }
+  "mcp": { "server": { "type": "local", "command": ["node"], "cwd": 42 } }
 }
 ```
 
@@ -47,6 +48,6 @@ The following examples demonstrate what triggers this rule and how to fix it.
 
 ```json
 {
-  "mcp": { "server": { "type": "local", "command": ["node"] } }
+  "mcp": { "server": { "type": "local", "command": ["node"], "cwd": "plugins/sub" } }
 }
 ```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `423` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `424` validation rules generated from `knowledge-base/rules.json`.
 `127` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -135,6 +135,7 @@ This section contains all `423` validation rules generated from `knowledge-base/
 | [CC-SET-004](./generated/cc-set-004.md) | Invalid Sandbox Path Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-005](./generated/cc-set-005.md) | Invalid parentSettingsBehavior Value | MEDIUM | Claude Settings | No |
 | [CC-SET-006](./generated/cc-set-006.md) | Non-boolean disableBundledSkills Setting | MEDIUM | Claude Settings | No |
+| [CC-SET-007](./generated/cc-set-007.md) | Non-boolean enforceAvailableModels Setting | MEDIUM | Claude Settings | No |
 | [CDX-000](./generated/cdx-000.md) | TOML Parse Error | HIGH | Codex CLI | No |
 | [CDX-001](./generated/cdx-001.md) | Invalid Approval Mode | HIGH | Codex CLI | Yes (unsafe) |
 | [CDX-002](./generated/cdx-002.md) | Invalid Full Auto Error Mode | HIGH | Codex CLI | Yes (unsafe) |
@@ -397,7 +398,7 @@ This section contains all `423` validation rules generated from `knowledge-base/
 | [OC-CFG-004](./generated/oc-cfg-004.md) | Invalid Default Agent | MEDIUM | OpenCode | No |
 | [OC-CFG-005](./generated/oc-cfg-005.md) | Hardcoded API Key | HIGH | OpenCode | No |
 | [OC-CFG-006](./generated/oc-cfg-006.md) | Invalid MCP Server Structure | HIGH | OpenCode | No |
-| [OC-CFG-007](./generated/oc-cfg-007.md) | MCP Server Missing Command or URL | HIGH | OpenCode | No |
+| [OC-CFG-007](./generated/oc-cfg-007.md) | Invalid MCP Server Command, URL, or cwd | HIGH | OpenCode | No |
 | [OC-AG-001](./generated/oc-ag-001.md) | Invalid Agent Mode Value | HIGH | OpenCode | No |
 | [OC-AG-002](./generated/oc-ag-002.md) | Invalid Color Format | HIGH | OpenCode | No |
 | [OC-AG-003](./generated/oc-ag-003.md) | Temperature Out of Range | HIGH | OpenCode | No |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 423,
+  "totalRules": 424,
   "categoryCount": 40,
   "autofixCount": 127,
   "uniqueTools": [


### PR DESCRIPTION
## Summary
- Add CC-SET-007 for Claude Code enforceAvailableModels boolean validation and generated docs
- Accept Claude Agent parameter-scoped tool syntax and refresh Codex rust-v0.140.0 config coverage
- Validate OpenCode local MCP cwd and bump release baselines for Claude Code, Codex, OpenCode, Cline, and Cursor

## Tests
- node scripts/sync-rule-bookkeeping.js --check
- cargo fmt
- cargo check
- cargo test -p agnix-core claude_settings
- cargo test -p agnix-core codex
- cargo test -p agnix-core opencode
- cargo test -p agnix-core test_cc_ag_009_parameter_scoped_agent_tool_valid
- cargo test -p agnix-core test_cc_ag_010_parameter_scoped_agent_tool_valid
- cargo test -p agnix-core test_cc_sk_008_parameter_scoped_agent_tool_valid
- cargo test -p agnix-cli --test rule_parity
- cargo run -p agnix-cli --bin agnix -- .
- cargo test
- cargo test --workspace

Closes #1039.
Closes #1040.
Closes #1041.
Closes #1047.
Closes #1048.