### PR TITLE
[codex] accept plugin-prefixed skill names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **AS-004/AS-017 plugin-prefixed skill names**. Skills named with the standard `plugin:skill-name` form now validate each segment independently and compare the parent directory against only the local skill-name segment, eliminating false positives for bundled plugin skills while preserving existing bare-name checks.
+
 ## [0.34.0] - 2026-06-21
 
 ### Added

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -12,9 +12,9 @@ rules:
     message: Skill frontmatter is missing required 'description' field
     suggestion: 'Add ''description: Use when...'' to frontmatter'
   as_004:
-    message: Name '%{name}' must be 1-64 characters of lowercase letters, digits, and hyphens
-    suggestion: Lowercase and trim the name, replace spaces and '_' with '-', collapse multiple '-' into one, remove invalid
-      characters, and truncate to 64 characters
+    message: Name '%{name}' must be 1-64 characters per segment using lowercase letters, digits, and hyphens, as a bare skill name or plugin:skill-name
+    suggestion: Lowercase and trim each name segment, replace spaces and '_' with '-', collapse multiple '-' into one, remove invalid
+      characters, and truncate each segment to 64 characters
     fix: 'Convert name to kebab-case: ''%{name}'''
   as_005:
     message: Name '%{name}' cannot start or end with hyphen

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -12,9 +12,9 @@ rules:
     message: Al frontmatter del skill le falta el campo requerido 'description'
     suggestion: 'Agrega ''description: Usar cuando...'' al frontmatter'
   as_004:
-    message: El nombre '%{name}' debe tener 1-64 caracteres de letras minúsculas, dígitos y guiones
-    suggestion: Convierte a minúsculas, recorta el nombre, reemplaza espacios y '_' con '-', colapsa multiples '-' en uno,
-      elimina caracteres inválidos y trunca a 64 caracteres
+    message: El nombre '%{name}' debe tener 1-64 caracteres por segmento, con letras minúsculas, dígitos y guiones, como skill-name o plugin:skill-name
+    suggestion: Convierte a minúsculas y recorta cada segmento del nombre, reemplaza espacios y '_' con '-', colapsa multiples '-' en uno,
+      elimina caracteres inválidos y trunca cada segmento a 64 caracteres
     fix: 'Convertir nombre a kebab-case: ''%{name}'''
   as_005:
     message: El nombre '%{name}' no puede comenzar ni terminar con guion

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -12,8 +12,8 @@ rules:
     message: Skill frontmatter 缺少必需的 'description' 字段
     suggestion: '在 frontmatter 中添加 ''description: Use when...'''
   as_004:
-    message: 名称 '%{name}' 必须是1-64个字符，包含小写字母、数字和连字符
-    suggestion: 转为小写并修剪名称，将空格和 '_' 替换为 '-'，合并多个 '-'，删除无效字符，并截断为64个字符
+    message: 名称 '%{name}' 的每个段必须是1-64个小写字母、数字和连字符，可为 skill-name 或 plugin:skill-name
+    suggestion: 转为小写并修剪每个名称段，将空格和 '_' 替换为 '-'，合并多个 '-'，删除无效字符，并将每个段截断为64个字符
     fix: '将名称转换为 kebab-case: ''%{name}'''
   as_005:
     message: 名称 '%{name}' 不能以连字符开头或结尾

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -12,9 +12,9 @@ rules:
     message: Skill frontmatter is missing required 'description' field
     suggestion: 'Add ''description: Use when...'' to frontmatter'
   as_004:
-    message: Name '%{name}' must be 1-64 characters of lowercase letters, digits, and hyphens
-    suggestion: Lowercase and trim the name, replace spaces and '_' with '-', collapse multiple '-' into one, remove invalid
-      characters, and truncate to 64 characters
+    message: Name '%{name}' must be 1-64 characters per segment using lowercase letters, digits, and hyphens, as a bare skill name or plugin:skill-name
+    suggestion: Lowercase and trim each name segment, replace spaces and '_' with '-', collapse multiple '-' into one, remove invalid
+      characters, and truncate each segment to 64 characters
     fix: 'Convert name to kebab-case: ''%{name}'''
   as_005:
     message: Name '%{name}' cannot start or end with hyphen

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -12,9 +12,9 @@ rules:
     message: Al frontmatter del skill le falta el campo requerido 'description'
     suggestion: 'Agrega ''description: Usar cuando...'' al frontmatter'
   as_004:
