### PR TITLE
Validate Claude attribution session URL setting

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-06-18",
+  "last_updated": "2026-06-21",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.181",
+      "last_known_version": "v2.1.185",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 425 rules, 75+ sources, rules.json
+knowledge-base/     # 426 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-425 rules defined in `knowledge-base/rules.json` (source of truth)
+426 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.29.0 - Production-ready with full validation pipeline
-- 425 validation rules across 43 validators
+- 426 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SET-009: Non-boolean attribution.sessionUrl Setting** (closes #1060). Claude Code v2.1.183 added the `attribution.sessionUrl` toggle for omitting claude.ai session links from commits and PR descriptions created from web or Remote Control sessions. New MEDIUM `claude-settings` rule warns when `attribution.sessionUrl` is present with a non-boolean value in `settings.json`, `settings.local.json`, or `managed-settings.json`; strict `true`/`false` values, `null`, and absent keys are accepted. Rule count 425 -> 426.
+
 ## [0.33.2] - 2026-06-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 425 rules, 75+ sources, rules.json
+knowledge-base/     # 426 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-425 rules defined in `knowledge-base/rules.json` (source of truth)
+426 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.29.0 - Production-ready with full validation pipeline
-- 425 validation rules across 43 validators
+- 426 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>425 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>426 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 425 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 426 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -1193,6 +1193,11 @@ rules:
       sandbox opt-in as a strict true/false toggle
     suggestion: Set sandbox.allowAppleEvents to an unquoted true or false, or remove it to keep Apple Events blocked in the
       macOS sandbox.
+  cc_set_009:
+    message: attribution.sessionUrl must be a boolean when present (got %{actual}); Claude Code 2.1.183+ documents this
+      attribution toggle as a strict true/false setting
+    suggestion: Set attribution.sessionUrl to an unquoted true or false. Use false to omit claude.ai session links from
+      commits and PR descriptions created from web or Remote Control sessions.
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -717,6 +717,11 @@ rules:
       documenta esta opcion de sandbox como un interruptor true/false estricto
     suggestion: Establece sandbox.allowAppleEvents en true o false sin comillas, o eliminalo para mantener Apple Events
       bloqueado en el sandbox de macOS.
+  cc_set_009:
+    message: attribution.sessionUrl debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.183+
+      documenta esta atribucion como una configuracion true/false estricta
+    suggestion: Establece attribution.sessionUrl en true o false sin comillas. Usa false para omitir enlaces de sesion
+      claude.ai en commits y descripciones de PR creados desde sesiones web o Remote Control.
 
 
 # ===========================================================================

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -683,6 +683,9 @@ rules:
   cc_set_008:
     message: sandbox.allowAppleEvents 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.181+ 将该 sandbox 选项记录为严格的 true/false 开关
     suggestion: 将 sandbox.allowAppleEvents 设置为不带引号的 true 或 false，或移除此字段以让 macOS sandbox 继续阻止 Apple Events。
+  cc_set_009:
+    message: attribution.sessionUrl 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.183+ 将该归因选项记录为严格的 true/false 设置
+    suggestion: 将 attribution.sessionUrl 设置为不带引号的 true 或 false。使用 false 可在 Web 或 Remote Control 会话创建的 commit 和 PR 描述中省略 claude.ai 会话链接。
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -1193,6 +1193,11 @@ rules:
       sandbox opt-in as a strict true/false toggle
     suggestion: Set sandbox.allowAppleEvents to an unquoted true or false, or remove it to keep Apple Events blocked in the
       macOS sandbox.
+  cc_set_009:
+    message: attribution.sessionUrl must be a boolean when present (got %{actual}); Claude Code 2.1.183+ documents this
+      attribution toggle as a strict true/false setting
+    suggestion: Set attribution.sessionUrl to an unquoted true or false. Use false to omit claude.ai session links from
+      commits and PR descriptions created from web or Remote Control sessions.
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -717,6 +717,11 @@ rules:
       documenta esta opcion de sandbox como un interruptor true/false estricto
     suggestion: Establece sandbox.allowAppleEvents en true o false sin comillas, o eliminalo para mantener Apple Events
       bloqueado en el sandbox de macOS.
+  cc_set_009:
+    message: attribution.sessionUrl debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.183+
+      documenta esta atribucion como una configuracion true/false estricta
+    suggestion: Establece attribution.sessionUrl en true o false sin comillas. Usa false para omitir enlaces de sesion
+      claude.ai en commits y descripciones de PR creados desde sesiones web o Remote Control.
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -683,6 +683,9 @@ rules:
   cc_set_008:
     message: sandbox.allowAppleEvents 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.181+ 将该 sandbox 选项记录为严格的 true/false 开关
     suggestion: 将 sandbox.allowAppleEvents 设置为不带引号的 true 或 false，或移除此字段以让 macOS sandbox 继续阻止 Apple Events。
+  cc_set_009:
+    message: attribution.sessionUrl 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.183+ 将该归因选项记录为严格的 true/false 设置
+    suggestion: 将 attribution.sessionUrl 设置为不带引号的 true 或 false。使用 false 可在 Web 或 Remote Control 会话创建的 commit 和 PR 描述中省略 claude.ai 会话链接。
 
 
 # ===========================================================================

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -13,6 +13,7 @@
 //! - `disableBundledSkills` boolean check (CC-SET-006, added in Claude Code v2.1.169).
 //! - `enforceAvailableModels` boolean check (CC-SET-007, added in Claude Code v2.1.175).
 //! - `sandbox.allowAppleEvents` boolean check (CC-SET-008, added in Claude Code v2.1.181).
+//! - `attribution.sessionUrl` boolean check (CC-SET-009, added in Claude Code v2.1.183).
 //!
 //! Runs on FileType::Hooks (which covers `.claude/settings.json` -
 //! see `file_types/detection.rs`). Skips non-Claude Code settings paths
@@ -35,6 +36,7 @@ const RULE_IDS: &[&str] = &[
     "CC-SET-006",
     "CC-SET-007",
     "CC-SET-008",
+    "CC-SET-009",
 ];
 
 /// Allowed values for `worktree.baseRef` per Claude Code v2.1.133 release notes.
@@ -109,6 +111,10 @@ impl Validator for ClaudeSettingsValidator {
 
         if config.is_rule_enabled("CC-SET-008") {
             validate_sandbox_allow_apple_events(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-009") {
+            validate_attribution_session_url(path, content, &value, &mut diagnostics);
         }
 
         diagnostics
@@ -607,6 +613,47 @@ fn validate_sandbox_allow_apple_events(
             t!("rules.cc_set_008.message", actual = actual),
         )
         .with_suggestion(t!("rules.cc_set_008.suggestion")),
+    );
+}
+
+/// CC-SET-009: Validate `attribution.sessionUrl`. Claude Code v2.1.183
+/// added this nested attribution toggle so web and Remote Control sessions
+/// can omit the claude.ai session link from commits and PR descriptions. The
+/// setting is a strict boolean: `true` keeps the default link, `false` omits it.
+///
+/// Missing field is fine: session URLs remain enabled by default. `null` is
+/// treated as "field absent" by JSON convention, consistent with the other
+/// CC-SET boolean rules. Non-object `attribution` values are ignored by this
+/// rule to avoid conflating container-shape errors with the specific boolean
+/// opt-in.
+fn validate_attribution_session_url(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(field_value) = value.pointer("/attribution/sessionUrl") else {
+        return;
+    };
+
+    if field_value.is_boolean() || field_value.is_null() {
+        return;
+    }
+
+    let actual = describe_json_type(field_value);
+    let line = find_key_line(content, "sessionUrl")
+        .or_else(|| find_key_line(content, "attribution"))
+        .unwrap_or(1);
+
+    diagnostics.push(
+        Diagnostic::warning(
+            path.to_path_buf(),
+            line,
+            0,
+            "CC-SET-009",
+            t!("rules.cc_set_009.message", actual = actual),
+        )
+        .with_suggestion(t!("rules.cc_set_009.suggestion")),
     );
 }
 
@@ -1687,5 +1734,101 @@ mod tests {
         let diagnostics = validate(content);
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-004"));
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-008"));
+    }
+
+    // ===== CC-SET-009: attribution.sessionUrl =====
+
+    #[test]
+    fn test_attribution_session_url_absent_is_fine() {
+        let content =
+            r#"{"attribution": {"commit": "Co-authored-by: Claude <noreply@anthropic.com>"}}"#;
+        assert!(validate(content).iter().all(|d| d.rule != "CC-SET-009"));
+    }
+
+    #[test]
+    fn test_attribution_session_url_boolean_values_are_fine() {
+        assert!(
+            validate(r#"{"attribution": {"sessionUrl": true}}"#)
+                .iter()
+                .all(|d| d.rule != "CC-SET-009")
+        );
+        assert!(
+            validate(r#"{"attribution": {"sessionUrl": false}}"#)
+                .iter()
+                .all(|d| d.rule != "CC-SET-009")
+        );
+    }
+
+    #[test]
+    fn test_attribution_session_url_null_is_not_flagged() {
+        let content = r#"{"attribution": {"sessionUrl": null}}"#;
+        assert!(validate(content).iter().all(|d| d.rule != "CC-SET-009"));
+    }
+
+    #[test]
+    fn test_attribution_session_url_quoted_string_flags() {
+        let content = r#"{"attribution": {"sessionUrl": "false"}}"#;
+        let diagnostics = validate(content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-009")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].level, crate::diagnostics::DiagnosticLevel::Warning);
+        assert!(hits[0].message.to_lowercase().contains("boolean"));
+        assert!(hits[0].message.to_lowercase().contains("string"));
+    }
+
+    #[test]
+    fn test_attribution_session_url_number_flags() {
+        let content = r#"{"attribution": {"sessionUrl": 0}}"#;
+        let diagnostics = validate(content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-009")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].message.to_lowercase().contains("number"));
+    }
+
+    #[test]
+    fn test_attribution_session_url_runs_on_managed_settings() {
+        let content = r#"{"attribution": {"sessionUrl": "false"}}"#;
+        let diagnostics = validate_at(".claude/managed-settings.json", content);
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-009"));
+    }
+
+    #[test]
+    fn test_attribution_session_url_line_points_at_key() {
+        let content = "{\n  \"attribution\": {\n    \"sessionUrl\": \"false\"\n  }\n}";
+        let diagnostics = validate(content);
+        let hit = diagnostics
+            .iter()
+            .find(|d| d.rule == "CC-SET-009")
+            .expect("CC-SET-009 diagnostic");
+        assert_eq!(hit.line, 3);
+    }
+
+    #[test]
+    fn test_attribution_session_url_can_be_disabled() {
+        let mut builder = LintConfig::builder();
+        builder.disable_rule("CC-SET-009");
+        let config = builder.build().unwrap();
+        let validator = ClaudeSettingsValidator;
+        let path = PathBuf::from(".claude/settings.json");
+        let content = r#"{"attribution": {"sessionUrl": "false"}}"#;
+        let diagnostics = validator.validate(&path, content, &config);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-009"));
+    }
+
+    #[test]
+    fn test_attribution_session_url_coexists_with_other_cc_set_rules() {
+        let content = r#"{
+            "sandbox": {"allowAppleEvents": "true"},
+            "attribution": {"sessionUrl": "false"}
+        }"#;
+        let diagnostics = validate(content);
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-008"));
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-009"));
     }
 }

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -1193,6 +1193,11 @@ rules:
       sandbox opt-in as a strict true/false toggle
     suggestion: Set sandbox.allowAppleEvents to an unquoted true or false, or remove it to keep Apple Events blocked in the
       macOS sandbox.
+  cc_set_009:
+    message: attribution.sessionUrl must be a boolean when present (got %{actual}); Claude Code 2.1.183+ documents this
+      attribution toggle as a strict true/false setting
+    suggestion: Set attribution.sessionUrl to an unquoted true or false. Use false to omit claude.ai session links from
+      commits and PR descriptions created from web or Remote Control sessions.
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -717,6 +717,11 @@ rules:
       documenta esta opcion de sandbox como un interruptor true/false estricto
     suggestion: Establece sandbox.allowAppleEvents en true o false sin comillas, o eliminalo para mantener Apple Events
       bloqueado en el sandbox de macOS.
+  cc_set_009:
+    message: attribution.sessionUrl debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.183+
+      documenta esta atribucion como una configuracion true/false estricta
+    suggestion: Establece attribution.sessionUrl en true o false sin comillas. Usa false para omitir enlaces de sesion
+      claude.ai en commits y descripciones de PR creados desde sesiones web o Remote Control.
 
 
 # ===========================================================================

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -683,6 +683,9 @@ rules:
   cc_set_008:
     message: sandbox.allowAppleEvents 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.181+ 将该 sandbox 选项记录为严格的 true/false 开关
     suggestion: 将 sandbox.allowAppleEvents 设置为不带引号的 true 或 false，或移除此字段以让 macOS sandbox 继续阻止 Apple Events。
+  cc_set_009:
+    message: attribution.sessionUrl 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.183+ 将该归因选项记录为严格的 true/false 设置
+    suggestion: 将 attribution.sessionUrl 设置为不带引号的 true 或 false。使用 false 可在 Web 或 Remote Control 会话创建的 commit 和 PR 描述中省略 claude.ai 会话链接。
 
 
 # ===========================================================================

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 425,
-  "last_updated": "2026-06-18",
+  "total_rules": 426,
+  "last_updated": "2026-06-21",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3692,6 +3692,35 @@
       },
       "good_example": "{\n  \"sandbox\": {\"allowAppleEvents\": true}\n}",
       "bad_example": "{\n  \"sandbox\": {\"allowAppleEvents\": \"true\"}\n}"
+    },
+    {
+      "id": "CC-SET-009",
+      "name": "Non-boolean attribution.sessionUrl Setting",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.183",
+          "https://code.claude.com/docs/en/settings"
+        ],
+        "verified_on": "2026-06-21",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.183"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"attribution\": {\"sessionUrl\": false}\n}",
+      "bad_example": "{\n  \"attribution\": {\"sessionUrl\": \"false\"}\n}"
     },
     {
       "id": "CDX-000",
@@ -11938,7 +11967,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 8,
+      "count": 9,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 425 validation rules across 40 categories, sourced from 75+ references
+> 426 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 425 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 426 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (425 rules)
+├── VALIDATION-RULES.md             # Master validation reference (426 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **425 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **426 rules** |
 
 
 ### Validation Rules by Category
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **425** | **213** | **180** | **28** | **127** |
+| **TOTAL** | **426** | **213** | **180** | **28** | **127** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 425 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 426 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     425 rules
+Validation Rules:     426 rules
 Auto-Fixable Rules:   96 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 425 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 426 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-06-11
+**Last Updated**: 2026-06-21
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -16,7 +16,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-18 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-21 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
 | Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-18 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
 | OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-16 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-06-18 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -401,6 +401,13 @@ Rules with an empty `applies_to` object (`{}`) apply universally.
 **Fix**: Manual - set `sandbox.allowAppleEvents` to an unquoted `true` or `false`, or remove it to keep Apple Events blocked.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.181 (added `sandbox.allowAppleEvents`), code.claude.com/docs/en/settings
 
+<a id="cc-set-009"></a>
+### CC-SET-009 [MEDIUM] Non-boolean attribution.sessionUrl Setting
+**Requirement**: `attribution.sessionUrl` in `.claude/settings.json` / `.local.json` / `managed-settings.json` MUST be a boolean when present (Claude Code 2.1.183+). `true` keeps the default claude.ai session link in commits and PR descriptions created from web or Remote Control sessions; `false` omits it. Only strict `true`/`false` is documented.
+**Detection**: Parse settings.json; walk `attribution.sessionUrl`; flag (warning) non-boolean types (string, number, array, object). `null` values and absent keys are not flagged. Non-object `attribution` values are ignored by this rule to avoid conflating container shape errors with the specific boolean toggle.
+**Fix**: Manual - set `attribution.sessionUrl` to an unquoted `true` or `false`.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.183 (added `attribution.sessionUrl`), code.claude.com/docs/en/settings
+
 ---
 
 ## PER-CLIENT SKILL RULES
@@ -3473,8 +3480,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 425 validation rules across 40 categories
+**Total Coverage**: 426 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 213 HIGH, 184 MEDIUM, 28 LOW
+**Certainty**: 213 HIGH, 185 MEDIUM, 28 LOW
 **Auto-Fixable**: 127 rules (30%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 425,
-  "last_updated": "2026-06-18",
+  "total_rules": 426,
+  "last_updated": "2026-06-21",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3692,6 +3692,35 @@
       },
       "good_example": "{\n  \"sandbox\": {\"allowAppleEvents\": true}\n}",
       "bad_example": "{\n  \"sandbox\": {\"allowAppleEvents\": \"true\"}\n}"
+    },
+    {
+      "id": "CC-SET-009",
+      "name": "Non-boolean attribution.sessionUrl Setting",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.183",
+          "https://code.claude.com/docs/en/settings"
+        ],
+        "verified_on": "2026-06-21",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.183"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"attribution\": {\"sessionUrl\": false}\n}",
+      "bad_example": "{\n  \"attribution\": {\"sessionUrl\": \"false\"}\n}"
     },
     {
       "id": "CDX-000",
@@ -11938,7 +11967,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 8,
+      "count": 9,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1193,6 +1193,11 @@ rules:
       sandbox opt-in as a strict true/false toggle
     suggestion: Set sandbox.allowAppleEvents to an unquoted true or false, or remove it to keep Apple Events blocked in the
       macOS sandbox.
+  cc_set_009:
+    message: attribution.sessionUrl must be a boolean when present (got %{actual}); Claude Code 2.1.183+ documents this
+      attribution toggle as a strict true/false setting
+    suggestion: Set attribution.sessionUrl to an unquoted true or false. Use false to omit claude.ai session links from
+      commits and PR descriptions created from web or Remote Control sessions.
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -717,6 +717,11 @@ rules:
       documenta esta opcion de sandbox como un interruptor true/false estricto
     suggestion: Establece sandbox.allowAppleEvents en true o false sin comillas, o eliminalo para mantener Apple Events
       bloqueado en el sandbox de macOS.
+  cc_set_009:
+    message: attribution.sessionUrl debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.183+
+      documenta esta atribucion como una configuracion true/false estricta
+    suggestion: Establece attribution.sessionUrl en true o false sin comillas. Usa false para omitir enlaces de sesion
+      claude.ai en commits y descripciones de PR creados desde sesiones web o Remote Control.
 
 
 # ===========================================================================

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -683,6 +683,9 @@ rules:
   cc_set_008:
     message: sandbox.allowAppleEvents 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.181+ 将该 sandbox 选项记录为严格的 true/false 开关
     suggestion: 将 sandbox.allowAppleEvents 设置为不带引号的 true 或 false，或移除此字段以让 macOS sandbox 继续阻止 Apple Events。
+  cc_set_009:
+    message: attribution.sessionUrl 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.183+ 将该归因选项记录为严格的 true/false 设置
+    suggestion: 将 attribution.sessionUrl 设置为不带引号的 true 或 false。使用 false 可在 Web 或 Remote Control 会话创建的 commit 和 PR 描述中省略 claude.ai 会话链接。
 
 
 # ===========================================================================

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.33.2",
-  "description": "Lint agent configurations before they break your workflow. 425 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 426 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "[email protected]",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 425 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 426 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 425 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 426 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 425 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 426 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/rules/generated/cc-set-009.md
+++ b/website/docs/rules/generated/cc-set-009.md
@@ -1,0 +1,53 @@
+---
+id: cc-set-009
+title: "CC-SET-009: Non-boolean attribution.sessionUrl Setting"
+sidebar_label: "CC-SET-009"
+description: "agnix rule CC-SET-009 checks for non-boolean attribution.sessionurl setting in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-009", "non-boolean attribution.sessionurl setting", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-009`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-06-21`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.183`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.183
+- https://code.claude.com/docs/en/settings
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "attribution": {"sessionUrl": "false"}
+}
+```
+
+### Valid
+
+```json
+{
+  "attribution": {"sessionUrl": false}
+}
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `425` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `426` validation rules generated from `knowledge-base/rules.json`.
 `127` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -137,6 +137,7 @@ This section contains all `425` validation rules generated from `knowledge-base/
 | [CC-SET-006](./generated/cc-set-006.md) | Non-boolean disableBundledSkills Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-007](./generated/cc-set-007.md) | Non-boolean enforceAvailableModels Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-008](./generated/cc-set-008.md) | Non-boolean sandbox.allowAppleEvents Setting | MEDIUM | Claude Settings | No |
