### PR TITLE
Harden MCP path handling and validation panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Docs website deployment payload**. Reduced the GitHub Pages deploy window from six to three docs versions while keeping all versioned snapshots in the repository, so release docs publish with a smaller Pages artifact and avoid repeated `syncing_files` deployment failures.
+- **Security: MCP path confinement and panic hardening**. The MCP `validate_file` and `validate_project` tools now reject client-supplied paths that canonicalize outside the server working directory. Completion helpers clamp raw byte offsets to UTF-8 character boundaries before slicing, project validation converts per-file validator panics into diagnostics, and release builds keep unwinding enabled so one bad file cannot abort an entire scan.
 
 ## [0.37.1] - 2026-07-04
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,4 +87,3 @@ lto = "fat"
 codegen-units = 1
 strip = true
 opt-level = 3
-panic = "abort"

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -380,6 +380,8 @@ rules:
     message: Import cache lock was poisoned by a prior validator panic; recovered stale data
     suggestion: A validator panicked while holding the import cache lock. Validation continues with recovered data, but results
       may be stale.
+  file_panic_error: 'Validation panicked while processing this file: %{error}'
+  file_panic_error_suggestion: Please report this as a bug with the file type and rule context
   xp_001:
     message: 'Claude-specific feature ''%{feature}'' in %{filename}: %{description}'
     suggestion: Move to CLAUDE.md or wrap in a Claude-specific section (e.g., '## Claude Code Specific')

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -300,6 +300,8 @@ rules:
       pueden estar desactualizados
     suggestion: Un validador entró en pánico mientras sostenía el bloqueo de caché de importaciones. La validación continúa
       con datos recuperados, pero los resultados pueden estar desactualizados.
+  file_panic_error: 'La validación entró en pánico al procesar este archivo: %{error}'
+  file_panic_error_suggestion: Reporta esto como bug con el tipo de archivo y el contexto de la regla
   xp_001:
     message: 'Caracteristica especifica de Claude ''%{feature}'' en %{filename}: %{description}'
     suggestion: Mueve a CLAUDE.md o envuelve en una seccion especifica de Claude (ej., '## Claude Code Specific')

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -285,6 +285,8 @@ rules:
   cache_poison:
     message: 导入缓存锁被先前的验证器崩溃毒化；恢复的数据可能已过期
     suggestion: 验证器在持有导入缓存锁时崩溃。验证将继续使用恢复的数据，但结果可能已过期。
+  file_panic_error: '验证此文件时发生崩溃: %{error}'
+  file_panic_error_suggestion: 请将此作为 bug 报告，并附上文件类型和规则上下文
   xp_001:
     message: '%{filename} 中的 Claude 特有功能 ''%{feature}'': %{description}'
     suggestion: 移至 CLAUDE.md 或包装在 Claude 特定部分中（例如 '## Claude Code Specific'）

--- a/crates/agnix-core/src/authoring.rs
+++ b/crates/agnix-core/src/authoring.rs
@@ -134,8 +134,16 @@ fn is_json_family(file_type: FileType) -> bool {
     )
 }
 
