### PR TITLE
chore: add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Normalize line endings to LF across platforms so a Windows checkout
+# (default core.autocrlf=true) produces LF working-tree files, keeping
+# CRLF-sensitive tests and generated files stable. See #1151.
+* text=auto eol=lf
+
+# Binary assets git must not touch.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,11 @@
 # CRLF-sensitive tests and generated files stable. See #1151.
 * text=auto eol=lf
 
+# Windows batch scripts must keep CRLF or cmd.exe can mis-execute them
+# (e.g. editors/jetbrains/gradlew.bat).
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
 # Binary assets git must not touch.
 *.png binary
 *.jpg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,9 +4,11 @@
 * text=auto eol=lf
 
 # Windows batch scripts must keep CRLF or cmd.exe can mis-execute them
-# (e.g. editors/jetbrains/gradlew.bat).
+# (e.g. editors/jetbrains/gradlew.bat). Keep PowerShell scripts aligned
+# with the same Windows checkout policy.
 *.bat text eol=crlf
 *.cmd text eol=crlf
+*.ps1 text eol=crlf
 
 # Binary assets git must not touch.
 *.png binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Windows checkout line endings**. Added repository attributes that keep source files LF-normalized across platforms while preserving CRLF for Windows command and PowerShell scripts.
+
 ## [0.37.2] - 2026-07-04
 
 ### Fixed

--- a/tests/docs_workspace_membership.rs
+++ b/tests/docs_workspace_membership.rs
@@ -12,6 +12,27 @@ fn claude_and_agents_docs_are_byte_identical() {
 }
 
 #[test]
+fn gitattributes_preserves_repo_line_ending_policy() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let attrs = fs::read_to_string(format!("{root}/.gitattributes"))
+        .expect("Failed to read .gitattributes");
+
+    let required = [
+        "* text=auto eol=lf",
+        "*.bat text eol=crlf",
+        "*.cmd text eol=crlf",
+        "*.ps1 text eol=crlf",
+    ];
+
+    for pattern in required {
+        assert!(
+            attrs.lines().any(|line| line.trim() == pattern),
+            ".gitattributes must contain `{pattern}`"
+        );
+    }
+}
+
+#[test]
 fn architecture_docs_list_all_workspace_crates() {
     let root = env!("CARGO_MANIFEST_DIR");
 

--- a/tests/docs_workspace_membership.rs
+++ b/tests/docs_workspace_membership.rs
@@ -12,27 +12,6 @@ fn claude_and_agents_docs_are_byte_identical() {
 }
 
 #[test]
-fn gitattributes_preserves_repo_line_ending_policy() {
-    let root = env!("CARGO_MANIFEST_DIR");
-    let attrs = fs::read_to_string(format!("{root}/.gitattributes"))
-        .expect("Failed to read .gitattributes");
-
-    let required = [
-        "* text=auto eol=lf",
-        "*.bat text eol=crlf",
-        "*.cmd text eol=crlf",
-        "*.ps1 text eol=crlf",
-    ];
-
-    for pattern in required {
-        assert!(
-            attrs.lines().any(|line| line.trim() == pattern),
-            ".gitattributes must contain `{pattern}`"
-        );
-    }
-}
-
-#[test]
 fn architecture_docs_list_all_workspace_crates() {
     let root = env!("CARGO_MANIFEST_DIR");
 

--- a/tests/gitattributes.rs
+++ b/tests/gitattributes.rs
@@ -1,0 +1,22 @@
+use std::fs;
+
+#[test]
+fn gitattributes_preserves_repo_line_ending_policy() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let attrs = fs::read_to_string(format!("{root}/.gitattributes"))
+        .expect("Failed to read .gitattributes");
+
+    let required = [
+        "* text=auto eol=lf",
+        "*.bat text eol=crlf",
+        "*.cmd text eol=crlf",
+        "*.ps1 text eol=crlf",
+    ];
+
+    for pattern in required {
+        assert!(
+            attrs.lines().any(|line| line.trim() == pattern),
+            ".gitattributes must contain `{pattern}`"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

The repo has no `.gitattributes`, so on a Windows checkout with the default `core.autocrlf=true` the working tree gets CRLF line endings. This breaks a CRLF-sensitive test (see #1151, #1164): `tests/release_workflow.rs` asserts an LF literal against `.github/workflows/release.yml`, which is CRLF on disk.

## Fix

Add a `.gitattributes` with `* text=auto eol=lf` (plus `binary` overrides for image/font assets) so every checkout produces LF working-tree files.

After merging, a one-time `git add --renormalize .` may be wanted to normalize any already-CRLF-committed blobs, though git stores LF here already. This removes one of the two root causes behind the Windows test failures.

Found during an external audit of v0.37.2.