### PR TITLE
Triage tool release sweep

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-06-25",
+  "last_updated": "2026-06-27",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.187",
+      "last_known_version": "v2.1.195",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -60,7 +60,7 @@
         "agents_md"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.142.0",
+      "last_known_version": "rust-v0.142.3",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.17.7",
+      "last_known_version": "v1.17.11",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -136,7 +136,7 @@
       "html_url": "https://kiro.dev/changelog/cli/",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
       "notes_extractor": "glm",
-      "last_known_version": "2.8.0",
+      "last_known_version": "2.10.0",
       "tracked": true,
       "notes": "Proprietary CLI; no GH releases. Tracked via HTML scrape of kiro.dev/changelog/cli/ - the first NN.NN.NN version on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). The CLI itself exposes `kiro-cli version --changelog`. IDE has a separate changelog at https://kiro.dev/changelog/ide/ (not tracked here; could be added as a separate kiro-ide entry if needed).",
       "changes_of_interest": {
@@ -203,7 +203,7 @@
         "cline"
       ],
       "github_repo": "cline/cline",
-      "last_known_version": "cli-v3.0.24",
+      "last_known_version": "cli-v3.0.31",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -237,7 +237,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.8.11",
+      "last_known_version": "3.9.8",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {
@@ -305,7 +305,7 @@
       "html_url": "https://ampcode.com/news.rss",
       "version_regex": "https://ampcode\\.com/news/[a-zA-Z0-9._-]+",
       "notes_extractor": "rss_cdata",
-      "last_known_version": "end-of-public-threads",
+      "last_known_version": "custom-agents",
       "tracked": true,
       "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed).",
       "changes_of_interest": {
@@ -337,7 +337,7 @@
         "gemini_ignore"
       ],
       "github_repo": "google-gemini/gemini-cli",
-      "last_known_version": "v0.45.1",
+      "last_known_version": "v0.49.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 430 rules, 75+ sources, rules.json
+knowledge-base/     # 432 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-430 rules defined in `knowledge-base/rules.json` (source of truth)
+432 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.29.0 - Production-ready with full validation pipeline
-- 430 validation rules across 43 validators
+- 432 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SET-013: Non-boolean autoMode.classifyAllShell Setting** (closes #1084). Claude Code v2.1.193 added `autoMode.classifyAllShell` to route all Bash/PowerShell commands through the auto-mode classifier. New MEDIUM `claude-settings` rule warns when `autoMode.classifyAllShell` is present with a non-boolean value in `settings.json`, `settings.local.json`, or `managed-settings.json`; strict `true`/`false` values, `null`, and absent keys are accepted.
+- **CDX-PL-016: Invalid Dark-mode Logo Path** (closes #1081). Codex CLI `rust-v0.142.2` added local plugin manifest `interface.logoDark` for dark-mode logo assets. New MEDIUM Codex plugin rule validates that `logoDark` starts with `./` and does not traverse outside the plugin root. Rule count 430 -> 432.
+
+### Changed
+- **Tool baselines**: completed the release-watch sweep and bumped `amp` `end-of-public-threads` -> `custom-agents`, `claude-code` `v2.1.187` -> `v2.1.195`, `cline` `cli-v3.0.24` -> `cli-v3.0.31`, `codex` `rust-v0.142.0` -> `rust-v0.142.3`, `cursor` `3.8.11` -> `3.9.8`, `gemini-cli` `v0.45.1` -> `v0.49.0`, `kiro` `2.8.0` -> `2.10.0`, and `opencode` `v1.17.7` -> `v1.17.11` (closes #1079, #1082, #1083, #1085, #1086, #1087). Aside from the Claude Code and Codex changes above, the releases were triaged as UI/runtime/provider/model/packaging/news changes outside agnix's current validated config surfaces. `.github/tool-release-baselines.json`, `knowledge-base/RESEARCH-TRACKING.md`, rule metadata, and generated rule docs were updated.
+
 ## [0.36.0] - 2026-06-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 430 rules, 75+ sources, rules.json
+knowledge-base/     # 432 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-430 rules defined in `knowledge-base/rules.json` (source of truth)
+432 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.29.0 - Production-ready with full validation pipeline
-- 430 validation rules across 43 validators
+- 432 validation rules across 43 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>430 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>432 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 430 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 432 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -903,6 +903,9 @@ rules:
   cdx_pl_014:
     message: Missing 'description' field - recommended for marketplace visibility
     suggestion: Add a 'description' string to plugin.json for better discoverability
+  cdx_pl_016:
+    message: Dark-mode logo path '%{path}' in interface.logoDark must start with ./ and not use '..' traversal
+    suggestion: Use a relative dark-mode logo asset path such as './assets/logo-dark.png'
   roo_001:
     message: Roo Code rule file is empty
     suggestion: Add rule content to the file
@@ -1198,6 +1201,11 @@ rules:
       attribution toggle as a strict true/false setting
     suggestion: Set attribution.sessionUrl to an unquoted true or false. Use false to omit claude.ai session links from
       commits and PR descriptions created from web or Remote Control sessions.
+  cc_set_013:
+    message: autoMode.classifyAllShell must be a boolean when present (got %{actual}); Claude Code 2.1.193+ documents this
+      auto-mode setting as a strict true/false toggle
+    suggestion: Set autoMode.classifyAllShell to an unquoted true or false, or remove it to keep the default auto-mode
+      classifier scope.
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -626,6 +626,9 @@ rules:
   cdx_pl_014:
     message: Falta el campo 'description' - recomendado para visibilidad en el marketplace
     suggestion: Agrega una cadena 'description' a plugin.json para mejor descubrimiento
+  cdx_pl_016:
+    message: La ruta de logo oscuro '%{path}' en interface.logoDark debe comenzar con ./ y no usar recorrido '..'
+    suggestion: Usa una ruta relativa para el logo oscuro, como './assets/logo-dark.png'
   pe_001:
     message: Palabra clave critica '%{keyword}' al %{percent} por ciento del documento (40-60 por ciento es la zona 'perdido
       en el medio')
@@ -722,6 +725,11 @@ rules:
       documenta esta atribucion como una configuracion true/false estricta
     suggestion: Establece attribution.sessionUrl en true o false sin comillas. Usa false para omitir enlaces de sesion
       claude.ai en commits y descripciones de PR creados desde sesiones web o Remote Control.
+  cc_set_013:
+    message: autoMode.classifyAllShell debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.193+
+      documenta esta configuracion de auto-mode como un interruptor true/false estricto
+    suggestion: Establece autoMode.classifyAllShell en true o false sin comillas, o quitalo para conservar el alcance
+      predeterminado del clasificador auto-mode.
 
 
 # ===========================================================================

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -604,6 +604,9 @@ rules:
   cdx_pl_014:
     message: 缺少 'description' 字段 - 建议添加以提高市场可见性
     suggestion: 在 plugin.json 中添加 'description' 字符串以提高可发现性
+  cdx_pl_016:
+    message: interface.logoDark 中的深色模式 logo 路径 '%{path}' 必须以 ./ 开头且不使用 '..' 遍历
+    suggestion: 使用相对深色模式 logo 资源路径，例如 './assets/logo-dark.png'
   pe_001:
     message: 关键词 '%{keyword}' 在文档的 %{percent} 百分比处（40-60 百分比是'中间遗忘'区域）
     suggestion: 将关键内容移到文档的开头或结尾以获得更好的记忆效果
@@ -686,6 +689,9 @@ rules:
   cc_set_009:
     message: attribution.sessionUrl 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.183+ 将该归因选项记录为严格的 true/false 设置
     suggestion: 将 attribution.sessionUrl 设置为不带引号的 true 或 false。使用 false 可在 Web 或 Remote Control 会话创建的 commit 和 PR 描述中省略 claude.ai 会话链接。
+  cc_set_013:
+    message: autoMode.classifyAllShell 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.193+ 将该 auto-mode 设置记录为严格的 true/false 开关
+    suggestion: 将 autoMode.classifyAllShell 设置为不带引号的 true 或 false，或移除此字段以保留默认的 auto-mode 分类器范围。
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -903,6 +903,9 @@ rules:
   cdx_pl_014:
     message: Missing 'description' field - recommended for marketplace visibility
     suggestion: Add a 'description' string to plugin.json for better discoverability
+  cdx_pl_016:
+    message: Dark-mode logo path '%{path}' in interface.logoDark must start with ./ and not use '..' traversal
+    suggestion: Use a relative dark-mode logo asset path such as './assets/logo-dark.png'
   roo_001:
     message: Roo Code rule file is empty
     suggestion: Add rule content to the file
@@ -1198,6 +1201,11 @@ rules:
       attribution toggle as a strict true/false setting
     suggestion: Set attribution.sessionUrl to an unquoted true or false. Use false to omit claude.ai session links from
       commits and PR descriptions created from web or Remote Control sessions.
+  cc_set_013:
+    message: autoMode.classifyAllShell must be a boolean when present (got %{actual}); Claude Code 2.1.193+ documents this
+      auto-mode setting as a strict true/false toggle
+    suggestion: Set autoMode.classifyAllShell to an unquoted true or false, or remove it to keep the default auto-mode
+      classifier scope.
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -626,6 +626,9 @@ rules:
   cdx_pl_014:
     message: Falta el campo 'description' - recomendado para visibilidad en el marketplace
     suggestion: Agrega una cadena 'description' a plugin.json para mejor descubrimiento
+  cdx_pl_016:
+    message: La ruta de logo oscuro '%{path}' en interface.logoDark debe comenzar con ./ y no usar recorrido '..'
+    suggestion: Usa una ruta relativa para el logo oscuro, como './assets/logo-dark.png'
   pe_001:
     message: Palabra clave critica '%{keyword}' al %{percent} por ciento del documento (40-60 por ciento es la zona 'perdido
       en el medio')
@@ -722,6 +725,11 @@ rules:
       documenta esta atribucion como una configuracion true/false estricta
     suggestion: Establece attribution.sessionUrl en true o false sin comillas. Usa false para omitir enlaces de sesion
       claude.ai en commits y descripciones de PR creados desde sesiones web o Remote Control.
+  cc_set_013:
+    message: autoMode.classifyAllShell debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.193+
+      documenta esta configuracion de auto-mode como un interruptor true/false estricto
+    suggestion: Establece autoMode.classifyAllShell en true o false sin comillas, o quitalo para conservar el alcance
+      predeterminado del clasificador auto-mode.
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -604,6 +604,9 @@ rules:
   cdx_pl_014:
     message: 缺少 'description' 字段 - 建议添加以提高市场可见性
     suggestion: 在 plugin.json 中添加 'description' 字符串以提高可发现性
+  cdx_pl_016:
+    message: interface.logoDark 中的深色模式 logo 路径 '%{path}' 必须以 ./ 开头且不使用 '..' 遍历
+    suggestion: 使用相对深色模式 logo 资源路径，例如 './assets/logo-dark.png'
   pe_001:
     message: 关键词 '%{keyword}' 在文档的 %{percent} 百分比处（40-60 百分比是'中间遗忘'区域）
     suggestion: 将关键内容移到文档的开头或结尾以获得更好的记忆效果
@@ -686,6 +689,9 @@ rules:
   cc_set_009:
     message: attribution.sessionUrl 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.183+ 将该归因选项记录为严格的 true/false 设置
     suggestion: 将 attribution.sessionUrl 设置为不带引号的 true 或 false。使用 false 可在 Web 或 Remote Control 会话创建的 commit 和 PR 描述中省略 claude.ai 会话链接。
+  cc_set_013:
+    message: autoMode.classifyAllShell 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.193+ 将该 auto-mode 设置记录为严格的 true/false 开关
+    suggestion: 将 autoMode.classifyAllShell 设置为不带引号的 true 或 false，或移除此字段以保留默认的 auto-mode 分类器范围。
 
 
 # ===========================================================================

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -17,6 +17,7 @@
 //! - `teammateMode` enum check (CC-SET-010, `iterm2` added in Claude Code v2.1.186).
 //! - `respondToBashCommands` boolean check (CC-SET-011, added in Claude Code v2.1.186).
 //! - `sandbox.credentials` shape check (CC-SET-012, added in Claude Code v2.1.187).
+//! - `autoMode.classifyAllShell` boolean check (CC-SET-013, added in Claude Code v2.1.193).
 //!
 //! Runs on FileType::Hooks (which covers `.claude/settings.json` -
 //! see `file_types/detection.rs`). Skips non-Claude Code settings paths
@@ -43,6 +44,7 @@ const RULE_IDS: &[&str] = &[
     "CC-SET-010",
     "CC-SET-011",
     "CC-SET-012",
+    "CC-SET-013",
 ];
 
 /// Allowed values for `worktree.baseRef` per Claude Code v2.1.133 release notes.
@@ -136,6 +138,10 @@ impl Validator for ClaudeSettingsValidator {
 
         if config.is_rule_enabled("CC-SET-012") {
             validate_sandbox_credentials(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-013") {
+            validate_auto_mode_classify_all_shell(path, content, &value, &mut diagnostics);
         }
 
         diagnostics
@@ -976,6 +982,42 @@ fn validate_sandbox_credential_entries(
             }
         }
     }
+}
+
+/// CC-SET-013: Validate `autoMode.classifyAllShell`. Claude Code v2.1.193
+/// added this nested auto-mode setting so all Bash/PowerShell commands route
+/// through the auto-mode classifier. The release note describes it as an
+/// enabled/disabled setting, so agnix treats it like the other CC-SET boolean
+/// toggles: only strict JSON booleans are valid when present.
+fn validate_auto_mode_classify_all_shell(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(field_value) = value.pointer("/autoMode/classifyAllShell") else {
+        return;
+    };
+
+    if field_value.is_boolean() || field_value.is_null() {
+        return;
+    }
+
+    let actual = describe_json_type(field_value);
+    let line = find_key_line(content, "classifyAllShell")
+        .or_else(|| find_key_line(content, "autoMode"))
+        .unwrap_or(1);
+
+    diagnostics.push(
+        Diagnostic::warning(
+            path.to_path_buf(),
+            line,
+            0,
+            "CC-SET-013",
+            t!("rules.cc_set_013.message", actual = actual),
+        )
+        .with_suggestion(t!("rules.cc_set_013.suggestion")),
+    );
 }
 
 /// Renders a `serde_json::Value` variant as a short human-readable type
@@ -2472,5 +2514,90 @@ mod tests {
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-004"));
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-008"));
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-012"));
+    }
+
+    // ===== CC-SET-013: autoMode.classifyAllShell =====
+
+    #[test]
+    fn test_auto_mode_classify_all_shell_boolean_values_are_fine() {
+        assert!(
+            validate(r#"{"autoMode": {"classifyAllShell": true}}"#)
+                .iter()
+                .all(|d| d.rule != "CC-SET-013")
+        );
+        assert!(
+            validate(r#"{"autoMode": {"classifyAllShell": false}}"#)
+                .iter()
+                .all(|d| d.rule != "CC-SET-013")
+        );
+    }
+
+    #[test]
+    fn test_auto_mode_classify_all_shell_null_is_not_flagged() {
+        let content = r#"{"autoMode": {"classifyAllShell": null}}"#;
+        assert!(validate(content).iter().all(|d| d.rule != "CC-SET-013"));
+    }
+
+    #[test]
+    fn test_auto_mode_classify_all_shell_quoted_string_flags() {
+        let diagnostics = validate(r#"{"autoMode": {"classifyAllShell": "true"}}"#);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-013")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].level, crate::diagnostics::DiagnosticLevel::Warning);
+        assert!(hits[0].message.to_lowercase().contains("boolean"));
+        assert!(hits[0].message.to_lowercase().contains("string"));
+    }
+
+    #[test]
+    fn test_auto_mode_classify_all_shell_number_flags() {
+        let diagnostics = validate(r#"{"autoMode": {"classifyAllShell": 1}}"#);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-013")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].message.to_lowercase().contains("number"));
+    }
+
+    #[test]
+    fn test_auto_mode_classify_all_shell_ignores_non_object_auto_mode() {
+        let content = r#"{"autoMode": "enabled"}"#;
+        assert!(validate(content).iter().all(|d| d.rule != "CC-SET-013"));
+    }
+
+    #[test]
+    fn test_auto_mode_classify_all_shell_runs_on_managed_settings() {
+        let content = r#"{"autoMode": {"classifyAllShell": "true"}}"#;
+        let diagnostics = validate_at(".claude/managed-settings.json", content);
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-013"));
+    }
+
+    #[test]
+    fn test_auto_mode_classify_all_shell_line_points_at_key() {
+        let content = "{\n  \"autoMode\": {\n    \"classifyAllShell\": \"true\"\n  }\n}";
+        let diagnostics = validate(content);
+        let hit = diagnostics
+            .iter()
+            .find(|d| d.rule == "CC-SET-013")
+            .expect("CC-SET-013 diagnostic");
+        assert_eq!(hit.line, 3);
+    }
+
+    #[test]
+    fn test_auto_mode_classify_all_shell_can_be_disabled() {
+        let mut builder = LintConfig::builder();
+        builder.disable_rule("CC-SET-013");
+        let config = builder.build().unwrap();
+        let validator = ClaudeSettingsValidator;
+        let path = PathBuf::from(".claude/settings.json");
+        let diagnostics = validator.validate(
+            &path,
+            r#"{"autoMode": {"classifyAllShell": "true"}}"#,
+            &config,
+        );
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-013"));
     }
 }

--- a/crates/agnix-core/src/rules/codex_plugin.rs
+++ b/crates/agnix-core/src/rules/codex_plugin.rs
@@ -1,4 +1,4 @@
-//! Codex CLI plugin manifest validation (CDX-PL-001 to CDX-PL-015).
+//! Codex CLI plugin manifest validation (CDX-PL-001 to CDX-PL-016).
 //!
 //! Validates `.codex-plugin/plugin.json` manifests for the Codex CLI
 //! plugin system introduced in v0.117.0.
@@ -27,6 +27,7 @@ const RULE_IDS: &[&str] = &[
     "CDX-PL-013",
     "CDX-PL-014",
     "CDX-PL-015",
+    "CDX-PL-016",
 ];
 
 /// Max number of defaultPrompt entries
@@ -220,6 +221,15 @@ impl Validator for CodexPluginValidator {
                         }
                     }
                 }
+            }
+
+            // CDX-PL-016: dark-mode logo asset path validation. Codex
+            // rust-v0.142.2 added interface.logoDark as a separate local
+            // manifest field from remote catalog logoUrlDark values.
+            if config.is_rule_enabled("CDX-PL-016")
+                && let Some(val) = interface.get("logoDark").and_then(|v| v.as_str())
+            {
+                validate_logo_dark_path(val, path, &mut diagnostics);
             }
         }
 
@@ -512,6 +522,27 @@ fn validate_asset_path(p: &str, field: &str, path: &Path, diagnostics: &mut Vec<
                 t!("rules.cdx_pl_012.message", path = trimmed, field = field),
             )
             .with_suggestion(t!("rules.cdx_pl_012.suggestion")),
+        );
+    }
+}
+
+/// Validate the dark-mode logo asset path in the interface section.
+fn validate_logo_dark_path(p: &str, path: &Path, diagnostics: &mut Vec<Diagnostic>) {
+    let trimmed = p.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    if has_traversal(trimmed) || (!trimmed.starts_with("./") && !trimmed.starts_with(".\\")) {
+        diagnostics.push(
+            Diagnostic::warning(
+                path.to_path_buf(),
+                1,
+                0,
+                "CDX-PL-016",
+                t!("rules.cdx_pl_016.message", path = trimmed),
+            )
+            .with_suggestion(t!("rules.cdx_pl_016.suggestion")),
         );
     }
 }
@@ -1107,6 +1138,88 @@ mod tests {
         );
 
         assert!(diagnostics.iter().any(|d| d.rule == "CDX-PL-012"));
+    }
+
+    // ===== CDX-PL-016: Dark-mode logo asset path =====
+
+    #[test]
+    fn test_cdx_pl_016_logo_dark_missing_dot_slash() {
+        let temp = TempDir::new().unwrap();
+        let plugin_path = temp.path().join(".codex-plugin").join("plugin.json");
+        write_plugin(
+            &plugin_path,
+            r#"{"name":"test","description":"desc","interface":{"logoDark":"assets/logo-dark.png"}}"#,
+        );
+
+        let validator = CodexPluginValidator;
+        let diagnostics = validator.validate(
+            &plugin_path,
+            &fs::read_to_string(&plugin_path).unwrap(),
+            &LintConfig::default(),
+        );
+
+        assert!(diagnostics.iter().any(|d| d.rule == "CDX-PL-016"));
+        assert!(!diagnostics.iter().any(|d| d.rule == "CDX-PL-012"));
+    }
+
+    #[test]
+    fn test_cdx_pl_016_logo_dark_valid_path() {
+        let temp = TempDir::new().unwrap();
+        let plugin_path = temp.path().join(".codex-plugin").join("plugin.json");
+        write_plugin(
+            &plugin_path,
+            r#"{"name":"test","description":"desc","interface":{"logoDark":"./assets/logo-dark.png"}}"#,
+        );
+
+        let validator = CodexPluginValidator;
+        let diagnostics = validator.validate(
+            &plugin_path,
+            &fs::read_to_string(&plugin_path).unwrap(),
+            &LintConfig::default(),
+        );
+
+        assert!(!diagnostics.iter().any(|d| d.rule == "CDX-PL-016"));
+    }
+
+    #[test]
+    fn test_cdx_pl_016_logo_dark_traversal() {
+        let temp = TempDir::new().unwrap();
+        let plugin_path = temp.path().join(".codex-plugin").join("plugin.json");
+        write_plugin(
+            &plugin_path,
+            r#"{"name":"test","description":"desc","interface":{"logoDark":"./assets/../secret.png"}}"#,
+        );
+
+        let validator = CodexPluginValidator;
+        let diagnostics = validator.validate(
+            &plugin_path,
+            &fs::read_to_string(&plugin_path).unwrap(),
+            &LintConfig::default(),
+        );
+
+        assert!(diagnostics.iter().any(|d| d.rule == "CDX-PL-016"));
+    }
+
+    #[test]
+    fn test_cdx_pl_016_can_be_disabled() {
+        let temp = TempDir::new().unwrap();
+        let plugin_path = temp.path().join(".codex-plugin").join("plugin.json");
+        write_plugin(
+            &plugin_path,
+            r#"{"name":"test","description":"desc","interface":{"logoDark":"assets/logo-dark.png"}}"#,
+        );
+
+        let mut config = LintConfig::default();
+        config.rules_mut().disabled_rules = vec!["CDX-PL-016".to_string()];
+
+        let validator = CodexPluginValidator;
+        let diagnostics = validator.validate(
+            &plugin_path,
+            &fs::read_to_string(&plugin_path).unwrap(),
+            &config,
+        );
+
+        assert!(!diagnostics.iter().any(|d| d.rule == "CDX-PL-016"));
     }
 
     // ===== CDX-PL-013: hooks not supported =====

