### PR TITLE
ci: attest SLSA build provenance for release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -141,7 +141,7 @@ jobs:
           }
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-path: |
             agnix-*${{ matrix.target }}.tar.gz
@@ -185,6 +185,8 @@ jobs:
     name: Create Release
     needs: [build, test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,10 @@ jobs:
     name: Create Release
     needs: [build, test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -182,6 +186,13 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            artifacts/*.tar.gz
+            artifacts/*.zip
 
       - name: Generate release notes
         id: notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +140,13 @@ jobs:
             (Get-FileHash agnix-mcp-${{ matrix.target }}.zip -Algorithm SHA256).Hash.ToLower() + "  agnix-mcp-${{ matrix.target }}.zip" | Out-File -Encoding ASCII agnix-mcp-${{ matrix.target }}.zip.sha256
           }
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            agnix-*${{ matrix.target }}.tar.gz
+            agnix-*${{ matrix.target }}.zip
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -174,10 +185,6 @@ jobs:
     name: Create Release
     needs: [build, test]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -186,13 +193,6 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
-
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-path: |
-            artifacts/*.tar.gz
-            artifacts/*.zip
 
       - name: Generate release notes
         id: notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Release provenance attestations**. Release archive builds now generate GitHub artifact attestations with job-scoped OIDC and attestation permissions, while release publishing keeps write access isolated to the release job.
+
 ## [0.37.2] - 2026-07-04
 
 ### Fixed

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -66,6 +66,43 @@ fn release_workflow_publishes_lsp_binary_checksums() {
 }
 
 #[test]
+fn release_workflow_scopes_attestation_and_release_permissions() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let workflow = fs::read_to_string(format!("{root}/.github/workflows/release.yml"))
+        .expect("failed to read release workflow");
+
+    assert!(
+        workflow.contains("permissions:\n  contents: read"),
+        "release workflow default token permissions must be read-only"
+    );
+    assert!(
+        !workflow.contains("permissions:\n  contents: write"),
+        "release workflow must not grant contents: write at workflow scope"
+    );
+    assert!(
+        workflow.contains(
+            "  build:\n    name: Build (${{ matrix.target }})\n    runs-on: ${{ matrix.os }}\n    permissions:\n      contents: read\n      id-token: write\n      attestations: write"
+        ),
+        "build job must carry only the permissions needed to attest built artifacts"
+    );
+    assert!(
+        workflow.contains(
+            "  release:\n    name: Create Release\n    needs: [build, test]\n    runs-on: ubuntu-latest\n    permissions:\n      contents: write"
+        ),
+        "release job must receive contents: write only where assets are published"
+    );
+    assert!(
+        workflow.contains("uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1"),
+        "release workflow must use the SHA-pinned GitHub attestation action"
+    );
+    assert!(
+        workflow.contains("agnix-*${{ matrix.target }}.tar.gz")
+            && workflow.contains("agnix-*${{ matrix.target }}.zip"),
+        "attestation subject paths must cover release archives"
+    );
+}
+
+#[test]
 fn action_download_script_verifies_release_checksum() {
     let root = env!("CARGO_MANIFEST_DIR");
     let script = fs::read_to_string(format!("{root}/scripts/download.sh"))


### PR DESCRIPTION
## What

Adds GitHub-native SLSA build-provenance attestation so consumers can verify a downloaded binary was built by this repo's CI (`gh attestation verify --repo agent-sh/agnix <file>`), as defense-in-depth above the SHA-256 checksums.

## Change (revised per review)

Provenance is generated in the **`build` matrix job**, immediately after each target's archives are created and **before `upload-artifact`**, with `id-token: write` + `attestations: write` scoped to the `build` job only. The `release`/publish job carries no attestation tokens, so a compromised publish step cannot mint a valid attestation for a swapped archive - each artifact is attested at build time, bound to the build.

## Current upstream references

- GitHub's current artifact-attestation docs show build provenance for binaries with `actions/attest@v4` and `subject-path`: https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#generating-build-provenance-for-binaries
- The pinned `actions/attest@a1948c3f` README documents Provenance mode: when no `sbom-path` or predicate inputs are supplied, it auto-generates SLSA build provenance: https://github.com/actions/attest/blob/a1948c3f048ba23858d222213b7c278aabede763/README.md#attestation-modes
- The pinned `action.yml` marks `predicate-type`, `predicate`, and `predicate-path` as not required; those inputs are required only for custom attestations: https://github.com/actions/attest/blob/a1948c3f048ba23858d222213b7c278aabede763/action.yml
- `actions/attest-build-provenance@v4.1.1` documents itself as a wrapper over `actions/attest` and says new implementations should use `actions/attest`: https://github.com/actions/attest-build-provenance/tree/v4.1.1#usage
- Verified with `git ls-remote`: `actions/attest` tag `v4.1.1` resolves to `a1948c3f048ba23858d222213b7c278aabede763`.

Thanks @avifenesh for catching that the original attest-in-release-job version left the same self-signed-release gap open.

Found during an external audit of v0.37.2.