-    message: El nombre '%{name}' debe tener 1-64 caracteres de letras minúsculas, dígitos y guiones
-    suggestion: Convierte a minúsculas, recorta el nombre, reemplaza espacios y '_' con '-', colapsa multiples '-' en uno,
-      elimina caracteres inválidos y trunca a 64 caracteres
+    message: El nombre '%{name}' debe tener 1-64 caracteres por segmento, con letras minúsculas, dígitos y guiones, como skill-name o plugin:skill-name
+    suggestion: Convierte a minúsculas y recorta cada segmento del nombre, reemplaza espacios y '_' con '-', colapsa multiples '-' en uno,
+      elimina caracteres inválidos y trunca cada segmento a 64 caracteres
     fix: 'Convertir nombre a kebab-case: ''%{name}'''
   as_005:
     message: El nombre '%{name}' no puede comenzar ni terminar con guion

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -12,8 +12,8 @@ rules:
     message: Skill frontmatter 缺少必需的 'description' 字段
     suggestion: '在 frontmatter 中添加 ''description: Use when...'''
   as_004:
-    message: 名称 '%{name}' 必须是1-64个字符，包含小写字母、数字和连字符
-    suggestion: 转为小写并修剪名称，将空格和 '_' 替换为 '-'，合并多个 '-'，删除无效字符，并截断为64个字符
+    message: 名称 '%{name}' 的每个段必须是1-64个小写字母、数字和连字符，可为 skill-name 或 plugin:skill-name
+    suggestion: 转为小写并修剪每个名称段，将空格和 '_' 替换为 '-'，合并多个 '-'，删除无效字符，并将每个段截断为64个字符
     fix: '将名称转换为 kebab-case: ''%{name}'''
   as_005:
     message: 名称 '%{name}' 不能以连字符开头或结尾

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -8,7 +8,10 @@ use crate::{
     rules::per_client_skill::{SkillClient, claude_skill_rules_apply, resolve_skill_client},
     rules::{Validator, ValidatorMetadata},
     schemas::hooks::HooksSchema,
-    schemas::skill::{SkillSchema, VALID_EFFORT_LEVELS, VALID_SHELLS, is_valid_skill_model},
+    schemas::skill::{
+        SkillSchema, VALID_EFFORT_LEVELS, VALID_SHELLS, is_valid_skill_model,
+        parse_skill_name_parts,
+    },
     validation::is_valid_mcp_tool_format,
 };
 use regex::Regex;
