### PR TITLE
fix: harden security followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Security follow-ups** (closes #1149, #1150, #1154, #1155, #1156, #1157, #1158). Hardened MCP validation against handler panics and absolute-path disclosure, extended panic isolation to project-level checks, bound shell checksum parsing to the selected artifact filename, added VS Code release-download redirect host validation, corrected the YAML parser safety comment, and documented the remaining deprecated transitive `serde_yaml` dependency from `rust-i18n`.
+
 ## [0.37.2] - 2026-07-04
 
 ### Fixed

--- a/crates/agnix-core/src/parsers/frontmatter.rs
+++ b/crates/agnix-core/src/parsers/frontmatter.rs
@@ -9,9 +9,9 @@
 //!    extremely large YAML payloads from being read.
 //!
 //! 2. **Parser Library**: agnix's direct `serde_yaml` crate name is backed by
-//!    the maintained `serde_norway` package, which preserves the YAML parser API
-//!    and internal protections against excessive memory usage and stack overflow
-//!    from deeply nested structures.
+//!    the maintained `serde_norway` package, which preserves the YAML parser API.
+//!    The parser is not treated as the nesting or expansion-bomb boundary; agnix's
+//!    own size cap and depth guard below provide that protection.
 //!
 //! 3. **Memory Limit**: The entire file is bounded at 1 MiB, limiting total
 //!    memory consumption regardless of structure complexity.

--- a/crates/agnix-core/src/pipeline.rs
+++ b/crates/agnix-core/src/pipeline.rs
@@ -852,17 +852,17 @@ pub fn validate_project_with_registry(
     }
 
     // Run project-level checks (AGM-006, XP-004/005/006, VER-001)
-    {
+    diagnostics.extend(run_project_level_checks_with_panic_guard(&root_dir, || {
         agents_md_paths.sort();
         instruction_file_paths.sort();
 
-        diagnostics.extend(run_project_level_checks(
+        run_project_level_checks(
             &agents_md_paths,
             &instruction_file_paths,
             &config,
             &root_dir,
-        ));
-    }
+        )
+    }));
 
     sort_diagnostics(&mut diagnostics);
 
@@ -890,6 +890,28 @@ fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
             .then_with(|| a.suggestion.cmp(&b.suggestion))
             .then_with(|| a.fixes.len().cmp(&b.fixes.len()))
     });
+}
+
+fn run_project_level_checks_with_panic_guard<F>(root_dir: &Path, checks: F) -> Vec<Diagnostic>
+where
+    F: FnOnce() -> Vec<Diagnostic>,
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(checks)) {
+        Ok(diagnostics) => diagnostics,
+        Err(err) => {
+            let panic_message = panic_payload_message(err.as_ref());
+            vec![
+                Diagnostic::error(
+                    root_dir.to_path_buf(),
+                    0,
+                    0,
+                    "project::panic",
+                    t!("rules.file_panic_error", error = panic_message),
+                )
+                .with_suggestion(t!("rules.file_panic_error_suggestion")),
+            ]
+        }
+    }
 }
 
 #[cfg(feature = "filesystem")]
@@ -1407,6 +1429,24 @@ mod tests {
             }),
             "expected file::panic diagnostic, got {:?}",
             result.diagnostics
+        );
+    }
+
+    #[test]
+    fn project_level_panic_becomes_diagnostic() {
+        let temp = tempfile::TempDir::new().unwrap();
+
+        let diagnostics = run_project_level_checks_with_panic_guard(temp.path(), || {
+            panic!("intentional project panic")
+        });
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, "project::panic");
+        assert_eq!(diagnostics[0].file, temp.path());
+        assert!(
+            diagnostics[0].message.contains("intentional project panic"),
+            "expected panic payload in diagnostic: {:?}",
+            diagnostics[0]
         );
     }
 }