+fn clamp_to_char_boundary(content: &str, cursor_byte: usize) -> usize {
+    let mut clamped = cursor_byte.min(content.len());
+    while clamped > 0 && !content.is_char_boundary(clamped) {
+        clamped -= 1;
+    }
+    clamped
+}
+
 fn line_bounds_at(content: &str, cursor_byte: usize) -> (usize, usize) {
-    let clamped = cursor_byte.min(content.len());
+    let clamped = clamp_to_char_boundary(content, cursor_byte);
     let line_start = content[..clamped]
         .rfind('\n')
         .map(|idx| idx + 1)
@@ -173,6 +181,8 @@ fn detect_cursor_context(file_type: FileType, content: &str, cursor_byte: usize)
     if content.is_empty() {
         return CursorContext::Key;
     }
+
+    let cursor_byte = clamp_to_char_boundary(content, cursor_byte);
 
     if is_yaml_family(file_type) {
         let parts = split_frontmatter(content);
@@ -233,7 +243,7 @@ pub fn completion_candidates(
     let Some(family) = family_for_file_type(file_type) else {
         return Vec::new();
     };
-    let cursor = cursor_byte.min(content.len());
+    let cursor = clamp_to_char_boundary(content, cursor_byte);
     let context = detect_cursor_context(file_type, content, cursor);
     let mut out = Vec::new();
 
@@ -652,6 +662,20 @@ mod tests {
         assert!(
             !candidates.is_empty(),
             "partial/invalid content should still return fallback completions"
+        );
+    }
+
+    #[test]
+    fn test_completion_candidates_clamps_mid_codepoint_cursor() {
+        let content = "{\"😀\": 1}";
+        let cursor_inside_emoji = 3;
+        assert!(!content.is_char_boundary(cursor_inside_emoji));
+
+        let candidates = completion_candidates(FileType::Mcp, content, cursor_inside_emoji);
+
+        assert!(
+            !candidates.is_empty(),
+            "mid-codepoint cursor offsets should be clamped before slicing"
         );
     }
 }

--- a/crates/agnix-core/src/pipeline.rs
+++ b/crates/agnix-core/src/pipeline.rs
@@ -30,6 +30,17 @@ use crate::rules::project_level::run_project_level_checks;
 #[cfg(feature = "filesystem")]
 use crate::schemas;
 
+#[cfg(feature = "filesystem")]
+fn panic_payload_message(err: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = err.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = err.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
 /// Result of validating a project, including diagnostics and metadata.
 ///
 /// All fields are public. Use [`ValidationResult::new`] for convenient construction when only
@@ -767,18 +778,16 @@ pub fn validate_project_with_registry(
                     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         validate_file_with_type(&file_path, file_type, &config, registry)
                     })) {
-                        Err(_) => {
+                        Err(err) => {
+                            let panic_message = panic_payload_message(err.as_ref());
                             let panic_diag = Diagnostic::error(
                                 file_path,
                                 0,
                                 0,
                                 "file::panic",
-                                "Validation panicked while processing this file".to_string(),
+                                t!("rules.file_panic_error", error = panic_message),
                             )
-                            .with_suggestion(
-                                "Please report this as a bug with the file type and rule context"
-                                    .to_string(),
-                            );
+                            .with_suggestion(t!("rules.file_panic_error_suggestion"));
                             diags.push(panic_diag);
                         }
                         Ok(result) => match result {
@@ -1391,10 +1400,11 @@ mod tests {
 
         assert_eq!(result.files_checked, 1);
         assert!(
-            result
-                .diagnostics
-                .iter()
-                .any(|diag| { diag.rule == "file::panic" && diag.file == skill_path }),
+            result.diagnostics.iter().any(|diag| {
+                diag.rule == "file::panic"
+                    && diag.file == skill_path
+                    && diag.message.contains("intentional validator panic")
+            }),
             "expected file::panic diagnostic, got {:?}",
             result.diagnostics
         );

--- a/crates/agnix-core/src/pipeline.rs
+++ b/crates/agnix-core/src/pipeline.rs
@@ -764,37 +764,55 @@ pub fn validate_project_with_registry(
 
                     // Validate the file using the pre-resolved file_type to avoid
                     // re-compiling [files] glob patterns for every file.
-                    match validate_file_with_type(&file_path, file_type, &config, registry) {
-                        Ok(ValidationOutcome::Success(file_diagnostics)) => {
-                            diags.extend(file_diagnostics);
-                        }
-                        Ok(ValidationOutcome::IoError(file_error)) => {
-                            diags.push(
-                                Diagnostic::error(
-                                    file_path,
-                                    0,
-                                    0,
-                                    "file::read",
-                                    t!("rules.file_read_error", error = file_error.to_string()),
-                                )
-                                .with_suggestion(t!("rules.file_read_error_suggestion")),
+                    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        validate_file_with_type(&file_path, file_type, &config, registry)
+                    })) {
+                        Err(_) => {
+                            let panic_diag = Diagnostic::error(
+                                file_path,
+                                0,
+                                0,
+                                "file::panic",
+                                "Validation panicked while processing this file".to_string(),
+                            )
+                            .with_suggestion(
+                                "Please report this as a bug with the file type and rule context"
+                                    .to_string(),
                             );
+                            diags.push(panic_diag);
                         }
-                        Ok(ValidationOutcome::Skipped) => {
-                            // File type unknown - no validation needed
-                        }
-                        Err(e) => {
-                            diags.push(
-                                Diagnostic::error(
-                                    file_path,
-                                    0,
-                                    0,
-                                    "file::read",
-                                    t!("rules.file_read_error", error = e.to_string()),
-                                )
-                                .with_suggestion(t!("rules.file_read_error_suggestion")),
-                            );
-                        }
+                        Ok(result) => match result {
+                            Ok(ValidationOutcome::Success(file_diagnostics)) => {
+                                diags.extend(file_diagnostics);
+                            }
+                            Ok(ValidationOutcome::IoError(file_error)) => {
+                                diags.push(
+                                    Diagnostic::error(
+                                        file_path,
+                                        0,
+                                        0,
+                                        "file::read",
+                                        t!("rules.file_read_error", error = file_error.to_string()),
+                                    )
+                                    .with_suggestion(t!("rules.file_read_error_suggestion")),
+                                );
+                            }
+                            Ok(ValidationOutcome::Skipped) => {
+                                // File type unknown - no validation needed
+                            }
+                            Err(e) => {
+                                diags.push(
+                                    Diagnostic::error(
+                                        file_path,
+                                        0,
+                                        0,
+                                        "file::read",
+                                        t!("rules.file_read_error", error = e.to_string()),
+                                    )
+                                    .with_suggestion(t!("rules.file_read_error_suggestion")),
+                                );
+                            }
+                        },
                     }
 
                     (diags, agents, instructions)
@@ -1341,5 +1359,44 @@ mod tests {
                 lf_d.rule
             );
         }
+    }
+
+    #[test]
+    fn validate_project_converts_file_panic_to_diagnostic() {
+        use crate::config::PerFileLintConfig;
+        use crate::rules::Validator;
+
+        struct PanickingValidator;
+
+        impl Validator for PanickingValidator {
+            fn validate_per_file(
+                &self,
+                _path: &Path,
+                _content: &str,
+                _config: &PerFileLintConfig<'_>,
+            ) -> Vec<Diagnostic> {
+                panic!("intentional validator panic");
+            }
+        }
+
+        let temp = tempfile::TempDir::new().unwrap();
+        let skill_path = temp.path().join("SKILL.md");
+        std::fs::write(&skill_path, "---\nname: test\n---\nBody").unwrap();
+
+        let mut registry = ValidatorRegistry::new();
+        registry.register(FileType::Skill, || Box::new(PanickingValidator));
+
+        let result = validate_project_with_registry(temp.path(), &LintConfig::default(), &registry)
+            .expect("panicking per-file validator should become a diagnostic");
+
+        assert_eq!(result.files_checked, 1);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diag| { diag.rule == "file::panic" && diag.file == skill_path }),
+            "expected file::panic diagnostic, got {:?}",
+            result.diagnostics
+        );
     }
 }

--- a/crates/agnix-mcp/src/main.rs
+++ b/crates/agnix-mcp/src/main.rs
@@ -33,7 +33,7 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const TOOL_ALIASES: &[(&str, &str)] =
     &[("copilot", "github-copilot"), ("claudecode", "claude-code")];
@@ -42,14 +42,14 @@ const COMPAT_TOOL_NAMES: &[&str] = &["generic", "codex"];
 
 /// Input for validate_file tool.
 ///
-/// The `path` field accepts absolute or relative paths. Path safety is enforced
-/// downstream by `safe_read_file()` (symlink rejection, size limits).
+/// The `path` field accepts paths inside the server working directory. Path
+/// safety is enforced before validation and downstream by `safe_read_file()`.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[schemars(description = "Input for validating a single agent configuration file")]
 pub struct ValidateFileInput {
     /// Path to the file to validate
     #[schemars(
-        description = "Absolute or relative path to the agent configuration file (e.g., 'SKILL.md', '.claude/settings.json', 'mcp-config.json')"
+        description = "Path to an agent configuration file inside the server working directory (e.g., 'SKILL.md', '.claude/settings.json', 'mcp-config.json')"
     )]
     pub path: String,
     /// Tools to validate for (preferred over legacy target)