@@ -83,6 +86,91 @@ static_regex!(fn reference_path_regex, "(?i)\\b(?:references?|refs)[/\\\\][^\\s)
 static_regex!(fn plain_bash_regex, r"\bBash\b");
 static_regex!(fn imperative_verb_regex, r"(?i)\b(run|execute|create|build|deploy|install|configure|update|delete|remove|add|write|read|check|test|validate|ensure|make|use|call|invoke|start|stop|send|fetch|generate|implement|fix|analyze|review|search|find|move|copy|replace|push|pull|commit|clean|format|lint|parse|process|handle|prepare|download|upload|export|import|open|save|load|connect|verify|apply|enable|disable)\b");
 static_regex!(fn indexed_arguments_regex, r"\$ARGUMENTS\[\d+\]");
+
+fn is_valid_name_segment(segment: &str) -> bool {
+    segment.len() <= 64 && name_format_regex().is_match(segment)
+}
+
+fn is_valid_skill_name(name: &str) -> bool {
+    let Some(parts) = parse_skill_name_parts(name) else {
+        return false;
+    };
+
+    parts.plugin.is_none_or(is_valid_name_segment) && is_valid_name_segment(parts.skill)
+}
+
+fn skill_name_has_edge_hyphen(name: &str) -> bool {
+    let Some(parts) = parse_skill_name_parts(name) else {
+        return name.starts_with('-') || name.ends_with('-');
+    };
+
+    parts
+        .plugin
+        .is_some_and(|plugin| plugin.starts_with('-') || plugin.ends_with('-'))
+        || parts.skill.starts_with('-')
+        || parts.skill.ends_with('-')
+}
+
+fn skill_name_has_consecutive_hyphen(name: &str) -> bool {
+    let Some(parts) = parse_skill_name_parts(name) else {
+        return name.contains("--");
+    };
+
+    parts.plugin.is_some_and(|plugin| plugin.contains("--")) || parts.skill.contains("--")
+}
+
+fn fixed_skill_name(name: &str) -> String {
+    let Some(parts) = parse_skill_name_parts(name) else {
+        return convert_to_kebab_case(name);
+    };
+
+    match parts.plugin {
+        Some(plugin) => {
+            let fixed_plugin = convert_to_kebab_case(plugin);
+            let fixed_skill = convert_to_kebab_case(parts.skill);
+            if fixed_plugin.is_empty() || fixed_skill.is_empty() {
+                String::new()
+            } else {
+                format!("{}:{}", fixed_plugin, fixed_skill)
+            }
+        }
+        None => convert_to_kebab_case(parts.skill),
+    }
+}
+
+fn trim_skill_name_edge_hyphens(name: &str) -> String {
+    let Some(parts) = parse_skill_name_parts(name) else {
+        return name.trim_matches('-').to_string();
+    };
+
+    match parts.plugin {
+        Some(plugin) => format!(
+            "{}:{}",
+            plugin.trim_matches('-'),
+            parts.skill.trim_matches('-')
+        ),
+        None => parts.skill.trim_matches('-').to_string(),
+    }
+}
+
+fn collapse_skill_name_hyphens(name: &str) -> String {
+    let Some(parts) = parse_skill_name_parts(name) else {
+        return consecutive_hyphen_regex()
+            .replace_all(name, "-")
+            .to_string();
+    };
+
+    match parts.plugin {
+        Some(plugin) => format!(
+            "{}:{}",
+            consecutive_hyphen_regex().replace_all(plugin, "-"),
+            consecutive_hyphen_regex().replace_all(parts.skill, "-")
+        ),
+        None => consecutive_hyphen_regex()
+            .replace_all(parts.skill, "-")
+            .to_string(),
+    }
+}
 
 fn push_allowed_tool_token<'a>(
     tokens: &mut Vec<&'a str>,
@@ -475,9 +563,8 @@ impl<'a> ValidationContext<'a> {
 
         // AS-004: Invalid name format
         if self.config.is_rule_enabled("AS-004") {
-            let name_re = name_format_regex();
-            if name_trimmed.len() > 64 || !name_re.is_match(name_trimmed) {
-                let fixed_name = convert_to_kebab_case(name_trimmed);
+            if !is_valid_skill_name(name_trimmed) {
+                let fixed_name = fixed_skill_name(name_trimmed);
                 let mut diagnostic = Diagnostic::error(
                     self.path.to_path_buf(),
                     name_line,
@@ -488,14 +575,14 @@ impl<'a> ValidationContext<'a> {
                 .with_suggestion(t!("rules.as_004.suggestion"));
 
                 // Add auto-fix if we can find the byte range and the fixed name is valid
-                if !fixed_name.is_empty() && name_re.is_match(&fixed_name) {
+                if !fixed_name.is_empty() && is_valid_skill_name(&fixed_name) {
                     if let Some((start, end)) = self.frontmatter_value_byte_range("name") {
                         // Determine if fix is safe: only case changes are safe
                         let has_structural_changes = name_trimmed.contains('_')
                             || name_trimmed.contains(' ')
                             || name_trimmed
                                 .chars()
-                                .any(|c| !c.is_ascii_alphanumeric() && c != '-');
+                                .any(|c| !c.is_ascii_alphanumeric() && c != '-' && c != ':');
                         let is_case_only =
                             !has_structural_changes && name_trimmed.to_lowercase() == fixed_name;
                         let fix = Fix::replace(
@@ -514,9 +601,7 @@ impl<'a> ValidationContext<'a> {
         }
 
         // AS-005: Name cannot start or end with hyphen
-        if self.config.is_rule_enabled("AS-005")
-            && (name_trimmed.starts_with('-') || name_trimmed.ends_with('-'))
-        {
+        if self.config.is_rule_enabled("AS-005") && skill_name_has_edge_hyphen(name_trimmed) {
             let mut diagnostic = Diagnostic::error(
                 self.path.to_path_buf(),
                 name_line,
@@ -528,10 +613,10 @@ impl<'a> ValidationContext<'a> {
 
             // Safe auto-fix: trim leading/trailing hyphens.
             if let Some((start, end)) = self.frontmatter_value_byte_range("name") {
-                let fixed_name = name_trimmed.trim_matches('-').to_string();
+                let fixed_name = trim_skill_name_edge_hyphens(name_trimmed);
                 if !fixed_name.is_empty()
                     && fixed_name != name_trimmed
-                    && name_format_regex().is_match(&fixed_name)
+                    && is_valid_skill_name(&fixed_name)
                 {
                     diagnostic = diagnostic.with_fix(Fix::replace(
                         start,
@@ -547,7 +632,8 @@ impl<'a> ValidationContext<'a> {
         }
 
         // AS-006: Name cannot contain consecutive hyphens
-        if self.config.is_rule_enabled("AS-006") && name_trimmed.contains("--") {
+        if self.config.is_rule_enabled("AS-006") && skill_name_has_consecutive_hyphen(name_trimmed)
+        {
             let mut diagnostic = Diagnostic::error(
                 self.path.to_path_buf(),
                 name_line,
@@ -559,12 +645,10 @@ impl<'a> ValidationContext<'a> {
 
             // Safe auto-fix: collapse repeated hyphens.
             if let Some((start, end)) = self.frontmatter_value_byte_range("name") {
-                let fixed_name = consecutive_hyphen_regex()
-                    .replace_all(name_trimmed, "-")
-                    .to_string();
+                let fixed_name = collapse_skill_name_hyphens(name_trimmed);
                 if !fixed_name.is_empty()
                     && fixed_name != name_trimmed
-                    && name_format_regex().is_match(&fixed_name)
+                    && is_valid_skill_name(&fixed_name)
                 {
                     diagnostic = diagnostic.with_fix(Fix::replace(
                         start,
@@ -601,7 +685,11 @@ impl<'a> ValidationContext<'a> {
         };
 
         let name_trimmed = name.trim();
-        if name_trimmed.is_empty() || parent_name == name_trimmed {
+        let skill_name = parse_skill_name_parts(name_trimmed)
+            .map(|parts| parts.skill)
+            .unwrap_or(name_trimmed);
+
+        if skill_name.is_empty() || parent_name == skill_name {
             return;
         }
 

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -88,6 +88,49 @@ Body"#;
 }
 
 #[test]
+fn test_as_004_plugin_prefixed_name_format_ok() {
+    let content = r#"---
+name: build-web-apps:frontend-app-builder
+description: Use when validating plugin-prefixed skill names
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(Path::new("test.md"), content, &LintConfig::default());
+
+    assert!(!diagnostics.iter().any(|d| d.rule == "AS-004"));
+}
+
+#[test]
+fn test_as_004_plugin_prefixed_name_uses_segment_length() {
+    let content = r#"---
+name: very-long-plugin-prefix-for-packaged-skills:frontend-app-builder-with-extra-context
+description: Use when validating plugin-prefixed skill names
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(Path::new("test.md"), content, &LintConfig::default());
+
+    assert!(!diagnostics.iter().any(|d| d.rule == "AS-004"));
+}
+
+#[test]
+fn test_as_004_plugin_prefixed_invalid_skill_segment() {
+    let content = r#"---
+name: build-web-apps:Frontend_App_Builder
+description: Use when validating plugin-prefixed skill names
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(Path::new("test.md"), content, &LintConfig::default());
+
+    let as_004_errors: Vec<_> = diagnostics.iter().filter(|d| d.rule == "AS-004").collect();
+    assert_eq!(as_004_errors.len(), 1);
+}
+
+#[test]
 fn test_as_017_name_directory_mismatch() {
     let content = r#"---
 name: deploy-skill
@@ -123,6 +166,43 @@ Body"#;
 
     let as_017_errors: Vec<_> = diagnostics.iter().filter(|d| d.rule == "AS-017").collect();
     assert_eq!(as_017_errors.len(), 0);
+}
+
+#[test]
+fn test_as_017_plugin_prefixed_name_matches_local_directory() {
+    let content = r#"---
+name: enhance:code-review
+description: Use when validating directory name matching
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new("code-review/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    assert!(!diagnostics.iter().any(|d| d.rule == "AS-017"));
+}
+
+#[test]
+fn test_as_017_plugin_prefixed_name_still_checks_local_directory() {
+    let content = r#"---
+name: enhance:deploy-skill
+description: Use when validating directory name matching
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new("code-review/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let as_017_errors: Vec<_> = diagnostics.iter().filter(|d| d.rule == "AS-017").collect();
+    assert_eq!(as_017_errors.len(), 1);
 }
 
 #[test]

--- a/crates/agnix-core/src/schemas/skill.rs
+++ b/crates/agnix-core/src/schemas/skill.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 /// SKILL.md frontmatter schema
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SkillSchema {
-    /// Required: skill name (lowercase, hyphens, 1-64 chars)
+    /// Required: skill name, optionally prefixed as `<plugin>:<skill-name>`.
     pub name: String,
 
     /// Required: description (1-1024 chars)
@@ -69,6 +69,35 @@ pub struct SkillSchema {
     pub shell: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SkillNameParts<'a> {
+    pub(crate) plugin: Option<&'a str>,
+    pub(crate) skill: &'a str,
+}
+
+pub(crate) fn parse_skill_name_parts(name: &str) -> Option<SkillNameParts<'_>> {
+    if name.is_empty() {
+        return None;
+    }
+
+    match name.split_once(':') {
+        None => Some(SkillNameParts {
+            plugin: None,
+            skill: name,
+        }),
+        Some((plugin, skill)) => {
+            if plugin.is_empty() || skill.is_empty() || skill.contains(':') {
+                None
+            } else {
+                Some(SkillNameParts {
+                    plugin: Some(plugin),
+                    skill,
+                })
+            }
+        }
+    }
+}
+
 /// Known top-level frontmatter fields for SKILL.md
 #[cfg(test)]
 pub const KNOWN_SKILL_FRONTMATTER_FIELDS: &[&str] = &[
@@ -108,36 +137,51 @@ impl SkillSchema {
     /// Validate skill name format
     #[allow(dead_code)] // schema-level API; validation uses Validator trait
     pub fn validate_name(&self) -> Result<(), String> {
-        let name = &self.name;
+        let Some(parts) = parse_skill_name_parts(&self.name) else {
+            return Err("Name must be a bare skill name or '<plugin>:<skill-name>'".to_string());
+        };
 
-        // Length check
-        if name.is_empty() || name.len() > 64 {
-            return Err(format!("Name must be 1-64 characters, got {}", name.len()));
+        if let Some(plugin) = parts.plugin {
+            validate_name_segment(plugin, "Plugin prefix")?;
         }
+        validate_name_segment(parts.skill, "Skill name")
+    }
+}
 
-        // Character check
-        for ch in name.chars() {
-            if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '-' {
-                return Err(format!(
-                    "Name must contain only lowercase letters, digits, and hyphens, found '{}'",
-                    ch
-                ));
-            }
-        }
-
-        // Start/end check
-        if name.starts_with('-') || name.ends_with('-') {
-            return Err("Name cannot start or end with hyphen".to_string());
-        }
-
-        // Consecutive hyphens
-        if name.contains("--") {
-            return Err("Name cannot contain consecutive hyphens".to_string());
-        }
-
-        Ok(())
+fn validate_name_segment(segment: &str, label: &str) -> Result<(), String> {
+    // Length check
+    if segment.is_empty() || segment.len() > 64 {
+        return Err(format!(
+            "{} must be 1-64 characters, got {}",
+            label,
+            segment.len()
+        ));
     }
 
+    // Character check
+    for ch in segment.chars() {
+        if !ch.is_ascii_lowercase() && !ch.is_ascii_digit() && ch != '-' {
+            return Err(format!(
+                "{} must contain only lowercase letters, digits, and hyphens, found '{}'",
+                label, ch
+            ));
+        }
+    }
+
+    // Start/end check
+    if segment.starts_with('-') || segment.ends_with('-') {
+        return Err(format!("{} cannot start or end with hyphen", label));
+    }
+
+    // Consecutive hyphens
+    if segment.contains("--") {
+        return Err(format!("{} cannot contain consecutive hyphens", label));
+    }
+
+    Ok(())
+}
+
+impl SkillSchema {
     /// Validate description length
     #[allow(dead_code)] // schema-level API; validation uses Validator trait
     pub fn validate_description(&self) -> Result<(), String> {
@@ -277,6 +321,12 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_plugin_prefixed_skill_name() {
+        let skill = make_skill("build-web-apps:frontend-app-builder", "Reviews code");
+        assert!(skill.validate_name().is_ok());
+    }
+
+    #[test]
     fn test_invalid_skill_name_uppercase() {
         let skill = SkillSchema {
             name: "Code-Review".to_string(),
@@ -295,6 +345,12 @@ mod tests {
             paths: None,
             shell: None,
         };
+        assert!(skill.validate_name().is_err());
+    }
+
+    #[test]
+    fn test_invalid_plugin_prefixed_skill_name_segment() {
+        let skill = make_skill("build-web-apps:Frontend_App_Builder", "Reviews code");
         assert!(skill.validate_name().is_err());
     }
 

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -12,9 +12,9 @@ rules:
     message: Skill frontmatter is missing required 'description' field
     suggestion: 'Add ''description: Use when...'' to frontmatter'
   as_004:
-    message: Name '%{name}' must be 1-64 characters of lowercase letters, digits, and hyphens
-    suggestion: Lowercase and trim the name, replace spaces and '_' with '-', collapse multiple '-' into one, remove invalid
-      characters, and truncate to 64 characters
+    message: Name '%{name}' must be 1-64 characters per segment using lowercase letters, digits, and hyphens, as a bare skill name or plugin:skill-name
+    suggestion: Lowercase and trim each name segment, replace spaces and '_' with '-', collapse multiple '-' into one, remove invalid
+      characters, and truncate each segment to 64 characters
     fix: 'Convert name to kebab-case: ''%{name}'''
   as_005:
     message: Name '%{name}' cannot start or end with hyphen

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -12,9 +12,9 @@ rules:
     message: Al frontmatter del skill le falta el campo requerido 'description'
     suggestion: 'Agrega ''description: Usar cuando...'' al frontmatter'
   as_004:
-    message: El nombre '%{name}' debe tener 1-64 caracteres de letras minúsculas, dígitos y guiones
-    suggestion: Convierte a minúsculas, recorta el nombre, reemplaza espacios y '_' con '-', colapsa multiples '-' en uno,
-      elimina caracteres inválidos y trunca a 64 caracteres
+    message: El nombre '%{name}' debe tener 1-64 caracteres por segmento, con letras minúsculas, dígitos y guiones, como skill-name o plugin:skill-name
+    suggestion: Convierte a minúsculas y recorta cada segmento del nombre, reemplaza espacios y '_' con '-', colapsa multiples '-' en uno,
+      elimina caracteres inválidos y trunca cada segmento a 64 caracteres
     fix: 'Convertir nombre a kebab-case: ''%{name}'''
   as_005:
     message: El nombre '%{name}' no puede comenzar ni terminar con guion

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -12,8 +12,8 @@ rules:
     message: Skill frontmatter 缺少必需的 'description' 字段
     suggestion: '在 frontmatter 中添加 ''description: Use when...'''
   as_004:
-    message: 名称 '%{name}' 必须是1-64个字符，包含小写字母、数字和连字符
-    suggestion: 转为小写并修剪名称，将空格和 '_' 替换为 '-'，合并多个 '-'，删除无效字符，并截断为64个字符
+    message: 名称 '%{name}' 的每个段必须是1-64个小写字母、数字和连字符，可为 skill-name 或 plugin:skill-name
+    suggestion: 转为小写并修剪每个名称段，将空格和 '_' 替换为 '-'，合并多个 '-'，删除无效字符，并将每个段截断为64个字符
     fix: '将名称转换为 kebab-case: ''%{name}'''
   as_005:
     message: 名称 '%{name}' 不能以连字符开头或结尾

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -80,7 +80,7 @@ Parameters use `%{name}` syntax:
 
 ```yaml
 as_004:
-  message: "Name '%{name}' must be 1-64 characters of lowercase letters, digits, and hyphens"
+  message: "Name '%{name}' must be 1-64 characters per segment using lowercase letters, digits, and hyphens, as a bare skill name or plugin:skill-name"
 ```
 
 Parameters are filled at runtime. Keep the same parameter names across all locales.

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -114,13 +114,13 @@ Rules with an empty `applies_to` object (`{}`) apply universally.
 
 <a id="as-004"></a>
 ### AS-004 [HIGH] Invalid Name Format
-**Requirement**: name MUST be 1-64 chars, lowercase letters/numbers/hyphens only
-**Regex**: `^[a-z0-9]+(-[a-z0-9]+)*$`
+**Requirement**: name MUST be either a bare skill name or `<plugin>:<skill-name>`; each segment MUST be 1-64 chars, lowercase letters/numbers/hyphens only
+**Regex**: `^[a-z0-9]+(-[a-z0-9]+)*(?::[a-z0-9]+(-[a-z0-9]+)*)?$`
 **Detection**:
 ```rust
-!Regex::new(r"^[a-z0-9]+(-[a-z0-9]+)*$").matches(name) || name.len() > 64
+!is_valid_skill_name(name)
 ```
-**Fix**: [AUTO-FIX] Convert name to kebab-case (lowercase, replace `_` with `-`, remove invalid chars, collapse consecutive hyphens, truncate to 64 chars)
+**Fix**: [AUTO-FIX] Convert each name segment to kebab-case (lowercase, replace `_` with `-`, remove invalid chars, collapse consecutive hyphens, truncate to 64 chars)
 **Source**: agentskills.io/specification
 
 <a id="as-005"></a>
@@ -3306,12 +3306,11 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
     }
 
     // AS-004: Check name format
-    let name_re = Regex::new(r"^[a-z0-9]+(-[a-z0-9]+)*$").unwrap();
-    if !name_re.is_match(&frontmatter.name) || frontmatter.name.len() > 64 {
+    if !is_valid_skill_name(&frontmatter.name) {
         diagnostics.push(Diagnostic::error(
             path, 2, 0, "AS-004",
             format!("Invalid name format: {}", frontmatter.name)
-        ).with_suggestion("Use lowercase letters, numbers, hyphens only"));
+        ).with_suggestion("Use a bare skill name or '<plugin>:<skill-name>' with kebab-case segments"));
     }
 
     // Continue with other rules...

--- a/knowledge-base/agent-config-optional-fields.md
+++ b/knowledge-base/agent-config-optional-fields.md
@@ -29,7 +29,7 @@
 
 | Field | Type | Required | Valid Values | Default | agnix Rule | Gap? |
 |-------|------|----------|-------------|---------|------------|------|
-| `name` | string | No (recommended) | lowercase letters, numbers, hyphens; 1-64 chars; no leading/trailing/consecutive hyphens | directory name | AS-002, AS-004, AS-005, AS-006, AS-007 | No |
+| `name` | string | No (recommended) | bare skill name or `<plugin>:<skill-name>`; each segment lowercase letters, numbers, hyphens; 1-64 chars; no leading/trailing/consecutive hyphens | directory name or local skill-name segment | AS-002, AS-004, AS-005, AS-006, AS-007 | No |
 | `description` | string | Recommended | 1-1024 chars, no XML tags | first paragraph of content | AS-003, AS-008, AS-009, AS-010 | No |
 | `license` | string | No | Free-form license text | none | (none) | LOW |
 | `compatibility` | string | No | 1-500 chars if present | none | AS-011 | No |

--- a/knowledge-base/standards/agent-skills-HARD-RULES.md
+++ b/knowledge-base/standards/agent-skills-HARD-RULES.md
@@ -89,7 +89,7 @@ description: A description of what this skill does.
 
 **Source**: https://agentskills.io/specification
 
-The `name` field MUST satisfy ALL of the following constraints:
+The `name` field MUST satisfy ALL of the following constraints. For plugin-provided skills named as `<plugin>:<skill-name>`, apply these constraints to each segment and match the parent directory against only `<skill-name>`.
 
 #### Character Length
 - **MUST** be 1-64 characters

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,9 +12,9 @@ rules:
     message: Skill frontmatter is missing required 'description' field
     suggestion: 'Add ''description: Use when...'' to frontmatter'
   as_004:
-    message: Name '%{name}' must be 1-64 characters of lowercase letters, digits, and hyphens
-    suggestion: Lowercase and trim the name, replace spaces and '_' with '-', collapse multiple '-' into one, remove invalid
-      characters, and truncate to 64 characters
+    message: Name '%{name}' must be 1-64 characters per segment using lowercase letters, digits, and hyphens, as a bare skill name or plugin:skill-name
+    suggestion: Lowercase and trim each name segment, replace spaces and '_' with '-', collapse multiple '-' into one, remove invalid
+      characters, and truncate each segment to 64 characters
     fix: 'Convert name to kebab-case: ''%{name}'''
   as_005:
     message: Name '%{name}' cannot start or end with hyphen

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -12,9 +12,9 @@ rules:
     message: Al frontmatter del skill le falta el campo requerido 'description'
     suggestion: 'Agrega ''description: Usar cuando...'' al frontmatter'
   as_004:
-    message: El nombre '%{name}' debe tener 1-64 caracteres de letras minúsculas, dígitos y guiones
-    suggestion: Convierte a minúsculas, recorta el nombre, reemplaza espacios y '_' con '-', colapsa multiples '-' en uno,
-      elimina caracteres inválidos y trunca a 64 caracteres
+    message: El nombre '%{name}' debe tener 1-64 caracteres por segmento, con letras minúsculas, dígitos y guiones, como skill-name o plugin:skill-name
+    suggestion: Convierte a minúsculas y recorta cada segmento del nombre, reemplaza espacios y '_' con '-', colapsa multiples '-' en uno,
+      elimina caracteres inválidos y trunca cada segmento a 64 caracteres
     fix: 'Convertir nombre a kebab-case: ''%{name}'''
   as_005:
     message: El nombre '%{name}' no puede comenzar ni terminar con guion

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -12,8 +12,8 @@ rules:
     message: Skill frontmatter 缺少必需的 'description' 字段
     suggestion: '在 frontmatter 中添加 ''description: Use when...'''
   as_004:
-    message: 名称 '%{name}' 必须是1-64个字符，包含小写字母、数字和连字符
-    suggestion: 转为小写并修剪名称，将空格和 '_' 替换为 '-'，合并多个 '-'，删除无效字符，并截断为64个字符
+    message: 名称 '%{name}' 的每个段必须是1-64个小写字母、数字和连字符，可为 skill-name 或 plugin:skill-name
+    suggestion: 转为小写并修剪每个名称段，将空格和 '_' 替换为 '-'，合并多个 '-'，删除无效字符，并将每个段截断为64个字符
     fix: '将名称转换为 kebab-case: ''%{name}'''
   as_005:
     message: 名称 '%{name}' 不能以连字符开头或结尾


### PR DESCRIPTION
## Summary

Fixes false positives for valid plugin-provided skills named with the standard `plugin:skill-name` form.

- Parse skill names as either bare `skill-name` or prefixed `plugin:skill-name`.
- Validate AS-004/AS-005/AS-006 per segment so existing bare-name constraints still apply.
- Compare AS-017 parent-directory matches against only the local `skill-name` segment.
- Update AS-004 docs and locale text to describe the segment-based contract.

## Source

Reported via today's Gmail thread from Alexandr Tulai about `<plugin>:<skill-name>` false positives.

## Validation

- `cargo fmt --all --check`
- `bash scripts/check-locale-sync.sh`
- `node scripts/sync-rule-bookkeeping.js --check`
- `cargo test -p agnix-cli --test docs_website_parity`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Live reproduction: `name: enhance:code-review` under `code-review/SKILL.md` now reports `No issues found`