--- a/crates/agnix-core/src/rules/codex_plugin.rs
+++ b/crates/agnix-core/src/rules/codex_plugin.rs
@@ -229,7 +229,7 @@ impl Validator for CodexPluginValidator {
             if config.is_rule_enabled("CDX-PL-016")
                 && let Some(val) = interface.get("logoDark").and_then(|v| v.as_str())
             {
-                validate_logo_dark_path(val, path, &mut diagnostics);
+                validate_logo_dark_path(val, path, content, &mut diagnostics);
             }
         }
 
@@ -527,17 +527,18 @@ fn validate_asset_path(p: &str, field: &str, path: &Path, diagnostics: &mut Vec<
 }
 
 /// Validate the dark-mode logo asset path in the interface section.
-fn validate_logo_dark_path(p: &str, path: &Path, diagnostics: &mut Vec<Diagnostic>) {
+fn validate_logo_dark_path(p: &str, path: &Path, content: &str, diagnostics: &mut Vec<Diagnostic>) {
     let trimmed = p.trim();
     if trimmed.is_empty() {
         return;
     }
 
     if has_traversal(trimmed) || (!trimmed.starts_with("./") && !trimmed.starts_with(".\\")) {
+        let line = find_json_key_line(content, "logoDark").unwrap_or(1);
         diagnostics.push(
             Diagnostic::warning(
                 path.to_path_buf(),
-                1,
+                line,
                 0,
                 "CDX-PL-016",
                 t!("rules.cdx_pl_016.message", path = trimmed),
@@ -545,6 +546,14 @@ fn validate_logo_dark_path(p: &str, path: &Path, diagnostics: &mut Vec<Diagnosti
             .with_suggestion(t!("rules.cdx_pl_016.suggestion")),
         );
     }
+}
+
+fn find_json_key_line(content: &str, key: &str) -> Option<usize> {
+    let needle = format!("\"{}\"", key);
+    content
+        .lines()
+        .position(|line| line.contains(&needle))
+        .map(|idx| idx + 1)
 }
 
 #[cfg(test)]
@@ -1148,7 +1157,7 @@ mod tests {
         let plugin_path = temp.path().join(".codex-plugin").join("plugin.json");
         write_plugin(
             &plugin_path,
-            r#"{"name":"test","description":"desc","interface":{"logoDark":"assets/logo-dark.png"}}"#,
+            "{\n  \"name\":\"test\",\n  \"description\":\"desc\",\n  \"interface\":{\n    \"logoDark\":\"assets/logo-dark.png\"\n  }\n}",
         );
 
         let validator = CodexPluginValidator;
@@ -1158,7 +1167,11 @@ mod tests {
             &LintConfig::default(),
         );
 
-        assert!(diagnostics.iter().any(|d| d.rule == "CDX-PL-016"));
+        let hit = diagnostics
+            .iter()
+            .find(|d| d.rule == "CDX-PL-016")
+            .expect("CDX-PL-016 diagnostic");
+        assert_eq!(hit.line, 5);
         assert!(!diagnostics.iter().any(|d| d.rule == "CDX-PL-012"));
     }
 

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -903,6 +903,9 @@ rules:
   cdx_pl_014:
     message: Missing 'description' field - recommended for marketplace visibility
     suggestion: Add a 'description' string to plugin.json for better discoverability
+  cdx_pl_016:
+    message: Dark-mode logo path '%{path}' in interface.logoDark must start with ./ and not use '..' traversal
+    suggestion: Use a relative dark-mode logo asset path such as './assets/logo-dark.png'
   roo_001:
     message: Roo Code rule file is empty
     suggestion: Add rule content to the file
@@ -1198,6 +1201,11 @@ rules:
       attribution toggle as a strict true/false setting
     suggestion: Set attribution.sessionUrl to an unquoted true or false. Use false to omit claude.ai session links from
       commits and PR descriptions created from web or Remote Control sessions.
+  cc_set_013:
+    message: autoMode.classifyAllShell must be a boolean when present (got %{actual}); Claude Code 2.1.193+ documents this
+      auto-mode setting as a strict true/false toggle
+    suggestion: Set autoMode.classifyAllShell to an unquoted true or false, or remove it to keep the default auto-mode
+      classifier scope.
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -626,6 +626,9 @@ rules:
   cdx_pl_014:
     message: Falta el campo 'description' - recomendado para visibilidad en el marketplace
     suggestion: Agrega una cadena 'description' a plugin.json para mejor descubrimiento
+  cdx_pl_016:
+    message: La ruta de logo oscuro '%{path}' en interface.logoDark debe comenzar con ./ y no usar recorrido '..'
+    suggestion: Usa una ruta relativa para el logo oscuro, como './assets/logo-dark.png'
   pe_001:
     message: Palabra clave critica '%{keyword}' al %{percent} por ciento del documento (40-60 por ciento es la zona 'perdido
       en el medio')
@@ -722,6 +725,11 @@ rules:
       documenta esta atribucion como una configuracion true/false estricta
     suggestion: Establece attribution.sessionUrl en true o false sin comillas. Usa false para omitir enlaces de sesion
       claude.ai en commits y descripciones de PR creados desde sesiones web o Remote Control.
+  cc_set_013:
+    message: autoMode.classifyAllShell debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.193+
+      documenta esta configuracion de auto-mode como un interruptor true/false estricto
+    suggestion: Establece autoMode.classifyAllShell en true o false sin comillas, o quitalo para conservar el alcance
+      predeterminado del clasificador auto-mode.
 
 
 # ===========================================================================

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -604,6 +604,9 @@ rules:
   cdx_pl_014:
     message: 缺少 'description' 字段 - 建议添加以提高市场可见性
     suggestion: 在 plugin.json 中添加 'description' 字符串以提高可发现性
+  cdx_pl_016:
+    message: interface.logoDark 中的深色模式 logo 路径 '%{path}' 必须以 ./ 开头且不使用 '..' 遍历
+    suggestion: 使用相对深色模式 logo 资源路径，例如 './assets/logo-dark.png'
   pe_001:
     message: 关键词 '%{keyword}' 在文档的 %{percent} 百分比处（40-60 百分比是'中间遗忘'区域）
     suggestion: 将关键内容移到文档的开头或结尾以获得更好的记忆效果
@@ -686,6 +689,9 @@ rules:
   cc_set_009:
     message: attribution.sessionUrl 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.183+ 将该归因选项记录为严格的 true/false 设置
     suggestion: 将 attribution.sessionUrl 设置为不带引号的 true 或 false。使用 false 可在 Web 或 Remote Control 会话创建的 commit 和 PR 描述中省略 claude.ai 会话链接。
+  cc_set_013:
+    message: autoMode.classifyAllShell 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.193+ 将该 auto-mode 设置记录为严格的 true/false 开关
+    suggestion: 将 autoMode.classifyAllShell 设置为不带引号的 true 或 false，或移除此字段以保留默认的 auto-mode 分类器范围。
 
 
 # ===========================================================================

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 430,
-  "last_updated": "2026-06-25",
+  "total_rules": 432,
+  "last_updated": "2026-06-27",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3812,6 +3812,34 @@
       "bad_example": "{\n  \"sandbox\": {\n    \"credentials\": {\n      \"files\": [\n        {\"path\": \"~/.aws/credentials\", \"mode\": \"allow\"}\n      ],\n      \"envVars\": [\n        {\"name\": \"GITHUB_TOKEN\"}\n      ]\n    }\n  }\n}"
     },
     {
+      "id": "CC-SET-013",
+      "name": "Non-boolean autoMode.classifyAllShell Setting",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.193"
+        ],
+        "verified_on": "2026-06-27",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.193"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"autoMode\": {\"classifyAllShell\": true}\n}",
+      "bad_example": "{\n  \"autoMode\": {\"classifyAllShell\": \"true\"}\n}"
+    },
+    {
       "id": "CDX-000",
       "name": "TOML Parse Error",
       "severity": "HIGH",
@@ -5326,6 +5354,35 @@
       },
       "good_example": "{\"name\": \"my-plugin\", \"skills\": \"./skills\"}",
       "bad_example": "{\"name\": \"my-plugin\", \"skills\": [\"./skills\"]}"
+    },
+    {
+      "id": "CDX-PL-016",
+      "name": "Invalid Dark-mode Logo Path",
+      "severity": "MEDIUM",
+      "category": "codex",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/openai/codex/pull/29488",
+          "https://github.com/openai/codex/blob/rust-v0.142.2/codex-rs/core-plugins/src/manifest.rs"
+        ],
+        "verified_on": "2026-06-27",
+        "applies_to": {
+          "tool": "codex",
+          "version_range": ">=0.142.2"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\"name\": \"my-plugin\", \"interface\": {\"logoDark\": \"./assets/logo-dark.png\"}}",
+      "bad_example": "{\"name\": \"my-plugin\", \"interface\": {\"logoDark\": \"assets/logo-dark.png\"}}"
     },
     {
       "id": "CDX-CFG-023",
@@ -11965,7 +12022,7 @@
     },
     "codex": {
       "prefix": "CDX",
-      "count": 64,
+      "count": 65,
       "description": "Codex CLI configuration validation"
     },
     "roo-code": {
@@ -12085,7 +12142,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 12,
+      "count": 13,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 430 validation rules across 40 categories, sourced from 75+ references
+> 432 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 430 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 432 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (430 rules)
+├── VALIDATION-RULES.md             # Master validation reference (432 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **430 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **432 rules** |
 
 
 ### Validation Rules by Category
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **430** | **213** | **188** | **28** | **127** |
+| **TOTAL** | **432** | **213** | **188** | **28** | **127** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 430 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 432 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     430 rules
+Validation Rules:     432 rules
 Auto-Fixable Rules:   96 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 430 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 432 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-06-25
+**Last Updated**: 2026-06-27
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -16,31 +16,31 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-25 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
-| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-24 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
-| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-16 | AGM, XP, OC |
-| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-06-18 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-27 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
+| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-27 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
+| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-06-27 | AGM, XP, OC |
+| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-06-27 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 
 ### A Tier (test on major changes)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-04-22 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-06-16 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-06-21 | CUR |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-06-27 | CLN, CL-SK |
+| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-06-27 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Roo Code | `.roomodes`, `.rooignore`, `.roorules`, `.roo/rules/*.md`, `.roo/rules-{slug}/*.md`, `.roo/mcp.json` | https://github.com/RooCodeInc/Roo-Code | Automated (tool-release-watch.yml) | Quarterly | 2026-06-02 | ROO |
-| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-06-02 | AMP, AMP-SK |
+| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-06-27 | AMP, AMP-SK |
 
 ### C Tier (community reports fixes only)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-06-08 | GM |
+| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-06-27 | GM |
 
 ### D Tier (no support, nice to have)
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -429,6 +429,13 @@ Rules with an empty `applies_to` object (`{}`) apply universally.
 **Fix**: Manual - set entries to `{ "path": "...", "mode": "deny" }` for credential files and `{ "name": "...", "mode": "deny" }` for credential environment variables, or remove invalid entries.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.187 (added `sandbox.credentials`), code.claude.com/docs/en/settings, code.claude.com/docs/en/sandboxing
 
+<a id="cc-set-013"></a>
+### CC-SET-013 [MEDIUM] Non-boolean autoMode.classifyAllShell Setting
+**Requirement**: `autoMode.classifyAllShell` in `.claude/settings.json` / `.local.json` / `managed-settings.json` MUST be a boolean when present (Claude Code 2.1.193+). `true` routes all Bash/PowerShell commands through the auto-mode classifier; only strict `true`/`false` is documented.
+**Detection**: Parse settings.json; walk `autoMode.classifyAllShell`; flag (warning) non-boolean types (string, number, array, object). `null` values and absent keys are not flagged. Non-object `autoMode` values are ignored by this rule to avoid conflating container shape errors with the specific boolean toggle.
+**Fix**: Manual - set `autoMode.classifyAllShell` to an unquoted `true` or `false`.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.193 (added `autoMode.classifyAllShell`)
+
 ---
 
 ## PER-CLIENT SKILL RULES
@@ -2681,6 +2688,13 @@ Rules for local Gemini agent markdown files at `.gemini/agents/*.md`. These defi
 **Fix**: No auto-fix (set `skills` to a relative path string such as `./skills`, or remove the field)
 **Source**: github.com/openai/codex (codex-rs/core-plugins/src/manifest.rs @ rust-v0.137.0)
 
+<a id="cdx-pl-016"></a>
+### CDX-PL-016 [MEDIUM] Invalid Dark-mode Logo Path
+**Requirement**: Plugin manifest `interface.logoDark` MUST start with `./` and MUST NOT contain directory traversal
+**Detection**: Validate the dark-mode logo asset path for `./` prefix and absence of `..`
+**Fix**: No auto-fix (set `logoDark` to a package-relative asset path such as `./assets/logo-dark.png`)
+**Source**: github.com/openai/codex (openai/codex#29488, codex-rs/core-plugins/src/manifest.rs @ rust-v0.142.2)
+
 ---
 
 ### Codex Requirements Rules (CDX-REQ)
@@ -3507,8 +3521,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 430 validation rules across 40 categories
+**Total Coverage**: 432 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 213 HIGH, 189 MEDIUM, 28 LOW
-**Auto-Fixable**: 127 rules (30%)
+**Certainty**: 213 HIGH, 191 MEDIUM, 28 LOW
+**Auto-Fixable**: 127 rules (29%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 430,
-  "last_updated": "2026-06-25",
+  "total_rules": 432,
+  "last_updated": "2026-06-27",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3812,6 +3812,34 @@
       "bad_example": "{\n  \"sandbox\": {\n    \"credentials\": {\n      \"files\": [\n        {\"path\": \"~/.aws/credentials\", \"mode\": \"allow\"}\n      ],\n      \"envVars\": [\n        {\"name\": \"GITHUB_TOKEN\"}\n      ]\n    }\n  }\n}"
     },
     {
+      "id": "CC-SET-013",
+      "name": "Non-boolean autoMode.classifyAllShell Setting",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.193"
+        ],
+        "verified_on": "2026-06-27",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.193"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"autoMode\": {\"classifyAllShell\": true}\n}",
+      "bad_example": "{\n  \"autoMode\": {\"classifyAllShell\": \"true\"}\n}"
+    },
+    {
       "id": "CDX-000",
       "name": "TOML Parse Error",
       "severity": "HIGH",
@@ -5326,6 +5354,35 @@
       },
       "good_example": "{\"name\": \"my-plugin\", \"skills\": \"./skills\"}",
       "bad_example": "{\"name\": \"my-plugin\", \"skills\": [\"./skills\"]}"
+    },
+    {
+      "id": "CDX-PL-016",
+      "name": "Invalid Dark-mode Logo Path",
+      "severity": "MEDIUM",
+      "category": "codex",
+      "evidence": {
+        "source_type": "vendor_code",
+        "source_urls": [
+          "https://github.com/openai/codex/pull/29488",
+          "https://github.com/openai/codex/blob/rust-v0.142.2/codex-rs/core-plugins/src/manifest.rs"
+        ],
+        "verified_on": "2026-06-27",
+        "applies_to": {
+          "tool": "codex",
+          "version_range": ">=0.142.2"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\"name\": \"my-plugin\", \"interface\": {\"logoDark\": \"./assets/logo-dark.png\"}}",
+      "bad_example": "{\"name\": \"my-plugin\", \"interface\": {\"logoDark\": \"assets/logo-dark.png\"}}"
     },
     {
       "id": "CDX-CFG-023",
@@ -11965,7 +12022,7 @@
     },
     "codex": {
       "prefix": "CDX",
-      "count": 64,
+      "count": 65,
       "description": "Codex CLI configuration validation"
     },
     "roo-code": {
@@ -12085,7 +12142,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 12,
+      "count": 13,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -903,6 +903,9 @@ rules:
   cdx_pl_014:
     message: Missing 'description' field - recommended for marketplace visibility
     suggestion: Add a 'description' string to plugin.json for better discoverability
+  cdx_pl_016:
+    message: Dark-mode logo path '%{path}' in interface.logoDark must start with ./ and not use '..' traversal
+    suggestion: Use a relative dark-mode logo asset path such as './assets/logo-dark.png'
   roo_001:
     message: Roo Code rule file is empty
     suggestion: Add rule content to the file
@@ -1198,6 +1201,11 @@ rules:
       attribution toggle as a strict true/false setting
     suggestion: Set attribution.sessionUrl to an unquoted true or false. Use false to omit claude.ai session links from
       commits and PR descriptions created from web or Remote Control sessions.
+  cc_set_013:
+    message: autoMode.classifyAllShell must be a boolean when present (got %{actual}); Claude Code 2.1.193+ documents this
+      auto-mode setting as a strict true/false toggle
+    suggestion: Set autoMode.classifyAllShell to an unquoted true or false, or remove it to keep the default auto-mode
+      classifier scope.
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -626,6 +626,9 @@ rules:
   cdx_pl_014:
     message: Falta el campo 'description' - recomendado para visibilidad en el marketplace
     suggestion: Agrega una cadena 'description' a plugin.json para mejor descubrimiento
+  cdx_pl_016:
+    message: La ruta de logo oscuro '%{path}' en interface.logoDark debe comenzar con ./ y no usar recorrido '..'
+    suggestion: Usa una ruta relativa para el logo oscuro, como './assets/logo-dark.png'
   pe_001:
     message: Palabra clave critica '%{keyword}' al %{percent} por ciento del documento (40-60 por ciento es la zona 'perdido
       en el medio')
@@ -722,6 +725,11 @@ rules:
       documenta esta atribucion como una configuracion true/false estricta
     suggestion: Establece attribution.sessionUrl en true o false sin comillas. Usa false para omitir enlaces de sesion
       claude.ai en commits y descripciones de PR creados desde sesiones web o Remote Control.
+  cc_set_013:
+    message: autoMode.classifyAllShell debe ser un booleano cuando esta presente (se obtuvo %{actual}); Claude Code 2.1.193+
+      documenta esta configuracion de auto-mode como un interruptor true/false estricto
+    suggestion: Establece autoMode.classifyAllShell en true o false sin comillas, o quitalo para conservar el alcance
+      predeterminado del clasificador auto-mode.
 
 
 # ===========================================================================

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -604,6 +604,9 @@ rules:
   cdx_pl_014:
     message: 缺少 'description' 字段 - 建议添加以提高市场可见性
     suggestion: 在 plugin.json 中添加 'description' 字符串以提高可发现性
+  cdx_pl_016:
+    message: interface.logoDark 中的深色模式 logo 路径 '%{path}' 必须以 ./ 开头且不使用 '..' 遍历
+    suggestion: 使用相对深色模式 logo 资源路径，例如 './assets/logo-dark.png'
   pe_001:
     message: 关键词 '%{keyword}' 在文档的 %{percent} 百分比处（40-60 百分比是'中间遗忘'区域）
     suggestion: 将关键内容移到文档的开头或结尾以获得更好的记忆效果
@@ -686,6 +689,9 @@ rules:
   cc_set_009:
     message: attribution.sessionUrl 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.183+ 将该归因选项记录为严格的 true/false 设置
     suggestion: 将 attribution.sessionUrl 设置为不带引号的 true 或 false。使用 false 可在 Web 或 Remote Control 会话创建的 commit 和 PR 描述中省略 claude.ai 会话链接。
+  cc_set_013:
+    message: autoMode.classifyAllShell 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.193+ 将该 auto-mode 设置记录为严格的 true/false 开关
+    suggestion: 将 autoMode.classifyAllShell 设置为不带引号的 true 或 false，或移除此字段以保留默认的 auto-mode 分类器范围。
 
 
 # ===========================================================================

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.36.0",
-  "description": "Lint agent configurations before they break your workflow. 430 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 432 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "[email protected]",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 430 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 432 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 430 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 432 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 430 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 432 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/rules/generated/cc-set-013.md
+++ b/website/docs/rules/generated/cc-set-013.md
@@ -1,0 +1,52 @@
+---
+id: cc-set-013
+title: "CC-SET-013: Non-boolean autoMode.classifyAllShell Setting"
+sidebar_label: "CC-SET-013"
+description: "agnix rule CC-SET-013 checks for non-boolean automode.classifyallshell setting in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-013", "non-boolean automode.classifyallshell setting", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-013`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-06-27`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.193`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.193
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "autoMode": {"classifyAllShell": "true"}
+}
+```
+
+### Valid
+
+```json
+{
+  "autoMode": {"classifyAllShell": true}
+}
+```

--- a/website/docs/rules/generated/cdx-pl-016.md
+++ b/website/docs/rules/generated/cdx-pl-016.md
@@ -1,0 +1,49 @@
+---
+id: cdx-pl-016
+title: "CDX-PL-016: Invalid Dark-mode Logo Path - Codex CLI"
+sidebar_label: "CDX-PL-016"
+description: "agnix rule CDX-PL-016 checks for invalid dark-mode logo path in codex cli files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CDX-PL-016", "invalid dark-mode logo path", "codex cli", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CDX-PL-016`
+- **Severity**: `MEDIUM`
+- **Category**: `Codex CLI`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-06-27`
+
+## Applicability
+
+- **Tool**: `codex`
+- **Version Range**: `>=0.142.2`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/openai/codex/pull/29488
+- https://github.com/openai/codex/blob/rust-v0.142.2/codex-rs/core-plugins/src/manifest.rs
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{"name": "my-plugin", "interface": {"logoDark": "assets/logo-dark.png"}}
+```
+
+### Valid
+
+```json
+{"name": "my-plugin", "interface": {"logoDark": "./assets/logo-dark.png"}}
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `430` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `432` validation rules generated from `knowledge-base/rules.json`.
 `127` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -141,6 +141,7 @@ This section contains all `430` validation rules generated from `knowledge-base/
 | [CC-SET-010](./generated/cc-set-010.md) | Invalid teammateMode Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-011](./generated/cc-set-011.md) | Non-boolean respondToBashCommands Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-012](./generated/cc-set-012.md) | Invalid sandbox.credentials Setting | MEDIUM | Claude Settings | No |
+| [CC-SET-013](./generated/cc-set-013.md) | Non-boolean autoMode.classifyAllShell Setting | MEDIUM | Claude Settings | No |
 | [CDX-000](./generated/cdx-000.md) | TOML Parse Error | HIGH | Codex CLI | No |
 | [CDX-001](./generated/cdx-001.md) | Invalid Approval Mode | HIGH | Codex CLI | Yes (unsafe) |
 | [CDX-002](./generated/cdx-002.md) | Invalid Full Auto Error Mode | HIGH | Codex CLI | Yes (unsafe) |
@@ -195,6 +196,7 @@ This section contains all `430` validation rules generated from `knowledge-base/
 | [CDX-PL-013](./generated/cdx-pl-013.md) | Unsupported Hooks Field | LOW | Codex CLI | No |
 | [CDX-PL-014](./generated/cdx-pl-014.md) | Missing Description | LOW | Codex CLI | No |
 | [CDX-PL-015](./generated/cdx-pl-015.md) | Invalid Skills Path Type | MEDIUM | Codex CLI | No |
+| [CDX-PL-016](./generated/cdx-pl-016.md) | Invalid Dark-mode Logo Path | MEDIUM | Codex CLI | No |
 | [CDX-CFG-023](./generated/cdx-cfg-023.md) | Invalid Approval Policy Sub-field | MEDIUM | Codex CLI | Yes (safe) |
 | [CDX-CFG-024](./generated/cdx-cfg-024.md) | Invalid Approvals Reviewer Value | MEDIUM | Codex CLI | Yes (unsafe) |
 | [CDX-CFG-025](./generated/cdx-cfg-025.md) | Invalid Service Tier Value | MEDIUM | Codex CLI | Yes (unsafe) |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 430,
+  "totalRules": 432,
   "categoryCount": 40,
   "autofixCount": 127,
   "uniqueTools": [


### PR DESCRIPTION
## Summary
- Add `CC-SET-013` for Claude Code `autoMode.classifyAllShell` type validation, based on the v2.1.193 setting addition.
- Add `CDX-PL-016` for Codex plugin `interface.logoDark` path validation, based on the rust-v0.142.2 dark-mode logo manifest support.
- Update release-watch baselines and research tracking for amp, Claude Code, Cline, Codex, Cursor, Gemini CLI, Kiro CLI, and OpenCode.
- Regenerate rule catalog mirrors, locale mirrors, generated website docs, plugin metadata, and count references for 432 rules.

Closes #1079
Closes #1081
Closes #1082
Closes #1083
Closes #1084
Closes #1085
Closes #1086
Closes #1087

## Validation
- `UPDATE_BASELINES=true GITHUB_STEP_SUMMARY=/tmp/agnix-tool-release-summary.md bash scripts/check-tool-releases.sh`
- `GITHUB_STEP_SUMMARY=/tmp/agnix-tool-release-summary-check.md bash scripts/check-tool-releases.sh`
- `node scripts/sync-rule-bookkeeping.js --check --validators=43`
- `bash scripts/check-locale-sync.sh`
- `cmp -s CLAUDE.md AGENTS.md`
- `cargo test -p agnix-core claude_settings`
- `cargo test -p agnix-core codex_plugin`
- `cargo test --workspace`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Live CLI action: temporary Codex plugin manifest produced `CDX-PL-016`.
- Live CLI action: temporary Claude settings file produced `CC-SET-013`.
