### PR TITLE
fix(npm): verify release archive checksum before extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **npm installer checksum verification**. The npm postinstall downloader now verifies release archive SHA-256 sidecars before extraction, binds sidecar entries to the expected archive filename, streams archive hashing, and cleans temporary artifacts after failed installs.
+
 ## [0.37.2] - 2026-07-04
 
 ### Fixed

--- a/npm/install.js
+++ b/npm/install.js
@@ -20,6 +20,20 @@ function removeIfExists(filePath) {
   }
 }
 
+function restoreWrapperBackup(wrapperPath, wrapperBackup, installCompleted) {
+  if (!fs.existsSync(wrapperBackup)) {
+    return;
+  }
+
+  if (installCompleted) {
+    removeIfExists(wrapperBackup);
+    return;
+  }
+
+  removeIfExists(wrapperPath);
+  fs.renameSync(wrapperBackup, wrapperPath);
+}
+
 /**
  * Get platform-specific asset name and binary name.
  */
@@ -222,6 +236,7 @@ async function main() {
   const extractedPath = path.join(binDir, platformInfo.extractedName);
   const wrapperPath = path.join(binDir, 'agnix');
   const wrapperBackup = path.join(binDir, 'agnix.backup');
+  let installCompleted = false;
 
   // Skip if binary already exists
   if (fs.existsSync(binaryPath)) {
@@ -270,6 +285,7 @@ async function main() {
       throw new Error('Binary not found after extraction');
     }
 
+    installCompleted = true;
     console.log('agnix installed successfully');
   } catch (error) {
     console.error(`Failed to install agnix: ${error.message}`);
@@ -281,13 +297,7 @@ async function main() {
     // Best-effort cleanup so a failed install leaves no stale archive or backup.
     removeIfExists(archivePath);
     try {
-      if (fs.existsSync(wrapperBackup)) {
-        if (!fs.existsSync(wrapperPath)) {
-          fs.renameSync(wrapperBackup, wrapperPath);
-        } else {
-          removeIfExists(wrapperBackup);
-        }
-      }
+      restoreWrapperBackup(wrapperPath, wrapperBackup, installCompleted);
     } catch (_) {
       // ignore
     }
@@ -305,6 +315,7 @@ module.exports = {
   main,
   parseSha256Sidecar,
   removeIfExists,
+  restoreWrapperBackup,
   sha256File,
   verifyChecksum,
 };

--- a/npm/install.js
+++ b/npm/install.js
@@ -10,6 +10,16 @@ const crypto = require('crypto');
 const GITHUB_REPO = 'agent-sh/agnix';
 const VERSION = require('./package.json').version;
 
+function removeIfExists(filePath) {
+  try {
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch (_) {
+    // best-effort cleanup
+  }
+}
+
 /**
  * Get platform-specific asset name and binary name.
  */
@@ -63,48 +73,60 @@ function getPlatformInfo() {
  */
 function downloadFile(url, destPath) {
   return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(destPath);
+    let file = null;
+    let settled = false;
+
+    const fail = (err) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (file) {
+        file.destroy();
+      }
+      removeIfExists(destPath);
+      reject(err);
+    };
 
     const request = https.get(url, (response) => {
       if (response.statusCode === 302 || response.statusCode === 301) {
         const redirectUrl = response.headers.location;
         if (redirectUrl) {
-          file.close();
-          fs.unlinkSync(destPath);
-          downloadFile(redirectUrl, destPath).then(resolve).catch(reject);
+          response.resume();
+          const nextUrl = new URL(redirectUrl, url).href;
+          downloadFile(nextUrl, destPath).then(resolve).catch(reject);
           return;
         }
       }
 
       if (response.statusCode !== 200) {
-        file.close();
-        try {
-          fs.unlinkSync(destPath);
-        } catch (_) {
-          // best-effort: don't leave a stale/empty file after a failed download
-        }
-        reject(new Error(`Download failed with status ${response.statusCode}`));
+        response.resume();
+        fail(new Error(`Download failed with status ${response.statusCode}`));
         return;
       }
 
+      file = fs.createWriteStream(destPath);
       response.pipe(file);
+      response.on('error', fail);
 
       file.on('finish', () => {
-        file.close();
-        resolve();
+        if (settled) {
+          return;
+        }
+        settled = true;
+        file.close((err) => {
+          if (err) {
+            removeIfExists(destPath);
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
       });
+      file.on('error', fail);
     });
 
-    request.on('error', (err) => {
-      file.close();
-      fs.unlinkSync(destPath);
-      reject(err);
-    });
-
-    file.on('error', (err) => {
-      fs.unlinkSync(destPath);
-      reject(err);
-    });
+    request.on('error', fail);
   });
 }
 
@@ -140,20 +162,47 @@ function sha256File(filePath) {
   });
 }
 
+function parseSha256Sidecar(contents, expectedFileName) {
+  const expectedBase = path.basename(expectedFileName);
+  for (const line of contents.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const [rawHash, rawFileName] = trimmed.split(/\s+/, 2);
+    if (!rawFileName) {
+      continue;
+    }
+
+    const normalizedFileName = rawFileName.replace(/^\*/, '').replace(/\\/g, '/');
+    const baseName = path.posix.basename(normalizedFileName);
+    if (baseName !== expectedBase) {
+      continue;
+    }
+
+    const expected = rawHash.toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(expected)) {
+      throw new Error(`Invalid checksum file for ${expectedBase}`);
+    }
+
+    return expected;
+  }
+
+  throw new Error(`Checksum file does not contain an entry for ${expectedBase}`);
+}
+
 /**
  * Download the `.sha256` sidecar for an archive and verify the archive against
  * it before extraction, so a tampered download is rejected (mirrors
  * scripts/download.sh). Throws on a missing/malformed sidecar or hash mismatch.
  */
-async function verifyChecksum(archivePath, checksumUrl) {
+async function verifyChecksum(archivePath, checksumUrl, deps = { downloadFile }) {
   const checksumPath = `${archivePath}.sha256`;
   try {
-    await downloadFile(checksumUrl, checksumPath);
+    await deps.downloadFile(checksumUrl, checksumPath);
     const raw = fs.readFileSync(checksumPath, 'utf8').trim();
-    const expected = (raw.split(/\s+/)[0] || '').toLowerCase();
-    if (!/^[0-9a-f]{64}$/.test(expected)) {
-      throw new Error(`Invalid checksum file for ${path.basename(archivePath)}`);
-    }
+    const expected = parseSha256Sidecar(raw, path.basename(archivePath));
     const actual = (await sha256File(archivePath)).toLowerCase();
     if (actual !== expected) {
       throw new Error(
@@ -162,11 +211,7 @@ async function verifyChecksum(archivePath, checksumUrl) {
     }
     console.log('Checksum verified.');
   } finally {
-    try {
-      if (fs.existsSync(checksumPath)) fs.unlinkSync(checksumPath);
-    } catch (_) {
-      // best-effort cleanup of the sidecar
-    }
+    removeIfExists(checksumPath);
   }
 }
 
@@ -234,17 +279,13 @@ async function main() {
     process.exitCode = 1;
   } finally {
     // Best-effort cleanup so a failed install leaves no stale archive or backup.
-    try {
-      if (fs.existsSync(archivePath)) fs.unlinkSync(archivePath);
-    } catch (_) {
-      // ignore
-    }
+    removeIfExists(archivePath);
     try {
       if (fs.existsSync(wrapperBackup)) {
         if (!fs.existsSync(wrapperPath)) {
           fs.renameSync(wrapperBackup, wrapperPath);
         } else {
-          fs.unlinkSync(wrapperBackup);
+          removeIfExists(wrapperBackup);
         }
       }
     } catch (_) {
@@ -253,4 +294,17 @@ async function main() {
   }
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  downloadFile,
+  extractArchive,
+  getPlatformInfo,
+  main,
+  parseSha256Sidecar,
+  removeIfExists,
+  sha256File,
+  verifyChecksum,
+};

--- a/npm/install.js
+++ b/npm/install.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const os = require('os');
+const crypto = require('crypto');
 
 const GITHUB_REPO = 'agent-sh/agnix';
 const VERSION = require('./package.json').version;
@@ -120,6 +121,36 @@ function extractArchive(archivePath, destDir) {
   }
 }
 
+/**
+ * Compute the SHA-256 of a file as a lowercase hex string.
+ */
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+/**
+ * Download the `.sha256` sidecar for an archive and verify the archive against it.
+ * Throws if the sidecar is missing/malformed or the hash does not match, so a
+ * tampered download is rejected before extraction (mirrors scripts/download.sh).
+ */
+async function verifyChecksum(archivePath, checksumUrl) {
+  const checksumPath = `${archivePath}.sha256`;
+  await downloadFile(checksumUrl, checksumPath);
+  const raw = fs.readFileSync(checksumPath, 'utf8').trim();
+  fs.unlinkSync(checksumPath);
+  const expected = (raw.split(/\s+/)[0] || '').toLowerCase();
+  if (!/^[0-9a-f]{64}$/.test(expected)) {
+    throw new Error(`Invalid checksum file for ${path.basename(archivePath)}`);
+  }
+  const actual = sha256File(archivePath).toLowerCase();
+  if (actual !== expected) {
+    throw new Error(
+      `Checksum mismatch for ${path.basename(archivePath)}: expected ${expected}, got ${actual}`
+    );
+  }
+  console.log('Checksum verified.');
+}
+
 async function main() {
   const platformInfo = getPlatformInfo();
   const binDir = path.join(__dirname, 'bin');
@@ -151,6 +182,7 @@ async function main() {
     }
 
     await downloadFile(downloadUrl, archivePath);
+    await verifyChecksum(archivePath, `${downloadUrl}.sha256`);
     console.log('Extracting...');
     extractArchive(archivePath, binDir);
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -78,6 +78,11 @@ function downloadFile(url, destPath) {
 
       if (response.statusCode !== 200) {
         file.close();
+        try {
+          fs.unlinkSync(destPath);
+        } catch (_) {
+          // best-effort: don't leave a stale/empty file after a failed download
+        }
         reject(new Error(`Download failed with status ${response.statusCode}`));
         return;
       }
@@ -122,33 +127,47 @@ function extractArchive(archivePath, destDir) {
 }
 
 /**
- * Compute the SHA-256 of a file as a lowercase hex string.
+ * Compute the SHA-256 of a file as a lowercase hex string, streaming the file
+ * so large archives are not read fully into memory.
  */
 function sha256File(filePath) {
-  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha256');
+    const stream = fs.createReadStream(filePath);
+    stream.on('error', reject);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
 }
 
 /**
- * Download the `.sha256` sidecar for an archive and verify the archive against it.
- * Throws if the sidecar is missing/malformed or the hash does not match, so a
- * tampered download is rejected before extraction (mirrors scripts/download.sh).
+ * Download the `.sha256` sidecar for an archive and verify the archive against
+ * it before extraction, so a tampered download is rejected (mirrors
+ * scripts/download.sh). Throws on a missing/malformed sidecar or hash mismatch.
  */
 async function verifyChecksum(archivePath, checksumUrl) {
   const checksumPath = `${archivePath}.sha256`;
-  await downloadFile(checksumUrl, checksumPath);
-  const raw = fs.readFileSync(checksumPath, 'utf8').trim();
-  fs.unlinkSync(checksumPath);
-  const expected = (raw.split(/\s+/)[0] || '').toLowerCase();
-  if (!/^[0-9a-f]{64}$/.test(expected)) {
-    throw new Error(`Invalid checksum file for ${path.basename(archivePath)}`);
+  try {
+    await downloadFile(checksumUrl, checksumPath);
+    const raw = fs.readFileSync(checksumPath, 'utf8').trim();
+    const expected = (raw.split(/\s+/)[0] || '').toLowerCase();
+    if (!/^[0-9a-f]{64}$/.test(expected)) {
+      throw new Error(`Invalid checksum file for ${path.basename(archivePath)}`);
+    }
+    const actual = (await sha256File(archivePath)).toLowerCase();
+    if (actual !== expected) {
+      throw new Error(
+        `Checksum mismatch for ${path.basename(archivePath)}: expected ${expected}, got ${actual}`
+      );
+    }
+    console.log('Checksum verified.');
+  } finally {
+    try {
+      if (fs.existsSync(checksumPath)) fs.unlinkSync(checksumPath);
+    } catch (_) {
+      // best-effort cleanup of the sidecar
+    }
   }
-  const actual = sha256File(archivePath).toLowerCase();
-  if (actual !== expected) {
-    throw new Error(
-      `Checksum mismatch for ${path.basename(archivePath)}: expected ${expected}, got ${actual}`
-    );
-  }
-  console.log('Checksum verified.');
 }
 
 async function main() {
@@ -156,6 +175,8 @@ async function main() {
   const binDir = path.join(__dirname, 'bin');
   const binaryPath = path.join(binDir, platformInfo.binary);
   const extractedPath = path.join(binDir, platformInfo.extractedName);
+  const wrapperPath = path.join(binDir, 'agnix');
+  const wrapperBackup = path.join(binDir, 'agnix.backup');
 
   // Skip if binary already exists
   if (fs.existsSync(binaryPath)) {
@@ -175,8 +196,6 @@ async function main() {
 
   try {
     // Save wrapper script if it exists (npm places it during install)
-    const wrapperPath = path.join(binDir, 'agnix');
-    const wrapperBackup = path.join(binDir, 'agnix.backup');
     if (fs.existsSync(wrapperPath) && wrapperPath !== binaryPath) {
       fs.copyFileSync(wrapperPath, wrapperBackup);
     }
@@ -185,9 +204,6 @@ async function main() {
     await verifyChecksum(archivePath, `${downloadUrl}.sha256`);
     console.log('Extracting...');
     extractArchive(archivePath, binDir);
-
-    // Clean up archive
-    fs.unlinkSync(archivePath);
 
     // Rename extracted binary to avoid conflict with wrapper script
     if (fs.existsSync(extractedPath) && extractedPath !== binaryPath) {
@@ -215,7 +231,25 @@ async function main() {
     console.error('');
     console.error('You can install manually:');
     console.error('  cargo install agnix-cli');
-    process.exit(1);
+    process.exitCode = 1;
+  } finally {
+    // Best-effort cleanup so a failed install leaves no stale archive or backup.
+    try {
+      if (fs.existsSync(archivePath)) fs.unlinkSync(archivePath);
+    } catch (_) {
+      // ignore
+    }
+    try {
+      if (fs.existsSync(wrapperBackup)) {
+        if (!fs.existsSync(wrapperPath)) {
+          fs.renameSync(wrapperBackup, wrapperPath);
+        } else {
+          fs.unlinkSync(wrapperBackup);
+        }
+      }
+    } catch (_) {
+      // ignore
+    }
   }
 }
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "postinstall": "node install.js",
-    "test": "node test/test.js"
+    "test": "node test/install-helpers.test.js && node test/test.js"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/npm/test/install-helpers.test.js
+++ b/npm/test/install-helpers.test.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/**
+ * Tests for npm installer helper behavior.
+ */
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  parseSha256Sidecar,
+  sha256File,
+  verifyChecksum,
+} = require('../install');
+
+let passed = 0;
+let failed = 0;
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  PASS: ${name}`);
+    passed++;
+  } catch (err) {
+    console.log(`  FAIL: ${name}`);
+    console.log(`        ${err.message}`);
+    failed++;
+  }
+}
+
+function sha256(contents) {
+  return crypto.createHash('sha256').update(contents).digest('hex');
+}
+
+async function withTempDir(fn) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agnix-install-test-'));
+  try {
+    await fn(tempDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+(async () => {
+  console.log('agnix npm installer helper tests\n');
+
+  await test('parseSha256Sidecar selects the matching archive basename', () => {
+    const expected = 'a'.repeat(64);
+    const ignored = 'b'.repeat(64);
+    const sidecar = [
+      `${ignored}  other-archive.tar.gz`,
+      `${expected}  nested/agnix-x86_64-unknown-linux-gnu.tar.gz`,
+    ].join('\n');
+
+    assert.strictEqual(
+      parseSha256Sidecar(sidecar, 'agnix-x86_64-unknown-linux-gnu.tar.gz'),
+      expected
+    );
+  });
+
+  await test('parseSha256Sidecar accepts Windows-style paths and binary markers', () => {
+    const expected = 'c'.repeat(64);
+    const sidecar = `${expected}  *nested\\agnix-x86_64-pc-windows-msvc.zip\n`;
+
+    assert.strictEqual(
+      parseSha256Sidecar(sidecar, 'agnix-x86_64-pc-windows-msvc.zip'),
+      expected
+    );
+  });
+
+  await test('parseSha256Sidecar rejects a malformed matching hash', () => {
+    assert.throws(
+      () => parseSha256Sidecar('not-a-hash  agnix.tar.gz\n', 'agnix.tar.gz'),
+      /Invalid checksum file/
+    );
+  });
+
+  await test('parseSha256Sidecar rejects sidecars without the archive entry', () => {
+    assert.throws(
+      () => parseSha256Sidecar(`${'d'.repeat(64)}  other.tar.gz\n`, 'agnix.tar.gz'),
+      /does not contain an entry/
+    );
+  });
+
+  await test('sha256File hashes the archive asynchronously', async () => {
+    await withTempDir(async (tempDir) => {
+      const archivePath = path.join(tempDir, 'archive.tar.gz');
+      fs.writeFileSync(archivePath, 'hello agnix');
+
+      assert.strictEqual(await sha256File(archivePath), sha256('hello agnix'));
+    });
+  });
+
+  await test('verifyChecksum awaits hashing and removes the sidecar', async () => {
+    await withTempDir(async (tempDir) => {
+      const archivePath = path.join(tempDir, 'agnix.tar.gz');
+      const contents = 'verified archive';
+      fs.writeFileSync(archivePath, contents);
+
+      await verifyChecksum(archivePath, 'https://example.invalid/agnix.tar.gz.sha256', {
+        downloadFile: async (_url, checksumPath) => {
+          fs.writeFileSync(checksumPath, `${sha256(contents)}  agnix.tar.gz\n`);
+        },
+      });
+
+      assert.ok(!fs.existsSync(`${archivePath}.sha256`), 'sidecar should be removed');
+    });
+  });
+
+  await test('verifyChecksum removes the sidecar after mismatch failures', async () => {
+    await withTempDir(async (tempDir) => {
+      const archivePath = path.join(tempDir, 'agnix.tar.gz');
+      fs.writeFileSync(archivePath, 'actual archive');
+
+      await assert.rejects(
+        verifyChecksum(archivePath, 'https://example.invalid/agnix.tar.gz.sha256', {
+          downloadFile: async (_url, checksumPath) => {
+            fs.writeFileSync(checksumPath, `${'e'.repeat(64)}  agnix.tar.gz\n`);
+          },
+        }),
+        /Checksum mismatch/
+      );
+
+      assert.ok(!fs.existsSync(`${archivePath}.sha256`), 'sidecar should be removed');
+    });
+  });
+
+  console.log(`\nResults: ${passed} passed, ${failed} failed`);
+  process.exitCode = failed > 0 ? 1 : 0;
+})();

--- a/npm/test/install-helpers.test.js
+++ b/npm/test/install-helpers.test.js
@@ -12,6 +12,7 @@ const path = require('path');
 
 const {
   parseSha256Sidecar,
+  restoreWrapperBackup,
   sha256File,
   verifyChecksum,
 } = require('../install');
@@ -125,6 +126,34 @@ async function withTempDir(fn) {
       );
 
       assert.ok(!fs.existsSync(`${archivePath}.sha256`), 'sidecar should be removed');
+    });
+  });
+
+  await test('restoreWrapperBackup restores over partial extraction on failure', async () => {
+    await withTempDir(async (tempDir) => {
+      const wrapperPath = path.join(tempDir, 'agnix');
+      const wrapperBackup = path.join(tempDir, 'agnix.backup');
+      fs.writeFileSync(wrapperPath, 'partial extracted binary');
+      fs.writeFileSync(wrapperBackup, 'npm wrapper');
+
+      restoreWrapperBackup(wrapperPath, wrapperBackup, false);
+
+      assert.strictEqual(fs.readFileSync(wrapperPath, 'utf8'), 'npm wrapper');
+      assert.ok(!fs.existsSync(wrapperBackup), 'backup should be moved back into place');
+    });
+  });
+
+  await test('restoreWrapperBackup removes stale backup after successful install', async () => {
+    await withTempDir(async (tempDir) => {
+      const wrapperPath = path.join(tempDir, 'agnix');
+      const wrapperBackup = path.join(tempDir, 'agnix.backup');
+      fs.writeFileSync(wrapperPath, 'installed wrapper');
+      fs.writeFileSync(wrapperBackup, 'old wrapper backup');
+
+      restoreWrapperBackup(wrapperPath, wrapperBackup, true);
+
+      assert.strictEqual(fs.readFileSync(wrapperPath, 'utf8'), 'installed wrapper');
+      assert.ok(!fs.existsSync(wrapperBackup), 'stale backup should be removed');
     });
   });
 


### PR DESCRIPTION
## Problem

The npm install path (`npm/install.js`) downloads the release archive and extracts + executes it with no integrity check, even though every release asset ships a `.sha256` sidecar and the shell installer (`scripts/download.sh`) already verifies it. So the npm channel is the one download path that trusts the bytes unconditionally.

## Fix

After `downloadFile` and before `extractArchive`, fetch `${downloadUrl}.sha256`, compute the SHA-256 of the downloaded archive with `node:crypto`, and throw on a missing/malformed sidecar or a hash mismatch - mirroring `scripts/download.sh:155-175`. Verified `node --check` clean.

Found during an external audit of v0.37.2.