@@ -371,6 +371,36 @@ fn make_invalid_params(msg: String) -> McpError {
     McpError::invalid_params(msg, None::<Value>)
 }
 
+fn resolve_path_within_workspace(
+    input_path: &str,
+    workspace_root: &Path,
+) -> Result<PathBuf, String> {
+    let canonical_root = workspace_root
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve workspace root: {e}"))?;
+    let requested = Path::new(input_path);
+    let candidate = if requested.is_absolute() {
+        requested.to_path_buf()
+    } else {
+        canonical_root.join(requested)
+    };
+    let canonical_candidate = candidate
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve path: {e}"))?;
+
+    if !canonical_candidate.starts_with(&canonical_root) {
+        return Err(format!("Path outside workspace boundary: {input_path}"));
+    }
+
+    Ok(canonical_candidate)
+}
+
+fn resolve_mcp_path(input_path: &str) -> Result<PathBuf, McpError> {
+    let workspace_root = std::env::current_dir()
+        .map_err(|e| make_internal_error(format!("Failed to read current directory: {e}")))?;
+    resolve_path_within_workspace(input_path, &workspace_root).map_err(make_invalid_params)
+}
+
 /// Agnix MCP Server - validates AI agent configurations
 ///
 /// Provides tools to validate SKILL.md, CLAUDE.md, AGENTS.md, hooks,
