### PR TITLE
[codex] fix allowed-tools scoped matcher parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CC-SK-008 allowed-tools scoped matcher parsing** (closes #1052). `allowed-tools` tokenization now preserves scoped matchers with spaces inside parentheses, such as `Bash(git add *)`, while still supporting normal comma- and space-separated tool lists. Added regressions for the official Claude Code docs example and a comma-separated scoped matcher.
+
 ## [0.33.0] - 2026-06-16
 
 ### Added

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -50,7 +50,7 @@ struct SkillFrontmatter {
     // Claude Code accepts `allowed-tools` as a space-separated string OR a YAML
     // list; agentskills.io documents a space-separated string. Deserialize both
     // shapes (a list is joined with spaces) so a list never trips AS-016
-    // (skill parse error). Downstream tool parsing splits on whitespace/commas.
+    // (skill parse error).
     #[serde(
         rename = "allowed-tools",
         default,
@@ -83,6 +83,43 @@ static_regex!(fn reference_path_regex, "(?i)\\b(?:references?|refs)[/\\\\][^\\s)
 static_regex!(fn plain_bash_regex, r"\bBash\b");
 static_regex!(fn imperative_verb_regex, r"(?i)\b(run|execute|create|build|deploy|install|configure|update|delete|remove|add|write|read|check|test|validate|ensure|make|use|call|invoke|start|stop|send|fetch|generate|implement|fix|analyze|review|search|find|move|copy|replace|push|pull|commit|clean|format|lint|parse|process|handle|prepare|download|upload|export|import|open|save|load|connect|verify|apply|enable|disable)\b");
 static_regex!(fn indexed_arguments_regex, r"\$ARGUMENTS\[\d+\]");
+
+fn push_allowed_tool_token<'a>(
+    tokens: &mut Vec<&'a str>,
+    tools: &'a str,
+    start: usize,
+    end: usize,
+) {
+    let token = tools[start..end].trim();
+    if !token.is_empty() {
+        tokens.push(token);
+    }
+}
+
+fn split_allowed_tools(tools: &str) -> Vec<&str> {
+    let mut tokens = Vec::new();
+    let mut start = 0;
+    let mut paren_depth = 0usize;
+
+    for (idx, ch) in tools.char_indices() {
+        match ch {
+            '(' => paren_depth += 1,
+            ')' if paren_depth > 0 => paren_depth -= 1,
+            ',' if paren_depth == 0 => {
+                push_allowed_tool_token(&mut tokens, tools, start, idx);
+                start = idx + ch.len_utf8();
+            }
+            c if c.is_whitespace() && paren_depth == 0 => {
+                push_allowed_tool_token(&mut tokens, tools, start, idx);
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    push_allowed_tool_token(&mut tokens, tools, start, tools.len());
+    tokens
+}
 
 /// Valid model description for CC-SK-001 diagnostic messages
 const VALID_MODELS_DESC: &str = "sonnet, opus, haiku, inherit, or claude-*";
@@ -926,23 +963,13 @@ impl<'a> ValidationContext<'a> {
         let (allowed_tools_line, allowed_tools_col) =
             self.frontmatter_key_line_col("allowed-tools");
 
-        // Parse allowed_tools once for CC-SK-007 and CC-SK-008
-        // Supports both formats:
-        // - Comma-separated: "Bash(git:*), Read, Grep" (preferred)
-        // - Space-separated: "Read Write Grep" (legacy)
-        let tool_list: Option<Vec<&str>> = schema.allowed_tools.as_ref().map(|tools| {
-            if tools.contains(',') {
-                // Comma-separated format
-                tools
-                    .split(',')
-                    .map(|t| t.trim())
-                    .filter(|t| !t.is_empty())
-                    .collect()
-            } else {
-                // Space-separated format (legacy)
-                tools.split_whitespace().collect()
-            }
-        });
+        // Parse allowed_tools once for CC-SK-007 and CC-SK-008. Claude Code
+        // accepts comma- or space-separated entries, and scoped matchers can
+        // contain spaces inside parentheses like `Bash(git add *)`.
+        let tool_list: Option<Vec<&str>> = schema
+            .allowed_tools
+            .as_ref()
+            .map(|tools| split_allowed_tools(tools));
 
         // CC-SK-007: Unrestricted Bash warning
         if self.config.is_rule_enabled("CC-SK-007") {

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -1232,6 +1232,58 @@ Body"#;
 }
 
 #[test]
+fn test_cc_sk_008_space_separated_scoped_bash_matchers_allow_internal_spaces() {
+    let content = r#"---
+name: commit
+description: Stage and commit the current changes
+allowed-tools: Bash(git add *) Bash(git commit *) Bash(git status *)
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/commit/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics.iter().all(|d| d.rule != "CC-SK-008"),
+        "scoped Bash matchers with spaces must not trip CC-SK-008: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SK-008")
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_cc_sk_008_comma_separated_scoped_matcher_allows_internal_spaces() {
+    let content = r#"---
+name: test-skill
+description: Use when testing
+allowed-tools: Bash(just playwright-cli:*), Read
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics.iter().all(|d| d.rule != "CC-SK-008"),
+        "comma-separated scoped matchers with spaces must not trip CC-SK-008: {:?}",
+        diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SK-008")
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_cc_sk_008_parameter_scoped_agent_tool_valid() {
     let content = r#"---
 name: test-skill


### PR DESCRIPTION
## Summary

- Fix CC-SK-008 tokenization for scoped `allowed-tools` matchers that contain spaces inside parentheses.
- Add regressions for the official Claude Code docs example and a comma-separated scoped matcher.

Closes #1052

## Validation

- `cargo test -p agnix-core cc_sk_008`
- `cargo test -p agnix-core rules::skill`
- `cargo test -p agnix-core`
- Live CLI repro: official-docs sample now reports `No issues found`.