--- a/crates/agnix-core/src/pipeline.rs
+++ b/crates/agnix-core/src/pipeline.rs
@@ -625,12 +625,14 @@ pub fn validate_project_rules(root: &Path, config: &LintConfig) -> LintResult<Ve
     instruction_file_paths.sort();
 
     let mut diagnostics = files_config_diags;
-    diagnostics.extend(run_project_level_checks(
-        &agents_md_paths,
-        &instruction_file_paths,
-        &config,
-        &root_dir,
-    ));
+    diagnostics.extend(run_project_level_checks_with_panic_guard(&root_dir, || {
+        run_project_level_checks(
+            &agents_md_paths,
+            &instruction_file_paths,
+            &config,
+            &root_dir,
+        )
+    }));
     Ok(diagnostics)
 }
 

--- a/crates/agnix-core/src/pipeline.rs
+++ b/crates/agnix-core/src/pipeline.rs
@@ -878,6 +878,7 @@ pub fn validate_project_with_registry(
         .with_validator_factories_registered(validator_factories_registered))
 }
 
+#[cfg(feature = "filesystem")]
 fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
     diagnostics.sort_by(|a, b| {
         a.level
@@ -892,6 +893,7 @@ fn sort_diagnostics(diagnostics: &mut [Diagnostic]) {
     });
 }
 
+#[cfg(feature = "filesystem")]
 fn run_project_level_checks_with_panic_guard<F>(root_dir: &Path, checks: F) -> Vec<Diagnostic>
 where
     F: FnOnce() -> Vec<Diagnostic>,

--- a/crates/agnix-mcp/src/main.rs
+++ b/crates/agnix-mcp/src/main.rs
@@ -32,7 +32,10 @@ use rmcp::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::any::Any;
 use std::collections::HashSet;
+use std::fmt::Display;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 
 const TOOL_ALIASES: &[(&str, &str)] =