@@ -407,9 +437,9 @@ impl AgnixServer {
         let mut config = LintConfig::default();
         apply_tool_selection(&mut config, input.tools, input.target)?;
 
-        let file_path = Path::new(&input.path);
+        let file_path = resolve_mcp_path(&input.path)?;
 
-        let outcome = core_validate_file(file_path, &config)
+        let outcome = core_validate_file(&file_path, &config)
             .map_err(|e| make_invalid_params(format!("Failed to validate file: {}", e)))?;
 
         let diagnostics = outcome.into_diagnostics();
@@ -431,7 +461,9 @@ impl AgnixServer {
         let mut config = LintConfig::default();
         apply_tool_selection(&mut config, input.tools, input.target)?;
 
-        let validation_result = core_validate_project(Path::new(&input.path), &config)
+        let project_path = resolve_mcp_path(&input.path)?;
+
+        let validation_result = core_validate_project(&project_path, &config)
             .map_err(|e| make_invalid_params(format!("Failed to validate project: {}", e)))?;
 
         let result = diagnostics_to_result(
@@ -551,7 +583,7 @@ async fn main() -> anyhow::Result<()> {
 mod tests {
     use super::{
         ToolsInput, ValidateFileInput, ValidateProjectInput, apply_tool_selection,
-        make_internal_error, make_invalid_params, parse_tools,
+        make_internal_error, make_invalid_params, parse_tools, resolve_path_within_workspace,
     };
     use agnix_core::LintConfig;
     use agnix_core::config::TargetTool;
@@ -794,6 +826,46 @@ mod tests {
             }
             _ => panic!("expected array tools variant"),
         }
+    }
+
+    #[test]
+    fn test_resolve_path_within_workspace_accepts_child_file() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let file = temp.path().join("SKILL.md");
+        std::fs::write(&file, "---\nname: test\n---\n").unwrap();
+
+        let resolved = resolve_path_within_workspace("SKILL.md", temp.path())
+            .expect("workspace child path should resolve");
+
+        assert_eq!(resolved, file.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_resolve_path_within_workspace_rejects_parent_traversal() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        let outside_file = outside.path().join("secret.md");
+        std::fs::write(&outside_file, "secret").unwrap();
+        let traversal = format!(
+            "../{}/secret.md",
+            outside.path().file_name().unwrap().to_string_lossy()
+        );
+
+        let err = resolve_path_within_workspace(&traversal, workspace.path())
+            .expect_err("parent traversal must be rejected");
+
+        assert!(err.contains("outside workspace boundary"));
+    }
+
+    #[test]
+    fn test_resolve_path_within_workspace_rejects_absolute_outside_path() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+
+        let err = resolve_path_within_workspace(outside.path().to_str().unwrap(), workspace.path())
+            .expect_err("absolute outside paths must be rejected");
+
+        assert!(err.contains("outside workspace boundary"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Thanks to @HetCreep for the reports. This PR fixes the runtime safety issues by:

- confining MCP `validate_file` and `validate_project` paths to the server working directory after canonicalization
- clamping authoring completion byte offsets to UTF-8 character boundaries before slicing
- converting per-file project-validation panics into `file::panic` diagnostics
- keeping release builds on unwind panics so the per-file isolation works in shipped binaries
- documenting the release-bound change in `CHANGELOG.md`

## Validation

- `cargo test -p agnix-core authoring`
- `cargo test -p agnix-core validate_project_converts_file_panic_to_diagnostic`
- `cargo test -p agnix-mcp resolve_path_within_workspace`
- `cargo test -p agnix-core`
- `cargo test -p agnix-mcp`
- `cargo fmt --check --all`
- `git diff --check`
- `diff -q CLAUDE.md AGENTS.md`