+| [CC-SET-009](./generated/cc-set-009.md) | Non-boolean attribution.sessionUrl Setting | MEDIUM | Claude Settings | No |
 | [CDX-000](./generated/cdx-000.md) | TOML Parse Error | HIGH | Codex CLI | No |
 | [CDX-001](./generated/cdx-001.md) | Invalid Approval Mode | HIGH | Codex CLI | Yes (unsafe) |
 | [CDX-002](./generated/cdx-002.md) | Invalid Full Auto Error Mode | HIGH | Codex CLI | Yes (unsafe) |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 425,
+  "totalRules": 426,
   "categoryCount": 40,
   "autofixCount": 127,
   "uniqueTools": [


### PR DESCRIPTION
## Summary
- add `CC-SET-009` for Claude Code `attribution.sessionUrl`, requiring a boolean when present
- document the new rule in `rules.json`, `VALIDATION-RULES.md`, locales, SARIF/generated rules data, and website rule docs
- advance the Claude Code release baseline to `v2.1.185` after confirming `v2.1.183` added this setting and later releases did not add another validation surface

## Sources
- https://github.com/anthropics/claude-code/releases/tag/v2.1.183
- https://github.com/anthropics/claude-code/releases/tag/v2.1.185
- https://code.claude.com/docs/en/settings

## Tests
- `bash scripts/check-locale-sync.sh`
- `node scripts/sync-rule-bookkeeping.js --check`
- `cargo test -p agnix-core attribution_session_url --lib`
- `cargo test -p agnix-core test_every_rule_locale_key_referenced_in_source_resolves --lib`
- `cargo test -p agnix-cli --test rule_parity`
- `cargo test -p agnix-cli --test docs_website_parity`
- `cargo run -p agnix-cli --bin agnix -- --format json <tmp-project-with-quoted-sessionUrl>` emitted `CC-SET-009`
- `cargo run -p agnix-cli --bin agnix -- --format json <tmp-project-with-boolean-sessionUrl>` emitted no diagnostics
- `cargo test`
- `cargo test --workspace`

Closes #1060
