### PR TITLE
[codex] fix JetBrains LSP binary path validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **JetBrains plugin LSP binary path validation**. The **LSP binary path** setting now rejects relative values like `agnix-lsp.exe` and tells users to provide the full absolute executable path, so locked-down Windows users do not silently fall back to the blocked auto-downloaded binary.
+
 ## [0.37.0] - 2026-07-02
 
 ### Added

--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -239,8 +239,9 @@ running the server from an allowed location: download
 `agnix-lsp-x86_64-pc-windows-msvc.zip` from the
 [releases](https://github.com/agent-sh/agnix/releases), extract it somewhere
 whitelisted (e.g. `C:\Program Files\agnix\`), set **Tools → agnix → Settings →
-LSP binary path** to it, and restart the language server — or ask IT to
-allowlist the path. See the
+LSP binary path** to the full absolute executable path (for example
+`C:\Program Files\agnix\agnix-lsp.exe`, not just `agnix-lsp.exe`), and restart
+the language server. Alternatively, ask IT to allowlist the path. See the
 [JetBrains plugin README](../editors/jetbrains/README.md#troubleshooting) for details.
 
 ## Zed

--- a/editors/jetbrains/CHANGELOG.md
+++ b/editors/jetbrains/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Surface an actionable notification when the OS or a security policy blocks execution of `agnix-lsp` (e.g. AppLocker/WDAC, EDR, or antivirus on locked-down Windows producing `CreateProcess error=5, Access is denied`). Previously this only appeared as a raw `CannotStartProcessException` stack trace. The notification explains the cause and offers "Set Binary Path" and "Troubleshooting" actions, since upgrading the IDE does not resolve an OS-level execution block. Access-denied detection is locale-independent (matches the Win32 `error=5` / POSIX `errno=13`/`EACCES` codes, not localized text).
+- Reject relative values in **LSP binary path** (for example `agnix-lsp.exe`) and tell users to provide the full absolute executable path, preventing the plugin from silently falling back to the blocked downloaded copy.
 
 ## [0.36.2] - 2026-06-27
 

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -96,8 +96,9 @@ Resolve it by running `agnix-lsp` from an allowed location:
    a whitelisted path (e.g. `C:\Program Files\agnix\`), or use `%USERPROFILE%\.cargo\bin`.
    (`cargo install agnix-cli` installs the CLI, not the LSP server, so use the
    release asset.)
-2. In the IDE: **Tools → agnix → Settings → LSP binary path** → point it at that
-   `agnix-lsp.exe`, then restart the language server (`Tools → agnix → Restart
-   Language Server`). The configured path takes priority over the blocked
+2. In the IDE: **Tools → agnix → Settings → LSP binary path** → point it at the
+   full absolute path to that executable, e.g. `C:\Program Files\agnix\agnix-lsp.exe`
+   (not just `agnix-lsp.exe`), then restart the language server (`Tools → agnix →
+   Restart Language Server`). The configured path takes priority over the blocked
    auto-downloaded copy.
 3. Alternatively, ask IT to allowlist the binary or the `%AppData%` plugin path.

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixLspPathValidation.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixLspPathValidation.kt
@@ -1,0 +1,36 @@
+package io.agnix.jetbrains.settings
+
+import java.io.File
+
+/**
+ * Validation for the optional user-configured agnix-lsp executable path.
+ */
+object AgnixLspPathValidation {
+
+    const val ABSOLUTE_PATH_REQUIRED_MESSAGE =
+        "LSP binary path must be a full absolute executable path, for example " +
+            "C:\\Program Files\\agnix\\agnix-lsp.exe. Do not use just agnix-lsp.exe."
+
+    private val windowsDriveAbsolutePath = Regex("^[A-Za-z]:[\\\\/].+")
+    private val windowsUncAbsolutePath = Regex("^\\\\\\\\[^\\\\/]+[\\\\/][^\\\\/]+.*")
+
+    fun validate(path: String): String? {
+        val trimmed = path.trim()
+        if (trimmed.isEmpty()) {
+            return null
+        }
+
+        return if (isAbsolutePath(trimmed)) {
+            null
+        } else {
+            ABSOLUTE_PATH_REQUIRED_MESSAGE
+        }
+    }
+
+    internal fun isAbsolutePath(path: String): Boolean {
+        val trimmed = path.trim()
+        return File(trimmed).isAbsolute ||
+            windowsDriveAbsolutePath.matches(trimmed) ||
+            windowsUncAbsolutePath.matches(trimmed)
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixLspPathValidation.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixLspPathValidation.kt
@@ -29,7 +29,8 @@ object AgnixLspPathValidation {
 
     internal fun isAbsolutePath(path: String): Boolean {
         val trimmed = path.trim()
-        return File(trimmed).isAbsolute ||
+        return trimmed.startsWith('/') ||
+            File(trimmed).isAbsolute ||
             windowsDriveAbsolutePath.matches(trimmed) ||
             windowsUncAbsolutePath.matches(trimmed)
     }

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurable.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurable.kt
@@ -1,6 +1,7 @@
 package io.agnix.jetbrains.settings
 
 import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.options.ConfigurationException
 import io.agnix.jetbrains.binary.AgnixBinaryResolver
 import javax.swing.JComponent
 
@@ -29,7 +30,7 @@ class AgnixSettingsConfigurable : Configurable {
         val component = settingsComponent ?: return false
 
         return component.enabled != settings.enabled ||
-            component.lspPath != settings.lspPath ||
+            component.lspPath.trim() != settings.lspPath ||
             component.autoDownload != settings.autoDownload ||
             component.traceLevel != settings.traceLevel ||
             component.codeLensEnabled != settings.codeLensEnabled
@@ -39,10 +40,15 @@ class AgnixSettingsConfigurable : Configurable {
         val settings = AgnixSettings.getInstance()
         val component = settingsComponent ?: return
 
-        val lspPathChanged = settings.lspPath != component.lspPath
+        val lspPath = component.lspPath.trim()
+        AgnixLspPathValidation.validate(lspPath)?.let { message ->
+            throw ConfigurationException(message)
+        }
+
+        val lspPathChanged = settings.lspPath != lspPath
 
         settings.enabled = component.enabled
-        settings.lspPath = component.lspPath
+        settings.lspPath = lspPath
         settings.autoDownload = component.autoDownload
         settings.traceLevel = component.traceLevel
         settings.codeLensEnabled = component.codeLensEnabled

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/settings/AgnixLspPathValidationTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/settings/AgnixLspPathValidationTest.kt
@@ -1,0 +1,40 @@
+package io.agnix.jetbrains.settings
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AgnixLspPathValidationTest {
+
+    @Test
+    fun `blank path is allowed for auto detection`() {
+        assertNull(AgnixLspPathValidation.validate(""))
+        assertNull(AgnixLspPathValidation.validate("   "))
+    }
+
+    @Test
+    fun `bare agnix-lsp exe is rejected with absolute path guidance`() {
+        val error = AgnixLspPathValidation.validate("agnix-lsp.exe")
+
+        assertTrue(error!!.contains("full absolute executable path"))
+        assertTrue(error.contains("C:\\Program Files\\agnix\\agnix-lsp.exe"))
+        assertTrue(error.contains("Do not use just agnix-lsp.exe"))
+    }
+
+    @Test
+    fun `relative paths are rejected`() {
+        assertFalse(AgnixLspPathValidation.isAbsolutePath("agnix-lsp.exe"))
+        assertFalse(AgnixLspPathValidation.isAbsolutePath("./agnix-lsp"))
+        assertFalse(AgnixLspPathValidation.isAbsolutePath("bin\\agnix-lsp.exe"))
+        assertFalse(AgnixLspPathValidation.isAbsolutePath("C:agnix-lsp.exe"))
+    }
+
+    @Test
+    fun `absolute paths are accepted`() {
+        assertTrue(AgnixLspPathValidation.isAbsolutePath("/usr/local/bin/agnix-lsp"))
+        assertTrue(AgnixLspPathValidation.isAbsolutePath("C:\\Program Files\\agnix\\agnix-lsp.exe"))
+        assertTrue(AgnixLspPathValidation.isAbsolutePath("C:/Program Files/agnix/agnix-lsp.exe"))
+        assertTrue(AgnixLspPathValidation.isAbsolutePath("\\\\server\\share\\agnix-lsp.exe"))
+    }
+}


### PR DESCRIPTION
## Summary

- Reject non-empty relative values in the JetBrains **LSP binary path** setting, including the Bankdata support-loop value `agnix-lsp.exe`.
- Show a direct settings error telling users to provide a full absolute executable path such as `C:\Program Files\agnix\agnix-lsp.exe`.
- Keep empty values working for auto-detection/downloaded/PATH fallback, and update JetBrains/root docs and changelogs.

## Why

Frank Henningsen's June 29-30 support thread showed a managed Windows machine where the bundled `%AppData%` `agnix-lsp.exe` could not execute. The workaround was correct only if the setting points at a full executable path in an allowed location. A bare `agnix-lsp.exe` could not be accepted as a configured executable, so the plugin could silently continue into the downloaded/PATH fallback and send the user back to the blocked binary.

This fails earlier and plainly in the JetBrains settings flow, preventing that exact support loop.

Closes #1102

## Validation

- `git diff --cached --check`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew --no-daemon test`