### PR TITLE
fix: point shipped rule-doc URLs at live agent-sh.github.io host (refs #1099)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dead documentation host in shipped rule-doc URLs** (refs #1099). The docs site is served at `https://agent-sh.github.io/agnix/` (HTTP 200), but several user-facing rule-doc links still hard-coded the pre-migration `https://avifenesh.github.io/agnix` host, which now returns 404. Updated the live host in the LSP diagnostic `code_description` (clickable rule links in IDEs), the SARIF `helpUri` emitted for every rule (CI integrations), the VS Code `showRules`/`showRuleDoc` actions, the Neovim `AgnixShowRuleDoc` command and rule pickers, the npm/VS Code/`agnix-rules` READMEs, and the Docusaurus `url`/`organizationName`/JSON-LD and `robots.txt` sitemap. Historical `website/versioned_docs/**` snapshots and past changelog entries are intentionally left untouched. This is the same broken-doc-link class as the JetBrains Marketplace **Documentation** resource link in #1099 (that link is corrected in the Marketplace web admin, not in-repo).
+
 ## [0.36.2] - 2026-06-27
 
 ### Fixed

--- a/crates/agnix-cli/src/sarif.rs
+++ b/crates/agnix-cli/src/sarif.rs
@@ -147,7 +147,7 @@ static RULES: LazyLock<Vec<ReportingDescriptor>> = LazyLock::new(|| {
                     text: desc.to_string(),
                 },
                 help_uri: Some(format!(
-                    "https://avifenesh.github.io/agnix/docs/rules/generated/{}",
+                    "https://agent-sh.github.io/agnix/docs/rules/generated/{}",
                     id.to_lowercase()
                 )),
                 properties,
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     fn test_help_uri_format_and_anchor() {
         let rules = get_all_rules();
-        const BASE_URL: &str = "https://avifenesh.github.io/agnix/docs/rules/generated/";
+        const BASE_URL: &str = "https://agent-sh.github.io/agnix/docs/rules/generated/";
 
         for rule in rules {
             let uri = rule

--- a/crates/agnix-cli/tests/cli_integration.rs
+++ b/crates/agnix-cli/tests/cli_integration.rs
@@ -882,7 +882,7 @@ fn test_format_sarif_rules_have_help_uri() {
         assert!(
             help_uri
                 .unwrap()
-                .contains("avifenesh.github.io/agnix/docs/rules/generated/"),
+                .contains("agent-sh.github.io/agnix/docs/rules/generated/"),
             "helpUri should reference website rule docs"
         );
     }

--- a/crates/agnix-lsp/src/diagnostic_mapper.rs
+++ b/crates/agnix-lsp/src/diagnostic_mapper.rs
@@ -90,7 +90,7 @@ pub fn to_lsp_diagnostic(diag: &Diagnostic) -> LspDiagnostic {
     let data = serialize_diagnostic_data(diag);
 
     let code_description = Url::parse(&format!(
-        "https://avifenesh.github.io/agnix/docs/rules/generated/{}",
+        "https://agent-sh.github.io/agnix/docs/rules/generated/{}",
         diag.rule.to_lowercase()
     ))
     .ok()
@@ -257,7 +257,7 @@ mod tests {
             .expect("code_description should be set");
         assert_eq!(
             desc.href.as_str(),
-            "https://avifenesh.github.io/agnix/docs/rules/generated/as-001"
+            "https://agent-sh.github.io/agnix/docs/rules/generated/as-001"
         );
     }
 
@@ -270,7 +270,7 @@ mod tests {
             .expect("code_description should be set");
         assert_eq!(
             desc.href.as_str(),
-            "https://avifenesh.github.io/agnix/docs/rules/generated/cc-sk-001"
+            "https://agent-sh.github.io/agnix/docs/rules/generated/cc-sk-001"
         );
     }
 

--- a/crates/agnix-rules/README.md
+++ b/crates/agnix-rules/README.md
@@ -37,7 +37,7 @@ for (prefix, tool) in TOOL_RULE_PREFIXES {
 - **XML-xxx**: XML validation
 - **XP-xxx**: Cross-platform compatibility
 
-For full rule documentation, see the [rules reference](https://avifenesh.github.io/agnix/docs/rules).
+For full rule documentation, see the [rules reference](https://agent-sh.github.io/agnix/docs/rules).
 
 ## License
 

--- a/editors/neovim/lua/agnix/commands.lua
+++ b/editors/neovim/lua/agnix/commands.lua
@@ -110,7 +110,7 @@ function M.setup()
       vim.notify('[agnix] Invalid rule ID format: ' .. rule_id, vim.log.levels.ERROR)
       return
     end
-    local url = 'https://avifenesh.github.io/agnix/docs/rules/generated/'
+    local url = 'https://agent-sh.github.io/agnix/docs/rules/generated/'
       .. rule_id:lower()
     if vim.ui.open then
       vim.ui.open(url)
@@ -153,7 +153,7 @@ function M._show_rules_fallback()
   end
   vim.ui.select(items, { prompt = 'agnix rule categories:' }, function(choice)
     if choice then
-      local url = 'https://avifenesh.github.io/agnix/docs/rules'
+      local url = 'https://agent-sh.github.io/agnix/docs/rules'
       vim.notify('[agnix] See: ' .. url, vim.log.levels.INFO)
     end
   end)

--- a/editors/neovim/lua/agnix/telescope.lua
+++ b/editors/neovim/lua/agnix/telescope.lua
@@ -49,7 +49,7 @@ function M.pick_rules()
           actions.close(prompt_bufnr)
           local selection = action_state.get_selected_entry()
           if selection then
-            local url = 'https://avifenesh.github.io/agnix/docs/rules'
+            local url = 'https://agent-sh.github.io/agnix/docs/rules'
             vim.notify('[agnix] See: ' .. url, vim.log.levels.INFO)
           end
         end)

--- a/editors/neovim/tests/agnix/test_commands.lua
+++ b/editors/neovim/tests/agnix/test_commands.lua
@@ -266,7 +266,7 @@ local function test_show_rules_fallback_selection()
   assert(#notify_messages > 0, 'should notify with a URL after selection')
   local found_url = false
   for _, msg in ipairs(notify_messages) do
-    if msg:find('avifenesh%.github%.io/agnix/docs/rules') then
+    if msg:find('agent%-sh%.github%.io/agnix/docs/rules') then
       found_url = true
       break
     end

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -190,7 +190,7 @@ The auto-downloaded binary is stored in the extension's global storage directory
 ## Links
 
 - [agnix on GitHub](https://github.com/agent-sh/agnix)
-- [Validation Rules Reference](https://avifenesh.github.io/agnix/docs/rules)
+- [Validation Rules Reference](https://agent-sh.github.io/agnix/docs/rules)
 - [Agent Skills Specification](https://agentskills.io)
 - [Model Context Protocol](https://modelcontextprotocol.io)
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1046,7 +1046,7 @@ async function showRules(): Promise<void> {
     // Open documentation
     vscode.env.openExternal(
       vscode.Uri.parse(
-        'https://avifenesh.github.io/agnix/docs/rules'
+        'https://agent-sh.github.io/agnix/docs/rules'
       )
     );
   }
@@ -1688,7 +1688,7 @@ class AgnixDiagnosticsTreeProvider implements vscode.TreeDataProvider<Diagnostic
  * Show documentation for a specific rule.
  */
 async function showRuleDoc(ruleId: string): Promise<void> {
-  const url = `https://avifenesh.github.io/agnix/docs/rules/generated/${ruleId.toLowerCase()}`;
+  const url = `https://agent-sh.github.io/agnix/docs/rules/generated/${ruleId.toLowerCase()}`;
   vscode.env.openExternal(vscode.Uri.parse(url));
 }
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -96,7 +96,7 @@ Run `agnix --help` for the full command reference.
 ## Links
 
 - [GitHub Repository](https://github.com/agent-sh/agnix)
-- [Validation Rules](https://avifenesh.github.io/agnix/docs/rules)
+- [Validation Rules](https://agent-sh.github.io/agnix/docs/rules)
 - [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix)
 
 ## License

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -8,10 +8,10 @@ const config = {
   tagline: 'Lint agent configurations before they break your workflow',
   favicon: 'img/logo.png',
 
-  url: 'https://avifenesh.github.io',
+  url: 'https://agent-sh.github.io',
   baseUrl: '/agnix/',
 
-  organizationName: 'avifenesh',
+  organizationName: 'agent-sh',
   projectName: 'agnix',
 
   onBrokenLinks: 'throw',
@@ -54,7 +54,7 @@ const config = {
           `Linter for AI agent configurations. ${siteData.totalRules} rules across Claude Code, Codex, OpenCode, Kiro, Cursor, Copilot, and more. CLI, LSP, and IDE plugins.`,
         applicationCategory: 'DeveloperApplication',
         operatingSystem: 'Windows, macOS, Linux',
-        url: 'https://avifenesh.github.io/agnix/',
+        url: 'https://agent-sh.github.io/agnix/',
         downloadUrl: 'https://github.com/agent-sh/agnix/releases',
         codeRepository: 'https://github.com/agent-sh/agnix',
         programmingLanguage: 'Rust',

--- a/website/static/robots.txt
+++ b/website/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://avifenesh.github.io/agnix/sitemap.xml
+Sitemap: https://agent-sh.github.io/agnix/sitemap.xml


### PR DESCRIPTION
## Summary

The agnix docs site is served at `https://agent-sh.github.io/agnix/` (HTTP 200), but the pre-migration host `https://avifenesh.github.io/agnix` now returns **404**. Several user-facing rule-doc URLs were still hard-coded to the dead host, so "open rule docs" links shipped to users were broken.

This is the in-repo half of #1099 — the same broken-documentation-link class as the JetBrains Marketplace **Documentation** resource link. (The Marketplace sidebar links themselves are stored in the Marketplace web admin, not in this repo; that fix is described in #1099.)

### Changed `avifenesh.github.io` → `agent-sh.github.io`
- `crates/agnix-lsp/src/diagnostic_mapper.rs` — LSP diagnostic `code_description` (clickable rule links in IDEs) + tests
- `crates/agnix-cli/src/sarif.rs` — SARIF `helpUri` for every rule (CI integrations) + test
- `crates/agnix-cli/tests/cli_integration.rs` — `helpUri` host assertion
- `editors/vscode/src/extension.ts` — `showRules` + `showRuleDoc`
- `editors/neovim/lua/agnix/commands.lua`, `editors/neovim/lua/agnix/telescope.lua` — `AgnixShowRuleDoc` + rule pickers
- `website/docusaurus.config.js` — `url`, `organizationName`, JSON-LD `url`
- `website/static/robots.txt` — sitemap URL
- `npm/README.md`, `editors/vscode/README.md`, `crates/agnix-rules/README.md`

Historical `website/versioned_docs/**` / `website/versioned_sidebars/**` snapshots and past `CHANGELOG.md` entries are intentionally left untouched.

## Type of Change

- [x] Bug fix
- [x] Documentation

## Checklist

- [x] Tests added/updated (existing host assertions updated in `diagnostic_mapper`, `sarif`, `cli_integration`)
- [x] CHANGELOG.md updated
- [x] Documentation updated (if applicable)
- [x] `cargo fmt && cargo clippy` passes

## Related Issues

Refs #1099

## Test Plan

- `cargo test -p agnix-lsp --lib diagnostic_mapper` → 24 passed
- `cargo test -p agnix-cli --bin agnix sarif` → 30 passed
- `cargo test -p agnix-cli --test cli_integration test_format_sarif_rules_have_help_uri` → passed
- `cargo fmt --check` clean; `cargo clippy -p agnix-lsp -p agnix-cli --all-targets` clean
- Live check: `agnix --format sarif tests/fixtures/invalid/skills` emits `agent-sh.github.io` for all 432 rule `helpUri`s, zero `avifenesh.github.io`
- Verified `https://agent-sh.github.io/agnix/docs/rules` and `.../docs/rules/generated/as-001` return 200; the old `avifenesh.github.io` equivalents return 404
