### PR TITLE
docs: update rule count for v0.34.0

### DIFF
--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -283,6 +283,6 @@ cargo install agnix-lsp
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for frontmatter fields
-- 405 validation rules
+- 426 validation rules
 - Status bar indicator (VS Code)
 - Syntax highlighting for SKILL.md (VS Code)

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 405 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 426 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -71,6 +71,6 @@ agnix --target copilot .
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 405 rules
+- [Rules Reference](./rules/index.md) - browse all 426 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 405 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 426 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 405 rules derived from official specs and real-world testing
+- **Validates** configuration files against 426 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 405 validation rules
+- [Rules Reference](./rules/index.md) - browse all 426 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics

--- a/website/versioned_docs/version-0.34.0/contributing.md
+++ b/website/versioned_docs/version-0.34.0/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 405 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 426 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/versioned_docs/version-0.34.0/getting-started.md
+++ b/website/versioned_docs/version-0.34.0/getting-started.md
@@ -71,6 +71,6 @@ agnix --target copilot .
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 405 rules
+- [Rules Reference](./rules/index.md) - browse all 426 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/versioned_docs/version-0.34.0/intro.md
+++ b/website/versioned_docs/version-0.34.0/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 405 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 426 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 405 rules derived from official specs and real-world testing
+- **Validates** configuration files against 426 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 405 validation rules
+- [Rules Reference](./rules/index.md) - browse all 426 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics


### PR DESCRIPTION
## Summary
- update latest website docs from 405 to 426 rules
- update the v0.34.0 versioned docs snapshot to match the release
- update editor setup docs rule count

## Checks
- node scripts/sync-rule-bookkeeping.js --check
- git diff --check
- rg "405 rules|405 validation|all 405" docs website/docs website/versioned_docs/version-0.34.0 README.md knowledge-base

Note: local `npm --prefix website run build:site:ci` hit Node heap OOM even with `NODE_OPTIONS=--max-old-space-size=8192`; relying on CI docs build for the full Docusaurus validation.