### PR TITLE
Bump Cursor release baseline to 3.8.11

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -237,7 +237,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.7.42",
+      "last_known_version": "3.8.11",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **CC-SET-009: Non-boolean attribution.sessionUrl Setting** (closes #1060). Claude Code v2.1.183 added the `attribution.sessionUrl` toggle for omitting claude.ai session links from commits and PR descriptions created from web or Remote Control sessions. New MEDIUM `claude-settings` rule warns when `attribution.sessionUrl` is present with a non-boolean value in `settings.json`, `settings.local.json`, or `managed-settings.json`; strict `true`/`false` values, `null`, and absent keys are accepted. Rule count 425 -> 426.
 
+### Changed
+- **Tool baseline**: `cursor` bumped `3.7.42` -> `3.8.11` (closes #1061). The stable update endpoint still reports `3.8.11`; Cursor 3.8 changelog entries are Automations, Slack/GitHub triggers, cloud-agent computer use, templates, and UI behavior outside agnix's validated Cursor surfaces. No validator, rule, `ToolVersions`, or `SpecRevisions` change required. `.github/tool-release-baselines.json` and `knowledge-base/RESEARCH-TRACKING.md` updated.
+
 ## [0.33.2] - 2026-06-18
 
 ### Added

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -27,7 +27,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-04-22 | COP |
 | Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-06-16 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-06-16 | CUR |
+| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-06-21 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 


### PR DESCRIPTION
## Summary
- bump the Cursor release watcher baseline from `3.7.42` to `3.8.11`
- update Cursor research tracking review date to `2026-06-21`
- document the triage in the changelog

## Triage
- The stable update endpoint still reports `3.8.11`.
- Cursor 3.8 changelog content covers Automations, Slack/GitHub triggers, cloud-agent computer use, templates, and UI behavior.
- Those changes do not alter agnix's validated Cursor surfaces: `.cursor/rules/**/*.{md,mdc}`, `.cursorrules`, `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, or `.cursor/mcp.json`.
- No validator, rule, `ToolVersions`, or `SpecRevisions` change required.

## Sources
- https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable
- https://cursor.com/changelog

## Tests
- `jq -e '.tools.cursor.last_known_version == "3.8.11"' .github/tool-release-baselines.json`
- `node scripts/sync-rule-bookkeeping.js --check`
- `cargo test -p agnix-cli --test research_docs`
- `cargo test --workspace`

Closes #1061
