### PR TITLE
Verify release downloads before install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,8 @@ jobs:
           set -euo pipefail
           cd target/${{ matrix.target }}/release
           if [ -f agnix-lsp ]; then
+            lsp_hash="$(shasum -a 256 agnix-lsp | awk '{print $1}')"
+            printf '%s  agnix-lsp\n' "$lsp_hash" > ../../../agnix-lsp-${{ matrix.target }}.sha256
             tar czvf ../../../agnix-lsp-${{ matrix.target }}.tar.gz agnix-lsp
             cd ../../..
             shasum -a 256 agnix-lsp-${{ matrix.target }}.tar.gz > agnix-lsp-${{ matrix.target }}.tar.gz.sha256
@@ -105,6 +107,8 @@ jobs:
         run: |
           cd target/${{ matrix.target }}/release
           if (Test-Path agnix-lsp.exe) {
+            $lspHash = (Get-FileHash agnix-lsp.exe -Algorithm SHA256).Hash.ToLower()
+            "$lspHash  agnix-lsp.exe" | Out-File -Encoding ASCII ../../../agnix-lsp-${{ matrix.target }}.sha256
             Compress-Archive -Path agnix-lsp.exe -DestinationPath ../../../agnix-lsp-${{ matrix.target }}.zip
             cd ../../..
             (Get-FileHash agnix-lsp-${{ matrix.target }}.zip -Algorithm SHA256).Hash.ToLower() + "  agnix-lsp-${{ matrix.target }}.zip" | Out-File -Encoding ASCII agnix-lsp-${{ matrix.target }}.zip.sha256
@@ -142,9 +146,33 @@ jobs:
             agnix-mcp-${{ matrix.target }}.*
           if-no-files-found: error
 
+  test:
+    name: Test release commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+
+      - name: Format check
+        run: cargo fmt --check --all
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace
+
   release:
     name: Create Release
-    needs: build
+    needs: [build, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -199,7 +227,7 @@ jobs:
 
   publish:
     name: Publish to crates.io
-    needs: build
+    needs: [build, test]
     runs-on: ubuntu-latest
     # Skip prereleases (tags with hyphens like v0.1.0-beta)
     if: ${{ !contains(github.ref, '-') }}
@@ -317,7 +345,7 @@ jobs:
 
   vscode:
     name: Publish VS Code Extension
-    needs: build
+    needs: [build, test]
     runs-on: ubuntu-latest
     # Skip prereleases
     if: ${{ !contains(github.ref, '-') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Docs website deployment payload**. Reduced the GitHub Pages deploy window from six to three docs versions while keeping all versioned snapshots in the repository, so release docs publish with a smaller Pages artifact and avoid repeated `syncing_files` deployment failures.
 - **Security: MCP path confinement and panic hardening**. The MCP `validate_file` and `validate_project` tools now reject client-supplied paths that canonicalize outside the server working directory. Completion helpers clamp raw byte offsets to UTF-8 character boundaries before slicing, project validation converts per-file validator panics into diagnostics, and release builds keep unwinding enabled so one bad file cannot abort an entire scan.
+- **Release download integrity and publish gating**. The GitHub Action installer, VS Code extension, JetBrains plugin, and Zed extension now verify release SHA-256 sidecars before using downloaded `agnix`/`agnix-lsp` artifacts. Release tags now run fmt, clippy, and workspace tests before GitHub releases, crates.io publish, or VS Code Marketplace publish can proceed.
 
 ## [0.37.1] - 2026-07-04
 

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/binary/AgnixBinaryDownloader.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/binary/AgnixBinaryDownloader.kt
@@ -14,6 +14,7 @@ import java.net.URI
 import java.nio.file.Files
 import java.nio.file.attribute.PosixFilePermission
 import java.security.MessageDigest
+import java.util.Locale
 import java.util.zip.GZIPInputStream
 import java.util.zip.ZipInputStream
 
@@ -111,7 +112,7 @@ class AgnixBinaryDownloader {
                 throw IOException("Checksum file is for $sidecarName, expected $expectedFileName")
             }
 
-            return hash.lowercase()
+            return hash.lowercase(Locale.ROOT)
         }
 
         internal fun sha256Hex(file: File): String {

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/binary/AgnixBinaryDownloader.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/binary/AgnixBinaryDownloader.kt
@@ -13,6 +13,7 @@ import java.net.HttpURLConnection
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.attribute.PosixFilePermission
+import java.security.MessageDigest
 import java.util.zip.GZIPInputStream
 import java.util.zip.ZipInputStream
 
@@ -37,6 +38,7 @@ class AgnixBinaryDownloader {
             "github-releases.githubusercontent.com"
         )
         private const val GITHUB_USER_CONTENT_SUFFIX = ".githubusercontent.com"
+        private val SHA256_HEX = Regex("^[0-9a-fA-F]{64}$")
 
         internal fun isTrustedDownloadUrl(urlString: String): Boolean {
             val url = try {
@@ -85,6 +87,53 @@ class AgnixBinaryDownloader {
             val normalizedOut = outFile.toPath().toAbsolutePath().normalize()
             if (!normalizedOut.startsWith(normalizedDest)) {
                 throw SecurityException("Output path escapes destination directory: $normalizedOut")
+            }
+        }
+
+        internal fun parseSha256Sidecar(contents: String, expectedFileName: String): String {
+            val line = contents
+                .lineSequence()
+                .map { it.trim() }
+                .firstOrNull { it.isNotEmpty() }
+                ?: throw IOException("Checksum file is empty")
+
+            val parts = line.split(Regex("\\s+"))
+            val hash = parts[0]
+            if (!SHA256_HEX.matches(hash)) {
+                throw IOException("Checksum file does not contain a valid SHA256 hash")
+            }
+
+            val sidecarName = parts.getOrNull(1)
+                ?.removePrefix("*")
+                ?.replace('\\', '/')
+                ?.substringAfterLast('/')
+            if (sidecarName != null && sidecarName != expectedFileName) {
+                throw IOException("Checksum file is for $sidecarName, expected $expectedFileName")
+            }
+
+            return hash.lowercase()
+        }
+
+        internal fun sha256Hex(file: File): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            FileInputStream(file).use { input ->
+                val buffer = ByteArray(BUFFER_SIZE)
+                while (true) {
+                    val bytesRead = input.read(buffer)
+                    if (bytesRead == -1) break
+                    digest.update(buffer, 0, bytesRead)
+                }
+            }
+            return digest.digest().joinToString("") { byte ->
+                (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+            }
+        }
+
+        internal fun verifySha256Sidecar(file: File, sidecar: File, expectedFileName: String) {
+            val expected = parseSha256Sidecar(sidecar.readText(), expectedFileName)
+            val actual = sha256Hex(file)
+            if (actual != expected) {
+                throw IOException("Checksum mismatch for $expectedFileName: expected $expected, got $actual")
             }
         }
 
@@ -214,12 +263,18 @@ class AgnixBinaryDownloader {
         }
 
         val archivePath = File(storageDir, binaryInfo.assetName)
+        val checksumPath = File(storageDir, "${binaryInfo.assetName}.sha256")
         val binaryPath = File(storageDir, binaryInfo.binaryName)
 
         try {
             // Download archive
             indicator?.text = "Downloading from GitHub..."
             downloadFile(downloadUrl, archivePath, indicator)
+
+            // Verify archive integrity before extraction
+            indicator?.text = "Verifying checksum..."
+            downloadFile("$downloadUrl.sha256", checksumPath, indicator)
+            verifySha256Sidecar(archivePath, checksumPath, binaryInfo.assetName)
 
             // Extract binary
             indicator?.text = "Extracting binary..."
@@ -261,6 +316,9 @@ class AgnixBinaryDownloader {
             // Clean up archive file
             if (archivePath.exists()) {
                 archivePath.delete()
+            }
+            if (checksumPath.exists()) {
+                checksumPath.delete()
             }
         }
     }

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/binary/AgnixBinaryDownloaderTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/binary/AgnixBinaryDownloaderTest.kt
@@ -1,5 +1,7 @@
 package io.agnix.jetbrains.binary
 
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -19,6 +21,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream
  * Tests for AgnixBinaryDownloader URL trust validation and archive extraction.
  */
 class AgnixBinaryDownloaderTest {
+
+    private val helloSha256 = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
 
     // ---- URL trust tests ----
 
@@ -139,6 +143,56 @@ class AgnixBinaryDownloaderTest {
         val dest = tempDir.toFile()
         // Should not throw when outFile is the destination itself
         AgnixBinaryDownloader.verifyPathWithinDestination(dest, dest)
+    }
+
+    // ---- checksum tests ----
+
+    @Test
+    fun `parseSha256Sidecar accepts matching artifact names`() {
+        val parsed = AgnixBinaryDownloader.parseSha256Sidecar(
+            "${helloSha256.uppercase()}  agnix-lsp.tar.gz\n",
+            "agnix-lsp.tar.gz"
+        )
+
+        assertEquals(helloSha256, parsed)
+    }
+
+    @Test
+    fun `parseSha256Sidecar rejects malformed hashes and mismatched artifacts`() {
+        assertThrows(IOException::class.java) {
+            AgnixBinaryDownloader.parseSha256Sidecar("not-a-hash  agnix-lsp.tar.gz", "agnix-lsp.tar.gz")
+        }
+        assertThrows(IOException::class.java) {
+            AgnixBinaryDownloader.parseSha256Sidecar(
+                "$helloSha256  agnix-lsp-linux.tar.gz",
+                "agnix-lsp-macos.tar.gz"
+            )
+        }
+    }
+
+    @Test
+    fun `verifySha256Sidecar accepts matching file content`(@TempDir tempDir: Path) {
+        val file = tempDir.resolve("agnix-lsp.tar.gz").toFile()
+        val sidecar = tempDir.resolve("agnix-lsp.tar.gz.sha256").toFile()
+        file.writeText("hello")
+        sidecar.writeText("$helloSha256  agnix-lsp.tar.gz\n")
+
+        assertEquals(helloSha256, AgnixBinaryDownloader.sha256Hex(file))
+        assertDoesNotThrow {
+            AgnixBinaryDownloader.verifySha256Sidecar(file, sidecar, "agnix-lsp.tar.gz")
+        }
+    }
+
+    @Test
+    fun `verifySha256Sidecar rejects mismatched file content`(@TempDir tempDir: Path) {
+        val file = tempDir.resolve("agnix-lsp.tar.gz").toFile()
+        val sidecar = tempDir.resolve("agnix-lsp.tar.gz.sha256").toFile()
+        file.writeText("tampered")
+        sidecar.writeText("$helloSha256  agnix-lsp.tar.gz\n")
+
+        assertThrows(IOException::class.java) {
+            AgnixBinaryDownloader.verifySha256Sidecar(file, sidecar, "agnix-lsp.tar.gz")
+        }
     }
 
     // ---- extractTarGz tests ----

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/binary/AgnixBinaryDownloaderTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/binary/AgnixBinaryDownloaderTest.kt
@@ -11,6 +11,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
 import java.nio.file.Path
+import java.util.Locale
 import java.util.zip.GZIPOutputStream
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -150,7 +151,7 @@ class AgnixBinaryDownloaderTest {
     @Test
     fun `parseSha256Sidecar accepts matching artifact names`() {
         val parsed = AgnixBinaryDownloader.parseSha256Sidecar(
-            "${helloSha256.uppercase()}  agnix-lsp.tar.gz\n",
+            "${helloSha256.uppercase(Locale.ROOT)}  agnix-lsp.tar.gz\n",
             "agnix-lsp.tar.gz"
         )
 

--- a/editors/vscode/src/checksum.ts
+++ b/editors/vscode/src/checksum.ts
@@ -1,0 +1,56 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/i;
+
+export function parseSha256Sidecar(
+  contents: string,
+  expectedFileName: string
+): string {
+  const line = contents
+    .split(/\r?\n/)
+    .map((candidate) => candidate.trim())
+    .find((candidate) => candidate.length > 0);
+
+  if (!line) {
+    throw new Error('Checksum file is empty');
+  }
+
+  const parts = line.split(/\s+/);
+  const hash = parts[0];
+  if (!SHA256_HEX_RE.test(hash)) {
+    throw new Error('Checksum file does not contain a valid SHA256 hash');
+  }
+
+  const sidecarName = parts[1]?.replace(/^\*/, '');
+  if (sidecarName && path.basename(sidecarName) !== expectedFileName) {
+    throw new Error(
+      `Checksum file is for ${sidecarName}, expected ${expectedFileName}`
+    );
+  }
+
+  return hash.toLowerCase();
+}
+
+export function sha256File(filePath: string): string {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+export function verifySha256File(
+  filePath: string,
+  checksumPath: string,
+  expectedFileName = path.basename(filePath)
+): void {
+  const expected = parseSha256Sidecar(
+    fs.readFileSync(checksumPath, 'utf8'),
+    expectedFileName
+  );
+  const actual = sha256File(filePath);
+
+  if (actual !== expected) {
+    throw new Error(
+      `Checksum mismatch for ${expectedFileName}: expected ${expected}, got ${actual}`
+    );
+  }
+}

--- a/editors/vscode/src/checksum.ts
+++ b/editors/vscode/src/checksum.ts
@@ -24,29 +24,39 @@ export function parseSha256Sidecar(
   }
 
   const sidecarName = parts[1]?.replace(/^\*/, '');
-  if (sidecarName && path.basename(sidecarName) !== expectedFileName) {
-    throw new Error(
-      `Checksum file is for ${sidecarName}, expected ${expectedFileName}`
-    );
+  if (sidecarName) {
+    const baseName = sidecarName.replace(/\\/g, '/').split('/').pop();
+    if (baseName !== expectedFileName) {
+      throw new Error(
+        `Checksum file is for ${sidecarName}, expected ${expectedFileName}`
+      );
+    }
   }
 
   return hash.toLowerCase();
 }
 
-export function sha256File(filePath: string): string {
-  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+export function sha256File(filePath: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hasher = crypto.createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+
+    stream.on('data', (chunk) => hasher.update(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(hasher.digest('hex')));
+  });
 }
 
-export function verifySha256File(
+export async function verifySha256File(
   filePath: string,
   checksumPath: string,
   expectedFileName = path.basename(filePath)
-): void {
+): Promise<void> {
   const expected = parseSha256Sidecar(
     fs.readFileSync(checksumPath, 'utf8'),
     expectedFileName
   );
-  const actual = sha256File(filePath);
+  const actual = await sha256File(filePath);
 
   if (actual !== expected) {
     throw new Error(

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -421,7 +421,7 @@ async function downloadAndInstallLsp(version?: string): Promise<string | null> {
         progress.report({ message: 'Verifying checksum...' });
         outputChannel.appendLine(`Downloading checksum from: ${releaseUrl}.sha256`);
         await downloadFile(`${releaseUrl}.sha256`, checksumPath);
-        verifySha256File(downloadPath, checksumPath, platformInfo.asset);
+        await verifySha256File(downloadPath, checksumPath, platformInfo.asset);
 
         progress.report({ message: 'Extracting...' });
         outputChannel.appendLine(`Extracting to: ${storageUri.fsPath}`);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -19,6 +19,7 @@ import {
   buildReleaseUrl,
   parseLspVersionOutput,
 } from './version-check';
+import { verifySha256File } from './checksum';
 
 const execAsync = promisify(exec);
 
@@ -401,6 +402,7 @@ async function downloadAndInstallLsp(version?: string): Promise<string | null> {
   await vscode.workspace.fs.createDirectory(storageUri);
 
   const downloadPath = path.join(storageUri.fsPath, platformInfo.asset);
+  const checksumPath = `${downloadPath}.sha256`;
   const binaryPath = path.join(storageUri.fsPath, platformInfo.binary);
 
   try {
@@ -415,6 +417,11 @@ async function downloadAndInstallLsp(version?: string): Promise<string | null> {
         outputChannel.appendLine(`Downloading from: ${releaseUrl}`);
 
         await downloadFile(releaseUrl, downloadPath);
+
+        progress.report({ message: 'Verifying checksum...' });
+        outputChannel.appendLine(`Downloading checksum from: ${releaseUrl}.sha256`);
+        await downloadFile(`${releaseUrl}.sha256`, checksumPath);
+        verifySha256File(downloadPath, checksumPath, platformInfo.asset);
 
         progress.report({ message: 'Extracting...' });
         outputChannel.appendLine(`Extracting to: ${storageUri.fsPath}`);
@@ -483,11 +490,13 @@ async function downloadAndInstallLsp(version?: string): Promise<string | null> {
           fs.chmodSync(binaryPath, 0o755);
         }
 
-        // Clean up archive
-        try {
-          fs.unlinkSync(downloadPath);
-        } catch {
-          // Error ignored during cleanup
+        // Clean up downloaded release files
+        for (const cleanupPath of [downloadPath, checksumPath]) {
+          try {
+            fs.unlinkSync(cleanupPath);
+          } catch {
+            // Error ignored during cleanup
+          }
         }
       }
     );
@@ -502,6 +511,13 @@ async function downloadAndInstallLsp(version?: string): Promise<string | null> {
       throw new Error('Binary not found after extraction');
     }
   } catch (error) {
+    for (const cleanupPath of [downloadPath, checksumPath]) {
+      try {
+        fs.unlinkSync(cleanupPath);
+      } catch {
+        // Error ignored during cleanup
+      }
+    }
     const message = error instanceof Error ? error.message : String(error);
     outputChannel.appendLine(`Installation failed: ${message}`);
     vscode.window.showErrorMessage(`Failed to install agnix-lsp: ${message}`);

--- a/editors/vscode/src/test/unit/checksum.test.ts
+++ b/editors/vscode/src/test/unit/checksum.test.ts
@@ -1,0 +1,74 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseSha256Sidecar,
+  sha256File,
+  verifySha256File,
+} from '../../checksum';
+
+const HELLO_SHA256 =
+  '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824';
+
+describe('checksum verification', () => {
+  it('parses sha256 sidecars with matching artifact names', () => {
+    const hash = HELLO_SHA256.toUpperCase();
+
+    assert.strictEqual(
+      parseSha256Sidecar(`${hash}  agnix-lsp.tar.gz\n`, 'agnix-lsp.tar.gz'),
+      HELLO_SHA256
+    );
+  });
+
+  it('rejects malformed hashes and mismatched artifact names', () => {
+    assert.throws(
+      () => parseSha256Sidecar('not-a-hash  agnix-lsp.tar.gz', 'agnix-lsp.tar.gz'),
+      /valid SHA256/
+    );
+    assert.throws(
+      () =>
+        parseSha256Sidecar(
+          `${HELLO_SHA256}  agnix-lsp-linux.tar.gz`,
+          'agnix-lsp-macos.tar.gz'
+        ),
+      /expected agnix-lsp-macos.tar.gz/
+    );
+  });
+
+  it('verifies a file against a matching sidecar', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agnix-checksum-'));
+    const filePath = path.join(tempDir, 'agnix-lsp.tar.gz');
+    const checksumPath = `${filePath}.sha256`;
+
+    try {
+      fs.writeFileSync(filePath, 'hello');
+      fs.writeFileSync(checksumPath, `${HELLO_SHA256}  agnix-lsp.tar.gz\n`);
+
+      assert.strictEqual(sha256File(filePath), HELLO_SHA256);
+      assert.doesNotThrow(() =>
+        verifySha256File(filePath, checksumPath, 'agnix-lsp.tar.gz')
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a mismatched file hash', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agnix-checksum-'));
+    const filePath = path.join(tempDir, 'agnix-lsp.tar.gz');
+    const checksumPath = `${filePath}.sha256`;
+
+    try {
+      fs.writeFileSync(filePath, 'tampered');
+      fs.writeFileSync(checksumPath, `${HELLO_SHA256}  agnix-lsp.tar.gz\n`);
+
+      assert.throws(
+        () => verifySha256File(filePath, checksumPath, 'agnix-lsp.tar.gz'),
+        /Checksum mismatch/
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/editors/vscode/src/test/unit/checksum.test.ts
+++ b/editors/vscode/src/test/unit/checksum.test.ts
@@ -36,7 +36,17 @@ describe('checksum verification', () => {
     );
   });
 
-  it('verifies a file against a matching sidecar', () => {
+  it('parses sidecars with Windows-style artifact paths', () => {
+    assert.strictEqual(
+      parseSha256Sidecar(
+        `${HELLO_SHA256}  releases\\agnix-lsp.tar.gz\n`,
+        'agnix-lsp.tar.gz'
+      ),
+      HELLO_SHA256
+    );
+  });
+
+  it('verifies a file against a matching sidecar', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agnix-checksum-'));
     const filePath = path.join(tempDir, 'agnix-lsp.tar.gz');
     const checksumPath = `${filePath}.sha256`;
@@ -45,8 +55,8 @@ describe('checksum verification', () => {
       fs.writeFileSync(filePath, 'hello');
       fs.writeFileSync(checksumPath, `${HELLO_SHA256}  agnix-lsp.tar.gz\n`);
 
-      assert.strictEqual(sha256File(filePath), HELLO_SHA256);
-      assert.doesNotThrow(() =>
+      assert.strictEqual(await sha256File(filePath), HELLO_SHA256);
+      await assert.doesNotReject(() =>
         verifySha256File(filePath, checksumPath, 'agnix-lsp.tar.gz')
       );
     } finally {
@@ -54,7 +64,7 @@ describe('checksum verification', () => {
     }
   });
 
-  it('rejects a mismatched file hash', () => {
+  it('rejects a mismatched file hash', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agnix-checksum-'));
     const filePath = path.join(tempDir, 'agnix-lsp.tar.gz');
     const checksumPath = `${filePath}.sha256`;
@@ -63,7 +73,7 @@ describe('checksum verification', () => {
       fs.writeFileSync(filePath, 'tampered');
       fs.writeFileSync(checksumPath, `${HELLO_SHA256}  agnix-lsp.tar.gz\n`);
 
-      assert.throws(
+      await assert.rejects(
         () => verifySha256File(filePath, checksumPath, 'agnix-lsp.tar.gz'),
         /Checksum mismatch/
       );

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -10,4 +10,5 @@ description = "Zed extension for agnix - lint agent configurations"
 crate-type = ["cdylib"]
 
 [dependencies]
+sha2 = "0.10"
 zed_extension_api = "0.7.0"

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -1,4 +1,5 @@
-use std::fs;
+use sha2::{Digest, Sha256};
+use std::{fmt::Write as _, fs};
 use zed_extension_api::{
     self as zed, Architecture, Command, DownloadedFileType, GithubReleaseOptions, LanguageServerId,
     Os, Result,
@@ -48,6 +49,77 @@ fn binary_name(os: Os) -> &'static str {
     }
 }
 
+fn binary_checksum_asset_name(asset_name: &str) -> Result<String> {
+    if let Some(prefix) = asset_name.strip_suffix(".tar.gz") {
+        Ok(format!("{prefix}.sha256"))
+    } else if let Some(prefix) = asset_name.strip_suffix(".zip") {
+        Ok(format!("{prefix}.sha256"))
+    } else {
+        Err(format!("unsupported asset extension for {asset_name}"))
+    }
+}
+
+fn is_trusted_download_url(url: &str) -> bool {
+    url.starts_with("https://github.com/")
+        || url.starts_with("https://objects.githubusercontent.com/")
+}
+
+fn parse_sha256_sidecar(contents: &str, expected_file_name: &str) -> Result<String> {
+    let line = contents
+        .lines()
+        .map(str::trim)
+        .find(|candidate| !candidate.is_empty())
+        .ok_or_else(|| "checksum file is empty".to_string())?;
+
+    let mut parts = line.split_whitespace();
+    let hash = parts
+        .next()
+        .ok_or_else(|| "checksum file is empty".to_string())?;
+    if hash.len() != 64 || !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("checksum file does not contain a valid SHA256 hash".to_string());
+    }
+
+    if let Some(sidecar_name) = parts.next() {
+        let file_name = sidecar_name
+            .trim_start_matches('*')
+            .rsplit(|c| c == '/' || c == '\\')
+            .next()
+            .unwrap_or(sidecar_name);
+        if file_name != expected_file_name {
+            return Err(format!(
+                "checksum file is for {file_name}, expected {expected_file_name}"
+            ));
+        }
+    }
+
+    Ok(hash.to_ascii_lowercase())
+}
+
+fn sha256_file(file_path: &str) -> Result<String> {
+    let bytes = fs::read(file_path).map_err(|e| format!("failed to read {file_path}: {e}"))?;
+    let digest = Sha256::digest(&bytes);
+    let mut output = String::with_capacity(64);
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").map_err(|e| e.to_string())?;
+    }
+    Ok(output)
+}
+
+fn verify_sha256_file(
+    file_path: &str,
+    checksum_contents: &str,
+    expected_file_name: &str,
+) -> Result<String> {
+    let expected = parse_sha256_sidecar(checksum_contents, expected_file_name)?;
+    let actual = sha256_file(file_path)?;
+    if actual != expected {
+        return Err(format!(
+            "checksum mismatch for {expected_file_name}: expected {expected}, got {actual}"
+        ));
+    }
+    Ok(expected)
+}
+
 impl AgnixExtension {
     /// Resolves the agnix-lsp binary path, downloading it from GitHub releases if needed.
     fn language_server_binary_path(
@@ -80,36 +152,71 @@ impl AgnixExtension {
 
         let version_dir = format!("agnix-lsp-{version}");
         let binary_path = format!("{version_dir}/{bin}");
+        let verification_marker_path = format!("{version_dir}/.agnix-lsp.sha256");
 
-        // If this version is already downloaded, use it
-        if fs::metadata(&binary_path).is_ok_and(|m| m.is_file()) {
+        // If this version is already downloaded and verified, use it.
+        if fs::metadata(&binary_path).is_ok_and(|m| m.is_file())
+            && fs::metadata(&verification_marker_path).is_ok_and(|m| m.is_file())
+        {
             self.cached_binary_path = Some(binary_path.clone());
             return Ok(binary_path);
+        } else if fs::metadata(&binary_path).is_ok_and(|m| m.is_file()) {
+            let _ = fs::remove_dir_all(&version_dir);
         }
 
         // Download the appropriate asset for this platform
         let (asset_name, file_type) = asset_for_platform(platform, arch)?;
+        let checksum_asset_name = binary_checksum_asset_name(asset_name)?;
+        let checksum_path = format!("{version_dir}/{checksum_asset_name}");
 
         let asset = release
             .assets
             .iter()
             .find(|a| a.name == asset_name)
             .ok_or_else(|| format!("no release asset found matching {asset_name}"))?;
+        let checksum_asset = release
+            .assets
+            .iter()
+            .find(|a| a.name == checksum_asset_name)
+            .ok_or_else(|| format!("no release checksum found matching {checksum_asset_name}"))?;
 
         // Validate download URL uses HTTPS from a trusted GitHub domain
-        let is_trusted = asset.download_url.starts_with("https://github.com/")
-            || asset
-                .download_url
-                .starts_with("https://objects.githubusercontent.com/");
-        if !is_trusted {
+        if !is_trusted_download_url(&asset.download_url) {
             return Err(format!(
                 "refusing download from untrusted URL: {}",
                 asset.download_url
             ));
         }
+        if !is_trusted_download_url(&checksum_asset.download_url) {
+            return Err(format!(
+                "refusing checksum download from untrusted URL: {}",
+                checksum_asset.download_url
+            ));
+        }
 
         zed::download_file(&asset.download_url, &version_dir, file_type)
             .map_err(|e| format!("failed to download {asset_name}: {e}"))?;
+        let verified_hash = (|| -> Result<String> {
+            zed::download_file(
+                &checksum_asset.download_url,
+                &checksum_path,
+                DownloadedFileType::Uncompressed,
+            )
+            .map_err(|e| format!("failed to download {checksum_asset_name}: {e}"))?;
+            let checksum_contents = fs::read_to_string(&checksum_path)
+                .map_err(|e| format!("failed to read {checksum_path}: {e}"))?;
+            verify_sha256_file(&binary_path, &checksum_contents, bin)
+        })()
+        .map_err(|e| {
+            let _ = fs::remove_dir_all(&version_dir);
+            e
+        })?;
+        fs::write(
+            &verification_marker_path,
+            format!("{verified_hash}  {bin}\n"),
+        )
+        .map_err(|e| format!("failed to write {verification_marker_path}: {e}"))?;
+        let _ = fs::remove_file(&checksum_path);
 
         zed::make_file_executable(&binary_path)?;
 
@@ -150,6 +257,8 @@ zed::register_extension!(AgnixExtension);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const HELLO_SHA256: &str = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
 
     #[test]
     fn asset_name_mac_aarch64() {
@@ -247,34 +356,139 @@ mod tests {
     }
 
     #[test]
+    fn checksum_asset_name_for_tarball() {
+        assert_eq!(
+            binary_checksum_asset_name("agnix-lsp-x86_64-unknown-linux-gnu.tar.gz")
+                .expect("should map tarball asset"),
+            "agnix-lsp-x86_64-unknown-linux-gnu.sha256"
+        );
+    }
+
+    #[test]
+    fn checksum_asset_name_for_zip() {
+        assert_eq!(
+            binary_checksum_asset_name("agnix-lsp-x86_64-pc-windows-msvc.zip")
+                .expect("should map zip asset"),
+            "agnix-lsp-x86_64-pc-windows-msvc.sha256"
+        );
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_accepts_matching_filename() {
+        assert_eq!(
+            parse_sha256_sidecar(
+                &format!("{}  agnix-lsp\n", HELLO_SHA256.to_uppercase()),
+                "agnix-lsp"
+            )
+            .expect("should parse matching sidecar"),
+            HELLO_SHA256
+        );
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_rejects_malformed_hash() {
+        let err = parse_sha256_sidecar("not-a-hash  agnix-lsp", "agnix-lsp")
+            .expect_err("malformed hash should be rejected");
+        assert!(err.contains("valid SHA256"));
+    }
+
+    #[test]
+    fn parse_sha256_sidecar_rejects_mismatched_filename() {
+        let err = parse_sha256_sidecar(
+            &format!("{HELLO_SHA256}  agnix-lsp-linux"),
+            "agnix-lsp-macos",
+        )
+        .expect_err("mismatched file name should be rejected");
+        assert!(err.contains("expected agnix-lsp-macos"));
+    }
+
+    #[test]
+    fn verify_sha256_file_accepts_matching_file() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "agnix-zed-checksum-{}-matching",
+            std::process::id()
+        ));
+        let file_path = temp_dir.join("agnix-lsp");
+        fs::create_dir_all(&temp_dir).expect("should create temp dir");
+
+        let result = (|| {
+            fs::write(&file_path, b"hello").expect("should write test file");
+            let file_path = file_path.to_string_lossy();
+            assert_eq!(
+                sha256_file(&file_path).expect("should hash file"),
+                HELLO_SHA256
+            );
+            verify_sha256_file(
+                &file_path,
+                &format!("{HELLO_SHA256}  agnix-lsp\n"),
+                "agnix-lsp",
+            )
+        })();
+
+        let _ = fs::remove_dir_all(&temp_dir);
+        assert!(
+            result.is_ok(),
+            "expected checksum verification to pass: {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_sha256_file_rejects_mismatched_file() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "agnix-zed-checksum-{}-mismatch",
+            std::process::id()
+        ));
+        let file_path = temp_dir.join("agnix-lsp");
+        fs::create_dir_all(&temp_dir).expect("should create temp dir");
+
+        let result = (|| {
+            fs::write(&file_path, b"tampered").expect("should write test file");
+            let file_path = file_path.to_string_lossy();
+            verify_sha256_file(
+                &file_path,
+                &format!("{HELLO_SHA256}  agnix-lsp\n"),
+                "agnix-lsp",
+            )
+        })();
+
+        let _ = fs::remove_dir_all(&temp_dir);
+        assert!(
+            result
+                .expect_err("mismatched file should fail")
+                .contains("checksum mismatch")
+        );
+    }
+
+    #[test]
     fn trusted_github_url_accepted() {
         let url = "https://github.com/agent-sh/agnix/releases/download/v0.8.0/agnix-lsp.tar.gz";
-        let is_trusted = url.starts_with("https://github.com/")
-            || url.starts_with("https://objects.githubusercontent.com/");
-        assert!(is_trusted, "github.com URL should be trusted");
+        assert!(
+            is_trusted_download_url(url),
+            "github.com URL should be trusted"
+        );
     }
 
     #[test]
     fn trusted_githubusercontent_url_accepted() {
         let url = "https://objects.githubusercontent.com/github-production-release-asset/12345";
-        let is_trusted = url.starts_with("https://github.com/")
-            || url.starts_with("https://objects.githubusercontent.com/");
-        assert!(is_trusted, "objects.githubusercontent.com URL should be trusted");
+        assert!(
+            is_trusted_download_url(url),
+            "objects.githubusercontent.com URL should be trusted"
+        );
     }
 
     #[test]
     fn untrusted_url_rejected() {
         let url = "https://evil.com/malware.tar.gz";
-        let is_trusted = url.starts_with("https://github.com/")
-            || url.starts_with("https://objects.githubusercontent.com/");
-        assert!(!is_trusted, "non-GitHub URL should be rejected");
+        assert!(
+            !is_trusted_download_url(url),
+            "non-GitHub URL should be rejected"
+        );
     }
 
     #[test]
     fn http_url_rejected() {
         let url = "http://github.com/agent-sh/agnix/releases/download/v0.8.0/agnix-lsp.tar.gz";
-        let is_trusted = url.starts_with("https://github.com/")
-            || url.starts_with("https://objects.githubusercontent.com/");
-        assert!(!is_trusted, "HTTP URL should be rejected");
+        assert!(!is_trusted_download_url(url), "HTTP URL should be rejected");
     }
 }

--- a/editors/zed/src/lib.rs
+++ b/editors/zed/src/lib.rs
@@ -1,5 +1,5 @@
 use sha2::{Digest, Sha256};
-use std::{fmt::Write as _, fs};
+use std::{fmt::Write as _, fs, io::Read};
 use zed_extension_api::{
     self as zed, Architecture, Command, DownloadedFileType, GithubReleaseOptions, LanguageServerId,
     Os, Result,
@@ -96,8 +96,20 @@ fn parse_sha256_sidecar(contents: &str, expected_file_name: &str) -> Result<Stri
 }
 
 fn sha256_file(file_path: &str) -> Result<String> {
-    let bytes = fs::read(file_path).map_err(|e| format!("failed to read {file_path}: {e}"))?;
-    let digest = Sha256::digest(&bytes);
+    let mut file =
+        fs::File::open(file_path).map_err(|e| format!("failed to open {file_path}: {e}"))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 8192];
+    loop {
+        let bytes_read = file
+            .read(&mut buffer)
+            .map_err(|e| format!("failed to read {file_path}: {e}"))?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+    let digest = hasher.finalize();
     let mut output = String::with_capacity(64);
     for byte in digest {
         write!(&mut output, "{byte:02x}").map_err(|e| e.to_string())?;

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -140,6 +140,42 @@ if [ "${HTTP_CODE}" != "200" ]; then
     exit 1
 fi
 
+CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
+CHECKSUM_FILE="${TEMP_DIR}/${ARTIFACT_NAME}.sha256"
+
+echo "Downloading checksum from ${CHECKSUM_URL}..."
+HTTP_CODE=$(curl -sL -w "%{http_code}" "${CHECKSUM_URL}" -o "${CHECKSUM_FILE}")
+
+if [ "${HTTP_CODE}" != "200" ]; then
+    echo "Error: Failed to download release checksum (HTTP ${HTTP_CODE})" >&2
+    echo "URL: ${CHECKSUM_URL}" >&2
+    exit 1
+fi
+
+EXPECTED_SHA="$(awk 'NF {print $1; exit}' "${CHECKSUM_FILE}" | tr '[:upper:]' '[:lower:]')"
+if ! printf '%s\n' "${EXPECTED_SHA}" | grep -Eq '^[0-9a-f]{64}$'; then
+    echo "Error: Invalid checksum file for ${ARTIFACT_NAME}" >&2
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL_SHA="$(sha256sum "${TEMP_DIR}/${ARTIFACT_NAME}" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')"
+elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL_SHA="$(shasum -a 256 "${TEMP_DIR}/${ARTIFACT_NAME}" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')"
+else
+    echo "Error: sha256sum or shasum is required to verify downloads" >&2
+    exit 1
+fi
+
+if [ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]; then
+    echo "Error: Checksum mismatch for ${ARTIFACT_NAME}" >&2
+    echo "Expected: ${EXPECTED_SHA}" >&2
+    echo "Actual:   ${ACTUAL_SHA}" >&2
+    exit 1
+fi
+
+echo "Checksum verified."
+
 echo "Extracting..."
 case "${EXT}" in
     tar.gz)

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -1,0 +1,86 @@
+use std::fs;
+
+#[test]
+fn release_publish_jobs_are_gated_by_tests() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let workflow = fs::read_to_string(format!("{root}/.github/workflows/release.yml"))
+        .expect("failed to read release workflow");
+
+    assert!(
+        workflow.contains("  test:\n    name: Test release commit"),
+        "release workflow must define a test job"
+    );
+    assert!(
+        workflow.contains("run: cargo fmt --check --all"),
+        "release test job must run fmt"
+    );
+    assert!(
+        workflow
+            .contains("run: cargo clippy --workspace --all-targets --all-features -- -D warnings"),
+        "release test job must run clippy"
+    );
+    assert!(
+        workflow.contains("run: cargo test --workspace"),
+        "release test job must run tests"
+    );
+
+    let lines: Vec<&str> = workflow.lines().collect();
+    for job in ["release", "publish", "vscode"] {
+        let job_line = format!("  {job}:");
+        let start = lines
+            .iter()
+            .position(|line| *line == job_line)
+            .unwrap_or_else(|| panic!("release workflow must contain job {job}"));
+        let next_job = lines
+            .iter()
+            .skip(start + 1)
+            .take_while(|line| !line.starts_with("  ") || line.starts_with("    "))
+            .copied()
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            next_job.contains("needs: [build, test]"),
+            "{job} must depend on the release test job"
+        );
+    }
+}
+
+#[test]
+fn release_workflow_publishes_lsp_binary_checksums() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let workflow = fs::read_to_string(format!("{root}/.github/workflows/release.yml"))
+        .expect("failed to read release workflow");
+
+    assert!(
+        workflow.contains("agnix-lsp-${{ matrix.target }}.sha256"),
+        "release workflow must publish binary checksum assets for Zed"
+    );
+    assert!(
+        workflow.contains("printf '%s  agnix-lsp\\n'"),
+        "Unix LSP checksum must name the extracted binary"
+    );
+    assert!(
+        workflow.contains("\"$lspHash  agnix-lsp.exe\""),
+        "Windows LSP checksum must name the extracted binary"
+    );
+}
+
+#[test]
+fn action_download_script_verifies_release_checksum() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let script = fs::read_to_string(format!("{root}/scripts/download.sh"))
+        .expect("failed to read download script");
+
+    assert!(
+        script.contains("CHECKSUM_URL=\"${DOWNLOAD_URL}.sha256\""),
+        "download script must fetch release checksum sidecars"
+    );
+    assert!(
+        script.contains("EXPECTED_SHA=") && script.contains("ACTUAL_SHA="),
+        "download script must compare expected and actual SHA256 values"
+    );
+    assert!(
+        script.contains("Checksum mismatch"),
+        "download script must fail closed on checksum mismatch"
+    );
+}


### PR DESCRIPTION
## Summary
- require release tags to pass fmt, clippy, and workspace tests before GitHub releases, crates.io publish, or VS Code Marketplace publish
- publish extracted `agnix-lsp` binary checksum sidecars for Zed and verify downloaded release sidecars in the GitHub Action installer, VS Code extension, JetBrains plugin, and Zed extension
- add checksum parser/hash tests and workflow guards so this stays covered

Thanks to @HetCreep for the careful report.

## Validation
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo test --test release_workflow`
- `bash -n scripts/download.sh`
- `npm --prefix editors/vscode run pretest && npm --prefix editors/vscode run test:unit`
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test --tests io.agnix.jetbrains.binary.AgnixBinaryDownloaderTest --no-daemon -Dkotlin.incremental=false`
- `cargo test --manifest-path editors/zed/Cargo.toml`
- `cargo check --manifest-path editors/zed/Cargo.toml --target wasm32-wasip2`
- `cargo fmt --check --all && cargo fmt --manifest-path editors/zed/Cargo.toml --check`
- `git diff --check && diff -q CLAUDE.md AGENTS.md`