### PR TITLE
fix: address CLI safety issue batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CLI config and autofix safety followups** (closes #1152, #1153, #1165, #1166, #1167). The CLI now fails non-zero when a discovered or explicitly passed `.agnix.toml` cannot be parsed instead of validating with defaults, skill frontmatter now reports duplicate top-level YAML keys instead of silently applying last-wins parsing, telemetry storage failures are logged at debug level, `agnix-lsp` initializes stderr tracing for startup/config-load visibility, bare `agnix --fix` / `--dry-run` now apply or preview only safe fixes unless `--fix-unsafe` is explicitly selected, and the rule-doc parity test now catches stale inline/table rule IDs such as the removed `AS-010` and `AS-014` references.
+
 ## [0.37.2] - 2026-07-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tower-lsp",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ cargo install agnix-cli
 
 ```bash
 agnix .              # Validate current directory
-agnix --fix .        # Apply HIGH and MEDIUM confidence fixes
-agnix --fix-safe .   # Apply only HIGH confidence fixes
-agnix --fix-unsafe . # Apply all fixes, including LOW confidence
+agnix --fix .        # Apply only safe fixes
+agnix --fix-safe .   # Explicit safe-only fix mode
+agnix --fix-unsafe . # Apply all fixes, including medium and LOW confidence
 agnix --dry-run --show-fixes .  # Preview fixes with inline diff output
 agnix --strict .     # Strict mode (warnings = errors)
 agnix --target claude-code .  # Legacy target preset (primarily affects CC-* rules)

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -1242,6 +1242,7 @@ core:
     files_pattern_count_limit: Field '%{field}' has %{count} patterns, which exceeds the recommended limit of %{limit}.
     files_pattern_count_limit_suggestion: Consider consolidating patterns or using broader glob expressions
     load_warning: 'Failed to parse config ''%{path}'': %{error}. Using defaults.'
+    load_error: 'Failed to parse config ''%{path}'': %{error}.'
 
 
 # ===========================================================================

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -763,6 +763,7 @@ core:
     files_pattern_count_limit: El campo '%{field}' tiene %{count} patrones, lo que excede el limite recomendado de %{limit}.
     files_pattern_count_limit_suggestion: Considera consolidar patrones o usar expresiones glob mas amplias
     load_warning: 'Error al analizar configuracion ''%{path}'': %{error}. Usando valores predeterminados.'
+    load_error: 'Error al analizar configuracion ''%{path}'': %{error}.'
 
 
 # ===========================================================================

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -724,6 +724,7 @@ core:
     files_pattern_count_limit: 字段 '%{field}' 有 %{count} 个模式，超过了建议的 %{limit} 个上限。
     files_pattern_count_limit_suggestion: 考虑合并模式或使用更广泛的 glob 表达式
     load_warning: '解析配置 ''%{path}'' 失败: %{error}。使用默认值。'
+    load_error: '解析配置 ''%{path}'' 失败: %{error}。'
 
 
 # ===========================================================================

--- a/crates/agnix-cli/src/main.rs
+++ b/crates/agnix-cli/src/main.rs
@@ -105,7 +105,7 @@ struct Cli {
     #[arg(short, long)]
     verbose: bool,
 
-    /// Apply automatic fixes (HIGH and MEDIUM confidence)
+    /// Apply automatic fixes marked safe
     #[arg(long, group = "fix_mode")]
     fix: bool,
 
@@ -117,7 +117,7 @@ struct Cli {
     #[arg(long, group = "fix_mode")]
     fix_safe: bool,
 
-    /// Apply all fixes, including LOW-confidence ones
+    /// Apply all fixes, including medium and LOW-confidence ones
     #[arg(long, group = "fix_mode")]
     fix_unsafe: bool,
 
@@ -304,7 +304,13 @@ fn main() {
     if cli.watch {
         let primary = primary_path(&cli.paths);
         let config_path = resolve_config_path(primary, cli.config.as_ref());
-        let (config, _) = LintConfig::load_or_default(config_path.as_ref());
+        let config = match load_config_or_default(config_path.as_ref()) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("{} {}", t!("cli.error_label").red().bold(), e);
+                process::exit(1);
+            }
+        };
 
         // Re-initialize locale if config specifies one and no --locale flag was given
         if cli.locale.is_none() {
@@ -353,6 +359,22 @@ fn format_paths_for_display(paths: &[PathBuf]) -> String {
         0 => ".".to_string(),
         1 => paths[0].display().to_string(),
         _ => format!("{} paths", paths.len()),
+    }
+}
+
+fn load_config_or_default(path: Option<&PathBuf>) -> anyhow::Result<LintConfig> {
+    match path {
+        Some(path) => LintConfig::load(path).map_err(|error| {
+            anyhow::anyhow!(
+                "{}",
+                t!(
+                    "core.config.load_error",
+                    path = path.display().to_string(),
+                    error = error.to_string()
+                )
+            )
+        }),
+        None => Ok(LintConfig::default()),
     }
 }
 
@@ -497,7 +519,7 @@ fn validate_command(paths: &[PathBuf], cli: &Cli) -> anyhow::Result<()> {
     let config_path = resolve_config_path(primary, cli.config.as_ref());
     tracing::debug!(config_path = ?config_path, "Resolved config path");
 
-    let (mut config, config_warning) = LintConfig::load_or_default(config_path.as_ref());
+    let mut config = load_config_or_default(config_path.as_ref())?;
 
     // Re-initialize locale if config specifies one and no --locale flag was given
     if cli.locale.is_none() {
@@ -506,11 +528,6 @@ fn validate_command(paths: &[PathBuf], cli: &Cli) -> anyhow::Result<()> {
         }
     }
 
-    // Display config warning before validation output
-    if let Some(warning) = config_warning {
-        eprintln!("{} {}", t!("cli.warning_label").yellow().bold(), warning);
-        eprintln!();
-    }
     config.set_target(cli.target.into());
 
     // Validate config semantics and display warnings (only for text output)
@@ -891,12 +908,7 @@ fn run_single_validation(
 ) -> anyhow::Result<bool> {
     let config_path = resolve_config_path(path, config_override);
 
-    let (mut config, config_warning) = LintConfig::load_or_default(config_path.as_ref());
-
-    if let Some(warning) = config_warning {
-        eprintln!("{} {}", t!("cli.warning_label").yellow().bold(), warning);
-        eprintln!();
-    }
+    let mut config = load_config_or_default(config_path.as_ref())?;
     config.set_target(target.into());
 
     let ValidationResult {
@@ -1002,8 +1014,8 @@ fn resolve_fix_mode(cli: &Cli) -> FixApplyMode {
     } else if cli.fix_unsafe {
         FixApplyMode::All
     } else {
-        // Default for --fix and --dry-run.
-        FixApplyMode::SafeAndMedium
+        // Default for --fix and --dry-run: only apply fixes marked safe.
+        FixApplyMode::SafeOnly
     }
 }
 
@@ -1111,15 +1123,7 @@ fn tools_command(subcmd: &ToolsCommand, cli: &Cli) -> anyhow::Result<()> {
             // Prefer the user's explicit --config; otherwise search from cwd.
             let cwd = env::current_dir()?;
             let config_path = resolve_config_path(&cwd, cli.config.as_ref());
-            let (config, config_warning) = LintConfig::load_or_default(config_path.as_ref());
-            // Surface any config-load warning (parse error, unknown keys,
-            // etc.). Without this, `check` would silently fall back to
-            // defaults + report nothing-pinned even when the user's config
-            // is broken.
-            if let Some(warning) = config_warning {
-                eprintln!("{} {}", t!("cli.warning_label").yellow().bold(), warning);
-                eprintln!();
-            }
+            let config = load_config_or_default(config_path.as_ref())?;
             let issues_found = tools::check_command(&config, *strict)?;
             if *strict && issues_found {
                 process::exit(1);
@@ -1420,15 +1424,15 @@ mod resolve_fix_mode_tests {
     }
 
     #[test]
-    fn fix_selects_safe_and_medium_mode() {
+    fn fix_selects_safe_only_mode() {
         let cli = Cli::parse_from(["agnix", "--fix"]);
-        assert_eq!(resolve_fix_mode(&cli), FixApplyMode::SafeAndMedium);
+        assert_eq!(resolve_fix_mode(&cli), FixApplyMode::SafeOnly);
     }
 
     #[test]
-    fn dry_run_selects_safe_and_medium_mode() {
+    fn dry_run_selects_safe_only_mode() {
         let cli = Cli::parse_from(["agnix", "--dry-run"]);
-        assert_eq!(resolve_fix_mode(&cli), FixApplyMode::SafeAndMedium);
+        assert_eq!(resolve_fix_mode(&cli), FixApplyMode::SafeOnly);
     }
 
     #[test]

--- a/crates/agnix-cli/src/telemetry/mod.rs
+++ b/crates/agnix-cli/src/telemetry/mod.rs
@@ -63,7 +63,10 @@ pub fn record_validation(
     // Check if telemetry is enabled first (fast path)
     let config = match TelemetryConfig::load() {
         Ok(c) => c,
-        Err(_) => return,
+        Err(error) => {
+            tracing::debug!(%error, "telemetry config load failed; skipping validation event");
+            return;
+        }
     };
 
     if !config.is_enabled() {
@@ -85,19 +88,25 @@ pub fn record_validation(
     // This is a fast file write (~1ms), so it won't noticeably block the CLI.
     let mut queue = match EventQueue::load() {
         Ok(q) => q,
-        Err(_) => return,
+        Err(error) => {
+            tracing::debug!(%error, "telemetry queue load failed; skipping validation event");
+            return;
+        }
     };
 
     // Push event to queue - if this fails, we can't do anything more
-    if queue.push(event).is_ok() {
-        // HTTP submission happens in background thread (only with telemetry feature).
-        // If CLI exits before this completes, events remain safely queued for next run.
-        #[cfg(feature = "telemetry")]
-        {
-            thread::spawn(move || {
-                try_submit_queued_events(&config, &mut queue);
-            });
-        }
+    if let Err(error) = queue.push(event) {
+        tracing::debug!(%error, "telemetry queue push failed; dropping validation event");
+        return;
+    }
+
+    // HTTP submission happens in background thread (only with telemetry feature).
+    // If CLI exits before this completes, events remain safely queued for next run.
+    #[cfg(feature = "telemetry")]
+    {
+        thread::spawn(move || {
+            try_submit_queued_events(&config, &mut queue);
+        });
     }
 }
 
@@ -108,19 +117,30 @@ pub fn record_validation(
 /// accepted as a limitation for best-effort telemetry.
 #[cfg(feature = "telemetry")]
 fn try_submit_queued_events(config: &TelemetryConfig, queue: &mut EventQueue) {
-    if let Ok(client) = TelemetryClient::new(config) {
-        let events = queue.take_batch(10);
-        if !events.is_empty() {
-            match client.submit_batch(&events) {
-                Ok(_) => {
-                    // Successfully submitted, remove events from queue
-                    queue.remove_batch(events.len());
-                    let _ = queue.save();
-                }
-                Err(_) => {
-                    // Failed to submit, events stay in queue for retry on next run
-                }
+    let client = match TelemetryClient::new(config) {
+        Ok(client) => client,
+        Err(error) => {
+            tracing::debug!(%error, "telemetry client initialization failed");
+            return;
+        }
+    };
+
+    let events = queue.take_batch(10);
+    if events.is_empty() {
+        return;
+    }
+
+    match client.submit_batch(&events) {
+        Ok(_) => {
+            // Successfully submitted, remove events from queue
+            queue.remove_batch(events.len());
+            if let Err(error) = queue.save() {
+                tracing::debug!(%error, "telemetry queue save failed after submission");
             }
+        }
+        Err(error) => {
+            // Failed to submit, events stay in queue for retry on next run
+            tracing::debug!(%error, "telemetry submission failed; events remain queued");
         }
     }
 }

--- a/crates/agnix-cli/tests/cli_integration.rs
+++ b/crates/agnix-cli/tests/cli_integration.rs
@@ -1108,7 +1108,7 @@ fn test_fix_exit_code_on_remaining_errors() {
     // Invalid fixtures have errors that cannot be auto-fixed
     let output = cmd
         .arg("tests/fixtures/invalid/skills/unknown-tool")
-        .arg("--fix")
+        .arg("--fix-unsafe")
         .output()
         .unwrap();
 
@@ -1156,13 +1156,13 @@ fn test_fix_exit_code_when_all_issues_are_fixed() {
                 .to_str()
                 .expect("Temp path is not valid UTF-8"),
         )
-        .arg("--fix")
+        .arg("--fix-unsafe")
         .output()
         .expect("Failed to execute agnix command");
 
     assert!(
         output.status.success(),
-        "Expected --fix to exit 0 when all issues are fixed, stdout: {}, stderr: {}",
+        "Expected --fix-unsafe to exit 0 when all issues are fixed, stdout: {}, stderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
@@ -1517,10 +1517,10 @@ fn test_fixtures_have_no_empty_placeholder_dirs() {
     );
 }
 
-// ===== Config Parse Warning Tests =====
+// ===== Config Parse Error Tests =====
 
 #[test]
-fn test_invalid_config_displays_warning_to_stderr() {
+fn test_invalid_config_fails_to_stderr() {
     let temp_dir = tempfile::tempdir().unwrap();
     let config_path = temp_dir.path().join(".agnix.toml");
 
@@ -1543,18 +1543,20 @@ fn test_invalid_config_displays_warning_to_stderr() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    // Should contain warning message
     assert!(
-        stderr.contains("Warning:") && stderr.contains("Failed to parse config"),
-        "Expected config warning in stderr, got: {}",
+        !output.status.success(),
+        "Invalid config should fail instead of validating with defaults"
+    );
+    assert!(
+        stderr.contains("Error:") && stderr.contains("Failed to parse config"),
+        "Expected config parse error in stderr, got: {}",
         stderr
     );
 
-    // Should still produce validation output (continues with defaults)
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("Validating:"),
-        "Should still run validation with default config"
+        !stdout.contains("Validating:"),
+        "Should not run validation with default config after parse failure"
     );
 }
 
@@ -1601,14 +1603,58 @@ exclude = []
 }
 
 #[test]
-fn test_config_warning_with_json_output() {
+fn test_unknown_config_key_fails_without_defaults() {
     let temp_dir = tempfile::tempdir().unwrap();
     let config_path = temp_dir.path().join(".agnix.toml");
 
-    // Create invalid TOML
+    std::fs::write(
+        &config_path,
+        r#"
+severity = "Warning"
+experimental_feature = true
+"#,
+    )
+    .unwrap();
+
+    let skill_dir = temp_dir.path().join(".claude").join("skills");
+    std::fs::create_dir_all(&skill_dir).unwrap();
+    let skill_file = skill_dir.join("test.md");
+    std::fs::write(&skill_file, "# Test\nSimple content").unwrap();
+
+    let mut cmd = agnix();
+    let output = cmd
+        .arg(temp_dir.path())
+        .arg("--config")
+        .arg(&config_path)
+        .output()
+        .unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "Unknown config keys should fail instead of falling back to defaults"
+    );
+    assert!(
+        stderr.contains("unknown field") && stderr.contains("experimental_feature"),
+        "Expected unknown-field error in stderr, got: {}",
+        stderr
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Validating:"),
+        "Should not validate with defaults after unknown config key"
+    );
+}
+
+#[test]
+fn test_config_error_with_json_output_goes_to_stderr() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_path = temp_dir.path().join(".agnix.toml");
+
     std::fs::write(&config_path, "invalid [[ toml").unwrap();
 
-    // Create a minimal valid directory to scan
     let skill_dir = temp_dir.path().join(".claude").join("skills");
     std::fs::create_dir_all(&skill_dir).unwrap();
     let skill_file = skill_dir.join("test.md");
@@ -1625,18 +1671,20 @@ fn test_config_warning_with_json_output() {
         .unwrap();
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-
-    // Warning should go to stderr, not corrupt JSON output
     assert!(
-        stderr.contains("Warning:"),
-        "Warning should be in stderr for JSON output"
+        !output.status.success(),
+        "Invalid config should fail for JSON output too"
+    );
+    assert!(
+        stderr.contains("Error:") && stderr.contains("Failed to parse config"),
+        "Config parse error should be in stderr for JSON output, got: {}",
+        stderr
     );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let json: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
     assert!(
-        json.is_ok(),
-        "JSON output should be valid despite config warning, got: {}",
+        stdout.trim().is_empty(),
+        "JSON stdout should stay empty on config parse failure, got: {}",
         stdout
     );
 }
@@ -1861,7 +1909,7 @@ fn test_init_creates_config_file_with_plain_text_output() {
 // ============================================================================
 
 #[test]
-fn test_fix_as_004_converts_name_to_kebab_case() {
+fn test_fix_unsafe_as_004_converts_name_to_kebab_case() {
     use std::fs;
     use std::io::Write;
 
@@ -1880,11 +1928,11 @@ fn test_fix_as_004_converts_name_to_kebab_case() {
         .unwrap();
     }
 
-    // Run with --fix
+    // Run with --fix-unsafe because this structural AS-004 rewrite is not safe-only.
     let mut cmd = agnix();
     let output = cmd
         .arg(temp_dir.path().to_str().unwrap())
-        .arg("--fix")
+        .arg("--fix-unsafe")
         .output()
         .unwrap();
 
@@ -1903,6 +1951,50 @@ fn test_fix_as_004_converts_name_to_kebab_case() {
     assert!(
         stdout.contains("Fixed") || stdout.contains("fix"),
         "Output should mention fix applied"
+    );
+}
+
+#[test]
+fn test_fix_skips_unsafe_as_004_by_default() {
+    use std::fs;
+    use std::io::Write;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let skills_dir = temp_dir.path().join("skills").join("test-skill");
+    fs::create_dir_all(&skills_dir).unwrap();
+
+    let skill_path = skills_dir.join("SKILL.md");
+    {
+        let mut file = fs::File::create(&skill_path).unwrap();
+        write!(
+            file,
+            "---\nname: Test_Skill_Name\ndescription: Use when testing\n---\nBody"
+        )
+        .unwrap();
+    }
+
+    let mut cmd = agnix();
+    let output = cmd
+        .arg(temp_dir.path().to_str().unwrap())
+        .arg("--fix")
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "bare --fix should leave unsafe AS-004 diagnostics as errors"
+    );
+    let fixed_content = fs::read_to_string(&skill_path).unwrap();
+    assert!(
+        fixed_content.contains("name: Test_Skill_Name"),
+        "bare --fix should not apply unsafe AS-004 rewrite, got: {}",
+        fixed_content
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Applying fixes (safe only)"),
+        "bare --fix should report safe-only mode, got: {}",
+        stdout
     );
 }
 
@@ -3032,7 +3124,7 @@ fn test_autofix_rules_json_reports_fixes_available() {
 // CLI --fix Integration Tests for Pack 2 Rules (Issue #285)
 // ============================================================================
 
-/// CC-SK: Skill name fix (AS-004) via --fix on invalid name
+/// CC-SK: Skill name fix (AS-004) via --fix-unsafe on invalid name
 #[test]
 fn test_fix_ccsk_invalid_skill_name() {
     use std::fs;
@@ -3055,13 +3147,13 @@ fn test_fix_ccsk_invalid_skill_name() {
     let mut cmd = agnix();
     let output = cmd
         .arg(temp_dir.path().to_str().unwrap())
-        .arg("--fix")
+        .arg("--fix-unsafe")
         .output()
         .unwrap();
 
     assert!(
         output.status.success(),
-        "--fix should exit successfully after applying skill name fix"
+        "--fix-unsafe should exit successfully after applying skill name fix"
     );
 
     let fixed = fs::read_to_string(&skill_path).unwrap();
@@ -3119,7 +3211,7 @@ fn test_fix_cchk_invalid_event_name() {
     );
 }
 
-/// CC-AG: Agent model fix (CC-AG-003) via --fix on invalid model value
+/// CC-AG: Agent model fix (CC-AG-003) via --fix-unsafe on invalid model value
 #[test]
 fn test_fix_ccag_invalid_model() {
     use std::fs;
@@ -3138,13 +3230,13 @@ fn test_fix_ccag_invalid_model() {
     let mut cmd = agnix();
     let output = cmd
         .arg(temp_dir.path().to_str().unwrap())
-        .arg("--fix")
+        .arg("--fix-unsafe")
         .output()
         .unwrap();
 
     assert!(
         output.status.success(),
-        "--fix should exit successfully after applying agent model fix"
+        "--fix-unsafe should exit successfully after applying agent model fix"
     );
 
     let fixed = fs::read_to_string(&agent_path).unwrap();

--- a/crates/agnix-cli/tests/rule_parity.rs
+++ b/crates/agnix-cli/tests/rule_parity.rs
@@ -589,9 +589,15 @@ fn test_rules_json_matches_validation_rules_md() {
         .captures_iter(&content)
         .map(|cap| cap[1].to_string())
         .collect();
+    let referenced_re = Regex::new(r"\b[A-Z]+(?:-[A-Z]+)*-[0-9]{3}\b").unwrap();
+    let referenced_ids: BTreeSet<String> = referenced_re
+        .captures_iter(&content)
+        .map(|cap| cap[0].to_string())
+        .collect();
 
     let missing_in_md: Vec<&String> = rules_json_ids.difference(&validation_rules_ids).collect();
     let extra_in_md: Vec<&String> = validation_rules_ids.difference(&rules_json_ids).collect();
+    let unknown_references: Vec<&String> = referenced_ids.difference(&rules_json_ids).collect();
 
     let mut report = String::new();
     if !missing_in_md.is_empty() {
@@ -606,9 +612,16 @@ fn test_rules_json_matches_validation_rules_md() {
             report.push_str(&format!("  - {}\n", rule));
         }
     }
+    if !unknown_references.is_empty() {
+        report
+            .push_str("Rule-like references in VALIDATION-RULES.md but not found in rules.json:\n");
+        for rule in &unknown_references {
+            report.push_str(&format!("  - {}\n", rule));
+        }
+    }
 
     assert!(
-        missing_in_md.is_empty() && extra_in_md.is_empty(),
+        missing_in_md.is_empty() && extra_in_md.is_empty() && unknown_references.is_empty(),
         "rules.json and VALIDATION-RULES.md rule ID parity failed:\n{}",
         report
     );

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -1248,6 +1248,7 @@ core:
     files_pattern_count_limit: Field '%{field}' has %{count} patterns, which exceeds the recommended limit of %{limit}.
     files_pattern_count_limit_suggestion: Consider consolidating patterns or using broader glob expressions
     load_warning: 'Failed to parse config ''%{path}'': %{error}. Using defaults.'
+    load_error: 'Failed to parse config ''%{path}'': %{error}.'
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -769,6 +769,7 @@ core:
     files_pattern_count_limit: El campo '%{field}' tiene %{count} patrones, lo que excede el limite recomendado de %{limit}.
     files_pattern_count_limit_suggestion: Considera consolidar patrones o usar expresiones glob mas amplias
     load_warning: 'Error al analizar configuracion ''%{path}'': %{error}. Usando valores predeterminados.'
+    load_error: 'Error al analizar configuracion ''%{path}'': %{error}.'
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -730,6 +730,7 @@ core:
     files_pattern_count_limit: 字段 '%{field}' 有 %{count} 个模式，超过了建议的 %{limit} 个上限。
     files_pattern_count_limit_suggestion: 考虑合并模式或使用更广泛的 glob 表达式
     load_warning: '解析配置 ''%{path}'' 失败: %{error}。使用默认值。'
+    load_error: '解析配置 ''%{path}'' 失败: %{error}。'
 
 
 # ===========================================================================

--- a/crates/agnix-core/src/parsers/frontmatter.rs
+++ b/crates/agnix-core/src/parsers/frontmatter.rs
@@ -246,13 +246,9 @@ pub(crate) fn check_yaml_duplicate_top_level_keys(yaml: &str) -> LintResult<()> 
             continue;
         }
 
-        let Some((key, _)) = line.split_once(':') else {
+        let Some(key) = top_level_yaml_key(line) else {
             continue;
         };
-        let key = key.trim();
-        if key.is_empty() || key.starts_with('-') || key.starts_with('?') {
-            continue;
-        }
 
         if let Some(first_line) = seen.insert(key, line_no) {
             return Err(CoreError::Validation(ValidationError::Other(
@@ -267,6 +263,36 @@ pub(crate) fn check_yaml_duplicate_top_level_keys(yaml: &str) -> LintResult<()> 
     }
 
     Ok(())
+}
+
+fn top_level_yaml_key(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    let key = if let Some(stripped) = trimmed.strip_suffix(':') {
+        stripped
+    } else if let Some(idx) = trimmed.find(": ") {
+        &trimmed[..idx]
+    } else {
+        return None;
+    };
+    let key = key.trim();
+    if key.is_empty() || key.starts_with('-') || key.starts_with('?') {
+        return None;
+    }
+    let key = strip_matching_yaml_key_quotes(key);
+    if key.is_empty() {
+        return None;
+    }
+    Some(key)
+}
+
+fn strip_matching_yaml_key_quotes(key: &str) -> &str {
+    let Some(unquoted) = key.strip_prefix('"').and_then(|key| key.strip_suffix('"')) else {
+        return key
+            .strip_prefix('\'')
+            .and_then(|key| key.strip_suffix('\''))
+            .unwrap_or(key);
+    };
+    unquoted
 }
 
 /// Parse YAML frontmatter from markdown content
@@ -419,6 +445,36 @@ metadata:
 "#;
 
         assert!(check_yaml_duplicate_top_level_keys(yaml).is_ok());
+    }
+
+    #[test]
+    fn test_colon_in_top_level_key_does_not_trip_duplicate_guard() {
+        let yaml = r#"
+rdf:type: agent-config
+rdf: namespace
+"http://example.com/schema": value
+http://example.com: bare-url-key
+"#;
+
+        assert!(check_yaml_duplicate_top_level_keys(yaml).is_ok());
+    }
+
+    #[test]
+    fn test_quoted_duplicate_top_level_key_rejected() {
+        let yaml = r#"
+name: first-name
+"name": second-name
+'description': first-description
+description: second-description
+"#;
+
+        let err = check_yaml_duplicate_top_level_keys(yaml)
+            .expect_err("quoted and unquoted copies should be duplicate keys")
+            .to_string();
+        assert!(
+            err.contains("Duplicate YAML frontmatter key 'name'"),
+            "expected normalized duplicate-key error, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/agnix-core/src/parsers/frontmatter.rs
+++ b/crates/agnix-core/src/parsers/frontmatter.rs
@@ -36,6 +36,7 @@
 //! `MAX_YAML_DEPTH` rather than disabling the check.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use crate::diagnostics::{CoreError, LintResult, ValidationError};
 use serde::de::DeserializeOwned;
@@ -231,6 +232,43 @@ pub(crate) fn check_yaml_depth(yaml: &str) -> LintResult<()> {
     Ok(())
 }
 
+/// Reject duplicate top-level YAML mapping keys before serde's default
+/// last-wins behavior can collapse them.
+pub(crate) fn check_yaml_duplicate_top_level_keys(yaml: &str) -> LintResult<()> {
+    let mut seen: HashMap<&str, usize> = HashMap::new();
+
+    for (idx, line) in yaml.lines().enumerate() {
+        let line_no = idx + 1;
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            continue;
+        }
+        if line.starts_with(' ') || line.starts_with('\t') {
+            continue;
+        }
+
+        let Some((key, _)) = line.split_once(':') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() || key.starts_with('-') || key.starts_with('?') {
+            continue;
+        }
+
+        if let Some(first_line) = seen.insert(key, line_no) {
+            return Err(CoreError::Validation(ValidationError::Other(
+                anyhow::anyhow!(
+                    "Duplicate YAML frontmatter key '{}' at line {} (first defined at line {})",
+                    key,
+                    line_no,
+                    first_line
+                ),
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 /// Parse YAML frontmatter from markdown content
 ///
 /// Expects content in format:
@@ -252,6 +290,7 @@ pub fn parse_frontmatter<T: DeserializeOwned>(content: &str) -> LintResult<(T, S
     let parts = split_frontmatter(content);
     // Pre-parse depth check to bound memory use on pathological inputs.
     check_yaml_depth(&parts.frontmatter)?;
+    check_yaml_duplicate_top_level_keys(&parts.frontmatter)?;
     let parsed: T = serde_yaml::from_str(&parts.frontmatter)
         .map_err(|e| CoreError::Validation(ValidationError::Other(e.into())))?;
     Ok((parsed, parts.body.trim_start().to_string()))
@@ -350,6 +389,36 @@ Body content here"#;
         assert_eq!(fm.name, "test-skill");
         assert_eq!(fm.description, "A test skill");
         assert_eq!(body, "Body content here");
+    }
+
+    #[test]
+    fn test_duplicate_top_level_frontmatter_key_rejected() {
+        let content = r#"---
+name: first-name
+description: A test skill
+name: second-name
+---
+Body content here"#;
+
+        let result: LintResult<(TestFrontmatter, String)> = parse_frontmatter(content);
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Duplicate YAML frontmatter key 'name'"),
+            "expected duplicate-key error, got: {err}"
+        );
+        assert!(err.contains("line 3"));
+    }
+
+    #[test]
+    fn test_nested_same_key_does_not_trip_top_level_duplicate_guard() {
+        let yaml = r#"
+name: test-skill
+description: A test skill
+metadata:
+  name: nested-name
+"#;
+
+        assert!(check_yaml_duplicate_top_level_keys(yaml).is_ok());
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/skill/helpers.rs
+++ b/crates/agnix-core/src/rules/skill/helpers.rs
@@ -1,5 +1,7 @@
 use crate::fs::FileSystem;
-use crate::parsers::frontmatter::FrontmatterParts;
+use crate::parsers::frontmatter::{
+    FrontmatterParts, check_yaml_depth, check_yaml_duplicate_top_level_keys,
+};
 use regex::Regex;
 use std::collections::HashSet;
 use std::path::Path;
@@ -7,13 +9,13 @@ use std::sync::OnceLock;
 
 use super::{PathMatch, SkillFrontmatter, reference_path_regex};
 
-pub(super) fn parse_frontmatter_fields(
-    frontmatter: &str,
-) -> Result<SkillFrontmatter, serde_yaml::Error> {
+pub(super) fn parse_frontmatter_fields(frontmatter: &str) -> Result<SkillFrontmatter, String> {
     if frontmatter.trim().is_empty() {
         return Ok(SkillFrontmatter::default());
     }
-    serde_yaml::from_str(frontmatter)
+    check_yaml_depth(frontmatter).map_err(|e| e.to_string())?;
+    check_yaml_duplicate_top_level_keys(frontmatter).map_err(|e| e.to_string())?;
+    serde_yaml::from_str(frontmatter).map_err(|e| e.to_string())
 }
 
 pub(super) fn extract_reference_paths(body: &str) -> Vec<PathMatch> {

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -2402,6 +2402,33 @@ Body content"#;
 }
 
 #[test]
+fn test_as_016_duplicate_frontmatter_key() {
+    let content = r#"---
+name: first-skill
+description: Use when validating duplicate frontmatter keys
+name: second-skill
+---
+Body content"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(Path::new("test.md"), content, &LintConfig::default());
+
+    let parse_errors: Vec<_> = diagnostics.iter().filter(|d| d.rule == "AS-016").collect();
+    assert_eq!(
+        parse_errors.len(),
+        1,
+        "duplicate top-level key should produce one AS-016 diagnostic"
+    );
+    assert!(
+        parse_errors[0]
+            .message
+            .contains("Duplicate YAML frontmatter key 'name'"),
+        "expected duplicate key message, got: {}",
+        parse_errors[0].message
+    );
+}
+
+#[test]
 fn test_as_016_allowed_tools_yaml_list_no_parse_error() {
     // Reproduces #957: `allowed-tools` as a YAML list previously failed to
     // deserialize (Option<String>) and tripped AS-016. Claude Code accepts a

--- a/crates/agnix-lsp/Cargo.toml
+++ b/crates/agnix-lsp/Cargo.toml
@@ -22,6 +22,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 rust-i18n = { workspace = true }
 sys-locale = { workspace = true }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 mimalloc = { workspace = true }

--- a/crates/agnix-lsp/src/backend.rs
+++ b/crates/agnix-lsp/src/backend.rs
@@ -315,6 +315,7 @@ impl LanguageServer for Backend {
                             self.config.store(Arc::new(config_with_root));
                         }
                         Err(e) => {
+                            tracing::warn!(error = %e, path = %config_path.display(), "failed to load workspace .agnix.toml");
                             // Log error but continue with default config
                             self.client
                                 .log_message(

--- a/crates/agnix-lsp/src/lib.rs
+++ b/crates/agnix-lsp/src/lib.rs
@@ -53,11 +53,13 @@ use tower_lsp::{LspService, Server};
 pub async fn start_server() -> anyhow::Result<()> {
     // Initialize locale from environment variables (AGNIX_LOCALE > LANG/LC_ALL > system > "en")
     locale::init_from_env();
+    tracing::debug!("agnix-lsp locale initialized");
 
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
     let (service, socket) = LspService::new(Backend::new);
+    tracing::info!("agnix-lsp server ready on stdio");
     Server::new(stdin, stdout, socket).serve(service).await;
     Ok(())
 }

--- a/crates/agnix-lsp/src/main.rs
+++ b/crates/agnix-lsp/src/main.rs
@@ -10,8 +10,29 @@ async fn main() {
         return;
     }
 
+    init_tracing();
+    tracing::debug!("starting agnix-lsp");
+
     if let Err(e) = agnix_lsp::start_server().await {
+        tracing::error!(error = %e, "LSP server failed");
         eprintln!("LSP server error: {e}");
         std::process::exit(1);
     }
+}
+
+fn init_tracing() {
+    use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("agnix_lsp=info,agnix_core=warn"));
+
+    let _ = tracing_subscriber::registry()
+        .with(
+            fmt::layer()
+                .with_target(true)
+                .with_level(true)
+                .with_writer(std::io::stderr),
+        )
+        .with(filter)
+        .try_init();
 }

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -3301,7 +3301,7 @@ Implement these 30 rules first:
 
 ### P1 (Week 4)
 Add these 15 rules:
-- AS-010 through AS-015 (Skills best practices)
+- AS-011 through AS-013 and AS-015 (Skills best practices)
 - CC-MEM-006 through CC-MEM-010 (Memory quality)
 - CC-AG-001 through CC-AG-013 (Agents)
 - CC-PL-001 through CC-PL-010 (Plugins)
@@ -3364,8 +3364,6 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | AS-004 | Convert name to kebab-case | safe/unsafe |
 | AS-005 | Strip leading/trailing hyphens | safe |
 | AS-006 | Collapse consecutive hyphens | safe |
-| AS-010 | Prepend "Use when user wants to " | unsafe |
-| AS-014 | Normalize Windows path separators | safe |
 | CC-SK-001 | Default invalid model to sonnet | unsafe |
 | CC-SK-002 | Normalize context to fork | unsafe |
 | CC-SK-003 | Add default agent for fork context | unsafe |

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1246,6 +1246,7 @@ core:
     files_pattern_count_limit: Field '%{field}' has %{count} patterns, which exceeds the recommended limit of %{limit}.
     files_pattern_count_limit_suggestion: Consider consolidating patterns or using broader glob expressions
     load_warning: 'Failed to parse config ''%{path}'': %{error}. Using defaults.'
+    load_error: 'Failed to parse config ''%{path}'': %{error}.'
 
 
 # ===========================================================================

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -767,6 +767,7 @@ core:
     files_pattern_count_limit: El campo '%{field}' tiene %{count} patrones, lo que excede el limite recomendado de %{limit}.
     files_pattern_count_limit_suggestion: Considera consolidar patrones o usar expresiones glob mas amplias
     load_warning: 'Error al analizar configuracion ''%{path}'': %{error}. Usando valores predeterminados.'
+    load_error: 'Error al analizar configuracion ''%{path}'': %{error}.'
 
 
 # ===========================================================================

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -728,6 +728,7 @@ core:
     files_pattern_count_limit: 字段 '%{field}' 有 %{count} 个模式，超过了建议的 %{limit} 个上限。
     files_pattern_count_limit_suggestion: 考虑合并模式或使用更广泛的 glob 表达式
     load_warning: '解析配置 ''%{path}'' 失败: %{error}。使用默认值。'
+    load_error: '解析配置 ''%{path}'' 失败: %{error}。'
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- fail CLI validation/tools/watch commands on malformed or unknown-key `.agnix.toml` instead of continuing with defaults
- reject duplicate top-level skill frontmatter keys before YAML last-wins parsing
- make bare `--fix` and `--dry-run` safe-only; keep broader edits behind `--fix-unsafe`
- add debug telemetry logging and stderr tracing for `agnix-lsp` startup/config visibility
- broaden VALIDATION-RULES parity to catch inline/table phantom rule IDs and remove stale AS-010/AS-014 references

Closes #1152
Closes #1153
Closes #1165
Closes #1166
Closes #1167

## Validation
- `cargo fmt --check --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo audit --deny warnings --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2026-0173`
- `cargo deny check advisories`
- `node scripts/sync-rule-bookkeeping.js --check`
- `diff -q CLAUDE.md AGENTS.md`
- live CLI probe: unknown config exits 1
- live CLI probe: bare `--fix` reports safe-only and leaves unsafe AS-004 unchanged