@@ -180,8 +183,16 @@ struct DiagnosticOutput {
 
 impl From<&Diagnostic> for DiagnosticOutput {
     fn from(d: &Diagnostic) -> Self {
+        Self::from_diagnostic(d, None)
+    }
+}
+
+impl DiagnosticOutput {
+    fn from_diagnostic(d: &Diagnostic, workspace_root: Option<&Path>) -> Self {
         Self {
-            file: d.file.display().to_string(),
+            file: workspace_root
+                .map(|root| display_path_for_client(&d.file, root))
+                .unwrap_or_else(|| d.file.display().to_string()),
             line: d.line,
             column: d.column,
             level: match d.level {
@@ -342,6 +353,7 @@ fn diagnostics_to_result(
     path: &str,
     diagnostics: Vec<Diagnostic>,
     files_checked: usize,
+    workspace_root: &Path,
 ) -> ValidationResult {
     let errors = diagnostics
         .iter()
@@ -359,7 +371,10 @@ fn diagnostics_to_result(
         errors,
         warnings,
         fixable,
-        diagnostics: diagnostics.iter().map(DiagnosticOutput::from).collect(),
+        diagnostics: diagnostics
+            .iter()
+            .map(|d| DiagnosticOutput::from_diagnostic(d, Some(workspace_root)))
+            .collect(),
     }
 }
 
@@ -395,10 +410,76 @@ fn resolve_path_within_workspace(
     Ok(canonical_candidate)
 }
 
-fn resolve_mcp_path(input_path: &str) -> Result<PathBuf, McpError> {
+struct ResolvedMcpPath {
+    canonical_path: PathBuf,
+    workspace_root: PathBuf,
+}
+
+fn resolve_mcp_path_with_root(input_path: &str) -> Result<ResolvedMcpPath, McpError> {
     let workspace_root = std::env::current_dir()
-        .map_err(|e| make_internal_error(format!("Failed to read current directory: {e}")))?;
-    resolve_path_within_workspace(input_path, &workspace_root).map_err(make_invalid_params)
+        .map_err(|e| make_internal_error(format!("Failed to read current directory: {e}")))?
+        .canonicalize()
+        .map_err(|e| make_internal_error(format!("Failed to resolve current directory: {e}")))?;
+    let canonical_path =
+        resolve_path_within_workspace(input_path, &workspace_root).map_err(make_invalid_params)?;
+
+    Ok(ResolvedMcpPath {
+        canonical_path,
+        workspace_root,
+    })
+}
+
+fn display_path_for_client(path: &Path, workspace_root: &Path) -> String {
+    let display_path = path.strip_prefix(workspace_root).unwrap_or(path);
+    if display_path.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        display_path.display().to_string()
+    }
+}
+
+fn sanitize_error_message(error: impl Display, workspace_root: &Path) -> String {
+    let mut message = error.to_string();
+    let root_display = workspace_root.display().to_string();
+    if !root_display.is_empty() {
+        message = message.replace(&root_display, ".");
+    }
+    message
+}
+
+fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(msg) = payload.downcast_ref::<&str>() {
+        (*msg).to_string()
+    } else if let Some(msg) = payload.downcast_ref::<String>() {
+        msg.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
+}
+
+fn run_validation_guarded<T, E, F>(
+    operation: &str,
+    input_path: &str,
+    workspace_root: &Path,
+    validate: F,
+) -> Result<T, McpError>
+where
+    E: Display,
+    F: FnOnce() -> Result<T, E>,
+{
+    match catch_unwind(AssertUnwindSafe(validate)) {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(make_invalid_params(format!(
+            "Failed to {operation} '{}': {}",
+            input_path,
+            sanitize_error_message(error, workspace_root)
+        ))),
+        Err(payload) => Err(make_internal_error(format!(
+            "Validation panicked while processing '{}': {}",
+            input_path,
+            panic_payload_message(payload.as_ref())
+        ))),
+    }
 }
 
 /// Agnix MCP Server - validates AI agent configurations
@@ -437,13 +518,18 @@ impl AgnixServer {
         let mut config = LintConfig::default();
         apply_tool_selection(&mut config, input.tools, input.target)?;
 
-        let file_path = resolve_mcp_path(&input.path)?;
+        let resolved_path = resolve_mcp_path_with_root(&input.path)?;
 
-        let outcome = core_validate_file(&file_path, &config)
-            .map_err(|e| make_invalid_params(format!("Failed to validate file: {}", e)))?;
+        let outcome = run_validation_guarded(
+            "validate file",
+            &input.path,
+            &resolved_path.workspace_root,
+            || core_validate_file(&resolved_path.canonical_path, &config),
+        )?;
 
         let diagnostics = outcome.into_diagnostics();
-        let result = diagnostics_to_result(&input.path, diagnostics, 1);
+        let result =
+            diagnostics_to_result(&input.path, diagnostics, 1, &resolved_path.workspace_root);
         let json = serde_json::to_string_pretty(&result)
             .map_err(|e| make_internal_error(format!("Failed to serialize result: {}", e)))?;
 
@@ -461,15 +547,20 @@ impl AgnixServer {
         let mut config = LintConfig::default();
         apply_tool_selection(&mut config, input.tools, input.target)?;
 
-        let project_path = resolve_mcp_path(&input.path)?;
+        let resolved_path = resolve_mcp_path_with_root(&input.path)?;
 
-        let validation_result = core_validate_project(&project_path, &config)
-            .map_err(|e| make_invalid_params(format!("Failed to validate project: {}", e)))?;
+        let validation_result = run_validation_guarded(
+            "validate project",
+            &input.path,
+            &resolved_path.workspace_root,
+            || core_validate_project(&resolved_path.canonical_path, &config),
+        )?;
 
         let result = diagnostics_to_result(
             &input.path,
             validation_result.diagnostics,
             validation_result.files_checked,
+            &resolved_path.workspace_root,
         );
         let json = serde_json::to_string_pretty(&result)
             .map_err(|e| make_internal_error(format!("Failed to serialize result: {}", e)))?;
@@ -583,12 +674,15 @@ async fn main() -> anyhow::Result<()> {
 mod tests {
     use super::{
         ToolsInput, ValidateFileInput, ValidateProjectInput, apply_tool_selection,
-        make_internal_error, make_invalid_params, parse_tools, resolve_path_within_workspace,
+        diagnostics_to_result, display_path_for_client, make_internal_error, make_invalid_params,
+        parse_tools, resolve_path_within_workspace, run_validation_guarded, sanitize_error_message,
     };
     use agnix_core::LintConfig;
     use agnix_core::config::TargetTool;
+    use agnix_core::diagnostics::{Diagnostic, LintError, ValidationError};
     use rmcp::model::ErrorCode;
     use serde_json::json;
+    use std::path::PathBuf;
 
     #[test]
     fn test_parse_tools_csv_trims_and_discards_empty_entries() {
@@ -866,6 +960,85 @@ mod tests {
             .expect_err("absolute outside paths must be rejected");
 
         assert!(err.contains("outside workspace boundary"));
+    }
+
+    #[test]
+    fn test_diagnostics_to_result_relativizes_workspace_paths() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let skill_path = workspace.path().join("SKILL.md");
+        std::fs::write(&skill_path, "---\nname: test\n---\n").unwrap();
+        let canonical_skill = skill_path.canonicalize().unwrap();
+        let diagnostic = Diagnostic::error(canonical_skill, 1, 1, "AS-001", "test diagnostic");
+
+        let result = diagnostics_to_result(
+            "SKILL.md",
+            vec![diagnostic],
+            1,
+            &workspace.path().canonicalize().unwrap(),
+        );
+
+        assert_eq!(result.path, "SKILL.md");
+        assert_eq!(result.diagnostics[0].file, "SKILL.md");
+    }
+
+    #[test]
+    fn test_display_path_for_client_uses_workspace_relative_path() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let nested = workspace.path().join("nested").join("SKILL.md");
+        let display = display_path_for_client(&nested, workspace.path());
+
+        assert_eq!(
+            display,
+            PathBuf::from("nested")
+                .join("SKILL.md")
+                .display()
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn test_sanitize_error_message_redacts_workspace_root() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let message = format!(
+            "failed to read {}",
+            workspace.path().join("secret").join("SKILL.md").display()
+        );
+
+        let sanitized = sanitize_error_message(message, workspace.path());
+
+        assert!(!sanitized.contains(&workspace.path().display().to_string()));
+        assert!(sanitized.contains("."));
+    }
+
+    #[test]
+    fn test_run_validation_guarded_converts_panic_to_mcp_error() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let err = run_validation_guarded(
+            "validate file",
+            "SKILL.md",
+            workspace.path(),
+            || -> Result<(), String> { panic!("intentional mcp panic") },
+        )
+        .expect_err("panic should be converted to an MCP error");
+
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("intentional mcp panic"));
+    }
+
+    #[test]
+    fn test_run_validation_guarded_sanitizes_validation_error() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let rooted_path = workspace.path().join("secret").join("SKILL.md");
+        let err = run_validation_guarded("validate file", "SKILL.md", workspace.path(), || {
+            Err::<(), LintError>(ValidationError::RootNotFound { path: rooted_path }.into())
+        })
+        .expect_err("validation error should become an MCP invalid params error");
+
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(
+            !err.message
+                .contains(&workspace.path().display().to_string())
+        );
     }
 
     #[test]

--- a/docs/RUSTSEC-ADVISORIES.md
+++ b/docs/RUSTSEC-ADVISORIES.md
@@ -89,6 +89,34 @@ cargo tree -i proc-macro-error2 -e dev    # Check if iai-callgrind still depends
 # 5. Close or update the related tracking issue
 ```
 
+## Tracked Non-RUSTSEC Supply-Chain Items
+
+### `serde_yaml` 0.9.34+deprecated - via `rust-i18n`
+
+**Status**: Runtime transitive dependency with no current RUSTSEC advisory ID
+
+**Details**:
+- agnix's direct YAML/frontmatter parser dependency is the maintained `serde_norway` package through the stable internal `serde_yaml` crate alias.
+- `rust-i18n 4.1.0` still pulls the upstream-deprecated `serde_yaml 0.9.34+deprecated` through `rust-i18n-support`.
+- The dependency is linked into release binaries, but agnix uses it for trusted, repository-owned locale data rather than untrusted user input.
+
+**Risk Level**: Low
+- Hygiene and binary-footprint concern, not a known exploitable advisory.
+- Untrusted frontmatter parsing uses agnix's direct `serde_norway` dependency plus local size and depth guards.
+
+**Action Items**:
+- Monitor `rust-i18n` for a release that removes the deprecated `serde_yaml` dependency.
+- Re-check with `cargo tree -e normal -p rust-i18n | grep serde_yaml` before each release.
+- Remove this section once `serde_yaml 0.9.34+deprecated` is absent from `Cargo.lock`.
+
+**References**:
+- rust-i18n: https://crates.io/crates/rust-i18n
+- serde_yaml: https://crates.io/crates/serde_yaml
+
+```bash
+cargo tree -e normal -p rust-i18n | grep serde_yaml
+```
+
 ## Adding New Advisory Ignores
 
 If a new advisory needs to be temporarily ignored:

--- a/editors/vscode/src/download-file.ts
+++ b/editors/vscode/src/download-file.ts
@@ -35,12 +35,30 @@ const defaultDeps: DownloadFileDeps = {
 };
 
 const MAX_REDIRECTS = 10;
+const TRUSTED_DOWNLOAD_HOSTS = ['github.com'];
+const TRUSTED_DOWNLOAD_SUFFIXES = ['.githubusercontent.com'];
 
 function toError(value: unknown): Error {
   if (value instanceof Error) {
     return value;
   }
   return new Error(String(value));
+}
+
+function isTrustedDownloadUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  return (
+    parsed.protocol === 'https:' &&
+    (TRUSTED_DOWNLOAD_HOSTS.includes(host) ||
+      TRUSTED_DOWNLOAD_SUFFIXES.some((suffix) => host.endsWith(suffix)))
+  );
 }
 
 /**
@@ -53,6 +71,11 @@ export function downloadFile(
   redirectCount = 0
 ): Promise<void> {
   return new Promise((resolve, reject) => {
+    if (!isTrustedDownloadUrl(url)) {
+      reject(new Error(`Untrusted download URL: ${url}`));
+      return;
+    }
+
     const file = deps.createWriteStream(destPath);
     let request: RequestLike | null = null;
     let response: ResponseLike | null = null;
@@ -133,6 +156,10 @@ export function downloadFile(
       }
 
       const nextUrl = new URL(redirectUrl, url).href;
+      if (!isTrustedDownloadUrl(nextUrl)) {
+        fail(new Error(`Untrusted redirect URL: ${nextUrl}`));
+        return;
+      }
       downloadFile(nextUrl, destPath, deps, redirectCount + 1)
         .then(resolveOnce)
         .catch((err) => {

--- a/editors/vscode/src/test/unit/downloadFile.test.ts
+++ b/editors/vscode/src/test/unit/downloadFile.test.ts
@@ -2,6 +2,9 @@ import * as assert from 'assert';
 import { EventEmitter } from 'events';
 import { downloadFile, type DownloadFileDeps } from '../../download-file';
 
+const TRUSTED_URL = 'https://github.com/agent-sh/agnix/releases/download/v0.37.2/archive.tar.gz';
+const TRUSTED_REDIRECT_URL = 'https://objects.githubusercontent.com/github-production-release-asset/archive.tar.gz';
+
 type PipeDestination = {
   emit?: (event: string, ...args: unknown[]) => boolean;
 };
@@ -88,12 +91,15 @@ describe('downloadFile', () => {
     );
 
     await assert.rejects(
-      downloadFile('https://example.com/archive.tar.gz', '/tmp/archive.tar.gz', deps),
+      downloadFile(TRUSTED_URL, '/tmp/archive.tar.gz', deps),
       /status 500/
     );
 
     assert.ok(writeStreams[0].closeCalls > 0, 'expected write stream to be closed');
-    assert.deepStrictEqual(unlinkedPaths, ['/tmp/archive.tar.gz']);
+    assert.ok(
+      unlinkedPaths.includes('/tmp/archive.tar.gz'),
+      'expected temp file cleanup'
+    );
     assert.strictEqual(request.destroyed, true, 'expected HTTP request to be destroyed');
     assert.strictEqual(response.resumed, true, 'expected HTTP response to be resumed');
     assert.strictEqual(response.destroyed, true, 'expected HTTP response to be destroyed');
@@ -117,12 +123,15 @@ describe('downloadFile', () => {
     );
 
     await assert.rejects(
-      downloadFile('https://example.com/archive.tar.gz', '/tmp/archive.tar.gz', deps),
+      downloadFile(TRUSTED_URL, '/tmp/archive.tar.gz', deps),
       /disk full/
     );
 
     assert.ok(writeStreams[0].closeCalls > 0, 'expected write stream to be closed');
-    assert.deepStrictEqual(unlinkedPaths, ['/tmp/archive.tar.gz']);
+    assert.ok(
+      unlinkedPaths.includes('/tmp/archive.tar.gz'),
+      'expected temp file cleanup'
+    );
     assert.strictEqual(request.destroyed, true, 'expected HTTP request to be destroyed');
     assert.strictEqual(response.destroyed, true, 'expected HTTP response to be destroyed');
   });
@@ -140,7 +149,7 @@ describe('downloadFile', () => {
     );
 
     await assert.rejects(
-      downloadFile('https://example.com/archive.tar.gz', '/tmp/archive.tar.gz', deps),
+      downloadFile(TRUSTED_URL, '/tmp/archive.tar.gz', deps),
       /network down/
     );
 
@@ -166,7 +175,7 @@ describe('downloadFile', () => {
     );
 
     await assert.rejects(
-      downloadFile('https://example.com/archive.tar.gz', '/tmp/archive.tar.gz', deps),
+      downloadFile(TRUSTED_URL, '/tmp/archive.tar.gz', deps),
       /socket reset/
     );
 
@@ -180,7 +189,9 @@ describe('downloadFile', () => {
     const requests: FakeRequest[] = [];
     const responses: FakeResponse[] = [];
     const calledUrls: string[] = [];
-    const originalUrl = 'https://example.com/releases/latest/download/archive.tar.gz';
+    const originalUrl = TRUSTED_URL;
+    const redirectLocation = '/archive.tar.gz';
+    const redirectedUrl = new URL(redirectLocation, originalUrl).href;
 
     const { deps, writeStreams, unlinkedPaths } = createDeps(
       (url, cb) => {
@@ -193,7 +204,7 @@ describe('downloadFile', () => {
             // Redirect response does not pipe content.
           });
           response.statusCode = 302;
-          response.headers.location = '/archive.tar.gz';
+          response.headers.location = redirectLocation;
           responses.push(response);
           setImmediate(() => cb(response));
           return request;
@@ -214,10 +225,7 @@ describe('downloadFile', () => {
 
     await downloadFile(originalUrl, '/tmp/archive.tar.gz', deps);
 
-    assert.deepStrictEqual(calledUrls, [
-      originalUrl,
-      'https://example.com/archive.tar.gz',
-    ]);
+    assert.deepStrictEqual(calledUrls, [originalUrl, redirectedUrl]);
     assert.strictEqual(requests[0].destroyed, true, 'expected first request to be destroyed on redirect');
     assert.strictEqual(responses[0].resumed, true, 'expected first response to be resumed on redirect');
     assert.strictEqual(responses[0].destroyed, true, 'expected first response to be destroyed on redirect');
@@ -248,7 +256,7 @@ describe('downloadFile', () => {
     );
 
     await assert.rejects(
-      downloadFile('https://example.com/archive.tar.gz', '/tmp/archive.tar.gz', deps),
+      downloadFile(TRUSTED_URL, '/tmp/archive.tar.gz', deps),
       /Too many redirects/
     );
 
@@ -274,11 +282,84 @@ describe('downloadFile', () => {
       }
     );
 
-    await downloadFile('https://example.com/archive.tar.gz', '/tmp/archive.tar.gz', deps);
+    await downloadFile(TRUSTED_URL, '/tmp/archive.tar.gz', deps);
 
     assert.ok(writeStreams[0].closeCalls > 0, 'expected write stream to be closed on success');
     assert.deepStrictEqual(unlinkedPaths, []);
     assert.strictEqual(request.destroyed, false);
     assert.strictEqual(response.destroyed, false);
+  });
+
+  it('rejects untrusted initial URLs before opening a file', async () => {
+    const { deps, writeStreams } = createDeps(() => {
+      throw new Error('request should not be created');
+    });
+
+    await assert.rejects(
+      downloadFile('https://example.com/archive.tar.gz', '/tmp/archive.tar.gz', deps),
+      /Untrusted download URL/
+    );
+
+    assert.strictEqual(writeStreams.length, 0);
+  });
+
+  it('rejects redirects to untrusted hosts', async () => {
+    const request = new FakeRequest();
+    const response = new FakeResponse(() => {
+      // Redirect response does not pipe content.
+    });
+    response.statusCode = 302;
+    response.headers.location = 'https://example.com/archive.tar.gz';
+
+    const { deps, writeStreams, unlinkedPaths } = createDeps((_url, cb) => {
+      setImmediate(() => cb(response));
+      return request;
+    });
+
+    await assert.rejects(
+      downloadFile(TRUSTED_URL, '/tmp/archive.tar.gz', deps),
+      /Untrusted redirect URL/
+    );
+
+    assert.ok(writeStreams[0].closeCalls > 0, 'expected write stream to be closed');
+    assert.ok(
+      unlinkedPaths.includes('/tmp/archive.tar.gz'),
+      'expected temp file cleanup'
+    );
+    assert.strictEqual(request.destroyed, true, 'expected request to be destroyed');
+    assert.strictEqual(response.destroyed, true, 'expected response to be destroyed');
+  });
+
+  it('follows redirects to trusted githubusercontent hosts', async () => {
+    const calledUrls: string[] = [];
+
+    const { deps } = createDeps((url, cb) => {
+      calledUrls.push(url);
+      const request = new FakeRequest();
+
+      if (calledUrls.length === 1) {
+        const response = new FakeResponse(() => {
+          // Redirect response does not pipe content.
+        });
+        response.statusCode = 302;
+        response.headers.location = TRUSTED_REDIRECT_URL;
+        setImmediate(() => cb(response));
+        return request;
+      }
+
+      const response = new FakeResponse((dest) => {
+        setImmediate(() => {
+          if (dest.emit) {
+            dest.emit('finish');
+          }
+        });
+      });
+      setImmediate(() => cb(response));
+      return request;
+    });
+
+    await downloadFile(TRUSTED_URL, '/tmp/archive.tar.gz', deps);
+
+    assert.deepStrictEqual(calledUrls, [TRUSTED_URL, TRUSTED_REDIRECT_URL]);
   });
 });

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -152,7 +152,28 @@ if [ "${HTTP_CODE}" != "200" ]; then
     exit 1
 fi
 
-EXPECTED_SHA="$(awk 'NF {print $1; exit}' "${CHECKSUM_FILE}" | tr '[:upper:]' '[:lower:]')"
+EXPECTED_SHA="$(awk -v expected="${ARTIFACT_NAME}" '
+NF {
+    hash = tolower($1)
+    file = $2
+    sub(/^\*/, "", file)
+    n = split(file, parts, /[\\\/]/)
+    base = parts[n]
+    if (base == expected) {
+        print hash
+        found = 1
+        exit
+    }
+}
+END {
+    if (!found) {
+        exit 1
+    }
+}
+' "${CHECKSUM_FILE}")" || {
+    echo "Error: Checksum file does not contain an entry for ${ARTIFACT_NAME}" >&2
+    exit 1
+}
 if ! printf '%s\n' "${EXPECTED_SHA}" | grep -Eq '^[0-9a-f]{64}$'; then
     echo "Error: Invalid checksum file for ${ARTIFACT_NAME}" >&2
     exit 1

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -157,6 +157,7 @@ NF {
     hash = tolower($1)
     file = $2
     sub(/^\*/, "", file)
+    sub(/\r$/, "", file)
     n = split(file, parts, /[\\\/]/)
     base = parts[n]
     if (base == expected) {

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -80,6 +80,10 @@ fn action_download_script_verifies_release_checksum() {
         "download script must compare expected and actual SHA256 values"
     );
     assert!(
+        script.contains("expected=\"${ARTIFACT_NAME}\"") && script.contains("base == expected"),
+        "download script must bind checksum sidecar entries to the downloaded artifact filename"
+    );
+    assert!(
         script.contains("Checksum mismatch"),
         "download script must fail closed on checksum mismatch"
     );

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -84,6 +84,10 @@ fn action_download_script_verifies_release_checksum() {
         "download script must bind checksum sidecar entries to the downloaded artifact filename"
     );
     assert!(
+        script.contains("sub(/\\r$/, \"\", file)"),
+        "download script must tolerate CRLF checksum sidecar entries"
+    );
+    assert!(
         script.contains("Checksum mismatch"),
         "download script must fail closed on checksum mismatch"
     );

--- a/tests/security_hygiene.rs
+++ b/tests/security_hygiene.rs
@@ -152,3 +152,17 @@ fn direct_yaml_parser_uses_maintained_package() {
         "fuzz targets must exercise the same maintained YAML parser package"
     );
 }
+
+#[test]
+fn deprecated_transitive_yaml_parser_is_tracked_until_removed() {
+    let lockfile = repo_file("Cargo.lock");
+    let advisory_docs = repo_file("docs/RUSTSEC-ADVISORIES.md");
+
+    if lockfile.contains("name = \"serde_yaml\"") {
+        assert!(
+            advisory_docs.contains("serde_yaml 0.9.34+deprecated")
+                && advisory_docs.contains("via `rust-i18n`"),
+            "deprecated transitive serde_yaml must be tracked while it remains in Cargo.lock"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- harden MCP validation so core panics become MCP errors and diagnostic paths are workspace-relative
- extend panic isolation to project-level checks
- bind shell checksum parsing to the selected artifact filename and require trusted VS Code download redirect hosts
- correct the frontmatter parser safety comment and track the remaining deprecated transitive serde_yaml runtime dependency
- update the changelog for release notes

Closes #1149
Closes #1150
Closes #1154
Closes #1155
Closes #1156
Closes #1157
Closes #1158

## Validation
- cargo fmt --check --all
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- cargo audit --deny warnings --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2026-0173
- cargo deny check advisories
- npm --prefix editors/vscode run test:unit
- node scripts/sync-rule-bookkeeping.js --check
- diff -q CLAUDE.md AGENTS.md
- git diff --check
