### PR TITLE
Fix tool release watch compatibility drift

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-07-02",
+  "last_updated": "2026-07-11",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.198",
+      "last_known_version": "v2.1.206",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -60,7 +60,7 @@
         "agents_md"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.142.5",
+      "last_known_version": "rust-v0.144.1",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.17.13",
+      "last_known_version": "v1.17.18",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -136,7 +136,7 @@
       "html_url": "https://kiro.dev/changelog/cli/",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
       "notes_extractor": "glm",
-      "last_known_version": "2.10.0",
+      "last_known_version": "2.12.0",
       "tracked": true,
       "notes": "Proprietary CLI; no GH releases. Tracked via HTML scrape of kiro.dev/changelog/cli/ - the first NN.NN.NN version on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). The CLI itself exposes `kiro-cli version --changelog`. IDE has a separate changelog at https://kiro.dev/changelog/ide/ (not tracked here; could be added as a separate kiro-ide entry if needed).",
       "changes_of_interest": {
@@ -203,7 +203,7 @@
         "cline"
       ],
       "github_repo": "cline/cline",
-      "last_known_version": "v4.0.6",
+      "last_known_version": "cli-v3.0.39",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -237,7 +237,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.9.16",
+      "last_known_version": "3.11.13",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {
@@ -305,7 +305,7 @@
       "html_url": "https://ampcode.com/news.rss",
       "version_regex": "https://ampcode\\.com/news/[a-zA-Z0-9._-]+",
       "notes_extractor": "rss_cdata",
-      "last_known_version": "read-bigger-threads",
+      "last_known_version": "the-dial",
       "tracked": true,
       "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed).",
       "changes_of_interest": {
@@ -337,7 +337,7 @@
         "gemini_ignore"
       ],
       "github_repo": "google-gemini/gemini-cli",
-      "last_known_version": "v0.49.0",
+      "last_known_version": "v0.50.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Tool release baselines**. Triaged the current release-watch batch and advanced Claude Code to `v2.1.206`, Codex CLI to `rust-v0.144.1`, OpenCode to `v1.17.18`, Kiro CLI to `2.12.0`, Cline to `cli-v3.0.39`, Cursor to `3.11.13`, amp to `the-dial`, and Gemini CLI to `v0.50.0` (closes #1181 through #1188). Releases without validated schema changes were classified as runtime, UI, provider, packaging, or news updates.
+
+### Fixed
+- **Codex 0.144.1 config compatibility**. Accept the current feature and MCP server keys, including session authentication, and recognize the managed `marketplaces` requirements table so valid Codex configuration no longer triggers unknown-key diagnostics.
+- **Kiro 2.12 OAuth validation**. Treat `oauth.clientId` as optional for Dynamic Client Registration, validate the new `clientSecret`, `redirectUri`, and `oauthScopes` fields, and enforce documented HTTP loopback redirect forms.
+- **Locale mirror parity**. Reconcile the canonical locale files with recently added panic, config-load, and hook-timeout messages, then resync all crate-local copies so the locale parity gate passes on Linux.
+
 ## [0.37.5] - 2026-07-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tool release baselines**. Triaged the current release-watch batch and advanced Claude Code to `v2.1.206`, Codex CLI to `rust-v0.144.1`, OpenCode to `v1.17.18`, Kiro CLI to `2.12.0`, Cline to `cli-v3.0.39`, Cursor to `3.11.13`, amp to `the-dial`, and Gemini CLI to `v0.50.0` (closes #1181 through #1188). Releases without validated schema changes were classified as runtime, UI, provider, packaging, or news updates.
 
 ### Fixed
+- **Rust 1.97 CI compatibility**. Apply the new Clippy simplifications in YAML parsing and CLI result destructuring so the warnings-denied Linux gate remains clean.
 - **Crossbeam advisory remediation**. Update the locked `crossbeam-epoch` dependency to `0.9.20`, resolving RUSTSEC-2026-0204 in both dependency security gates.
 - **Codex 0.144.1 config compatibility**. Accept the current feature and MCP server keys, including session authentication, and recognize the managed `marketplaces` requirements table so valid Codex configuration no longer triggers unknown-key diagnostics.
 - **Kiro 2.12 OAuth validation**. Treat `oauth.clientId` as optional for Dynamic Client Registration, validate the new `clientSecret`, `redirectUri`, and `oauthScopes` fields, and enforce documented HTTP loopback redirect forms.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tool release baselines**. Triaged the current release-watch batch and advanced Claude Code to `v2.1.206`, Codex CLI to `rust-v0.144.1`, OpenCode to `v1.17.18`, Kiro CLI to `2.12.0`, Cline to `cli-v3.0.39`, Cursor to `3.11.13`, amp to `the-dial`, and Gemini CLI to `v0.50.0` (closes #1181 through #1188). Releases without validated schema changes were classified as runtime, UI, provider, packaging, or news updates.
 
 ### Fixed
+- **Crossbeam advisory remediation**. Update the locked `crossbeam-epoch` dependency to `0.9.20`, resolving RUSTSEC-2026-0204 in both dependency security gates.
 - **Codex 0.144.1 config compatibility**. Accept the current feature and MCP server keys, including session authentication, and recognize the managed `marketplaces` requirements table so valid Codex configuration no longer triggers unknown-key diagnostics.
 - **Kiro 2.12 OAuth validation**. Treat `oauth.clientId` as optional for Dynamic Client Registration, validate the new `clientSecret`, `redirectUri`, and `oauthScopes` fields, and enforce documented HTTP loopback redirect forms.
 - **Locale mirror parity**. Reconcile the canonical locale files with recently added panic, config-load, and hook-timeout messages, then resync all crate-local copies so the locale parity gate passes on Linux.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -166,10 +166,14 @@ rules:
     command_no_timeout_suggestion: Add a "timeout" field (e.g., 600 for command hooks)
     command_exceeds: Command hook at %{location} has timeout %{timeout}s exceeding %{default}s default
     command_exceeds_suggestion: Consider timeout <= %{default}s (10-minute default limit)
-    prompt_no_timeout: Prompt/agent hook at %{location} has no timeout specified
-    prompt_no_timeout_suggestion: Add a "timeout" field (e.g., 30 for prompt/agent hooks)
-    prompt_exceeds: Prompt/agent hook at %{location} has timeout %{timeout}s exceeding %{default}s default
+    prompt_no_timeout: Prompt hook at %{location} has no timeout specified
+    prompt_no_timeout_suggestion: Add a "timeout" field (e.g., 30 for prompt hooks)
+    prompt_exceeds: Prompt hook at %{location} has timeout %{timeout}s exceeding %{default}s default
     prompt_exceeds_suggestion: Consider timeout <= %{default}s (30-second default limit)
+    agent_no_timeout: Agent hook at %{location} has no timeout specified
+    agent_no_timeout_suggestion: Add a "timeout" field (e.g., 60 for agent hooks)
+    agent_exceeds: Agent hook at %{location} has timeout %{timeout}s exceeding %{default}s default
+    agent_exceeds_suggestion: Consider timeout <= %{default}s (60-second default limit)
     assumption: Assumes Claude Code default timeout behavior. Pin claude_code version in .agnix.toml [tool_versions] for version-specific
       validation.
   cc_hk_011:
@@ -376,6 +380,8 @@ rules:
     message: Import cache lock was poisoned by a prior validator panic; recovered stale data
     suggestion: A validator panicked while holding the import cache lock. Validation continues with recovered data, but results
       may be stale.
+  file_panic_error: 'Validation panicked while processing this file: %{error}'
+  file_panic_error_suggestion: Please report this as a bug with the file type and rule context
   xp_001:
     message: 'Claude-specific feature ''%{feature}'' in %{filename}: %{description}'
     suggestion: Move to CLAUDE.md or wrap in a Claude-specific section (e.g., '## Claude Code Specific')
@@ -799,14 +805,20 @@ rules:
     message: Kiro MCP server '%{server}' has potential hardcoded secret in env '%{env_key}'
     suggestion: Use environment variable indirection such as ${VAR_NAME} instead of plaintext secrets
   kr_mcp_006:
-    message: 'Kiro MCP server ''%{server}'' has invalid oauth.clientId configuration: %{reason}'
-    suggestion: Use oauth.clientId as a non-empty string only on HTTP(S) remote MCP servers, or remove the oauth block
+    message: 'Kiro MCP server ''%{server}'' has invalid OAuth configuration: %{reason}'
+    suggestion: Use the documented optional OAuth fields on an HTTP(S) remote MCP server, or remove the oauth block
     reasons:
       oauth_object: '''oauth'' must be an object'
-      missing_client_id: '''oauth.clientId'' is required when ''oauth'' is configured'
       client_id_string: '''oauth.clientId'' must be a string'
       client_id_non_empty: '''oauth.clientId'' must not be empty'
-      http_url: '''oauth.clientId'' can only be used with HTTP(S) remote MCP server URLs'
+      client_secret_string: '''oauth.clientSecret'' must be a string'
+      client_secret_non_empty: '''oauth.clientSecret'' must not be empty'
+      client_secret_requires_client_id: '''oauth.clientSecret'' is only meaningful alongside ''oauth.clientId'''
+      redirect_uri_string: '''oauth.redirectUri'' must be a string'
+      redirect_uri_format: '''oauth.redirectUri'' must use an HTTP loopback address with a valid port'
+      oauth_scopes_array: '''oauth.oauthScopes'' must be an array'
+      oauth_scopes_strings: '''oauth.oauthScopes'' entries must all be strings'
+      http_url: '''oauth'' can only be used with HTTP(S) remote MCP server URLs'
   pe_001:
     message: Critical keyword '%{keyword}' at %{percent} percent of document (40-60 percent is the 'lost in the middle' zone)
     suggestion: Move critical content to the start or end of the document for better recall

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -150,6 +150,10 @@ rules:
     prompt_no_timeout_suggestion: Agrega un campo "timeout" (ej., 30 para hooks de prompt)
     prompt_exceeds: Hook de prompt en %{location} tiene timeout %{timeout}s excediendo el predeterminado de %{default}s
     prompt_exceeds_suggestion: Considera timeout <= %{default}s (limite predeterminado de 30 segundos)
+    agent_no_timeout: Hook de agente en %{location} no tiene timeout especificado
+    agent_no_timeout_suggestion: Agrega un campo "timeout" (ej., 60 para hooks de agente)
+    agent_exceeds: Hook de agente en %{location} tiene timeout %{timeout}s excediendo el predeterminado de %{default}s
+    agent_exceeds_suggestion: Considera timeout <= %{default}s (limite predeterminado de 60 segundos)
     assumption: Asume comportamiento de timeout predeterminado de Claude Code. Fija la version de claude_code en .agnix.toml
       [tool_versions] para validacion especifica de version.
   cc_hk_011:
@@ -296,6 +300,8 @@ rules:
       pueden estar desactualizados
     suggestion: Un validador entró en pánico mientras sostenía el bloqueo de caché de importaciones. La validación continúa
       con datos recuperados, pero los resultados pueden estar desactualizados.
+  file_panic_error: 'La validación entró en pánico al procesar este archivo: %{error}'
+  file_panic_error_suggestion: Reporta esto como bug con el tipo de archivo y el contexto de la regla
   xp_001:
     message: 'Caracteristica especifica de Claude ''%{feature}'' en %{filename}: %{description}'
     suggestion: Mueve a CLAUDE.md o envuelve en una seccion especifica de Claude (ej., '## Claude Code Specific')
@@ -576,14 +582,20 @@ rules:
     message: El servidor MCP Kiro '%{server}' tiene un posible secreto hardcodeado en env '%{env_key}'
     suggestion: Usa referencias de variables de entorno como ${VAR_NAME} en lugar de secretos en texto plano
   kr_mcp_006:
-    message: 'El servidor MCP Kiro ''%{server}'' tiene una configuración oauth.clientId inválida: %{reason}'
-    suggestion: Usa oauth.clientId como cadena no vacía solo en servidores MCP remotos HTTP(S), o elimina el bloque oauth
+    message: 'El servidor MCP Kiro ''%{server}'' tiene una configuración OAuth inválida: %{reason}'
+    suggestion: Usa los campos OAuth opcionales documentados en un servidor MCP remoto HTTP(S), o elimina el bloque oauth
     reasons:
       oauth_object: '''oauth'' debe ser un objeto'
-      missing_client_id: '''oauth.clientId'' es obligatorio cuando ''oauth'' está configurado'
       client_id_string: '''oauth.clientId'' debe ser una cadena'
       client_id_non_empty: '''oauth.clientId'' no debe estar vacío'
-      http_url: '''oauth.clientId'' solo puede usarse con URLs de servidor MCP remoto HTTP(S)'
+      client_secret_string: '''oauth.clientSecret'' debe ser una cadena'
+      client_secret_non_empty: '''oauth.clientSecret'' no debe estar vacío'
+      client_secret_requires_client_id: '''oauth.clientSecret'' solo tiene sentido junto con ''oauth.clientId'''
+      redirect_uri_string: '''oauth.redirectUri'' debe ser una cadena'
+      redirect_uri_format: '''oauth.redirectUri'' debe usar una dirección de bucle local HTTP con un puerto válido'
+      oauth_scopes_array: '''oauth.oauthScopes'' debe ser un arreglo'
+      oauth_scopes_strings: Todas las entradas de 'oauth.oauthScopes' deben ser cadenas
+      http_url: '''oauth'' solo puede usarse con URLs de servidor MCP remoto HTTP(S)'
   cdx_pl_001:
     message: plugin.json debe estar ubicado en el directorio .codex-plugin/
     suggestion: Mueve plugin.json a .codex-plugin/plugin.json

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -146,6 +146,10 @@ rules:
     prompt_no_timeout_suggestion: 添加 "timeout" 字段（例如，prompt hook 使用 30）
     prompt_exceeds: '%{location} 处的 prompt hook 超时 %{timeout}s 超过默认值 %{default}s'
     prompt_exceeds_suggestion: 考虑 timeout <= %{default}s（30秒默认限制）
+    agent_no_timeout: '%{location} 处的 agent hook 未指定超时'
+    agent_no_timeout_suggestion: 添加 "timeout" 字段（例如，agent hook 使用 60）
+    agent_exceeds: '%{location} 处的 agent hook 超时 %{timeout}s 超过默认值 %{default}s'
+    agent_exceeds_suggestion: 考虑 timeout <= %{default}s（60秒默认限制）
     assumption: 假设 Claude Code 默认超时行为。在 .agnix.toml [tool_versions] 中固定 claude_code 版本以进行特定版本验证。
   cc_hk_011:
     message: '%{location} 处的超时值无效：必须是正整数'
@@ -281,6 +285,8 @@ rules:
   cache_poison:
     message: 导入缓存锁被先前的验证器崩溃毒化；恢复的数据可能已过期
     suggestion: 验证器在持有导入缓存锁时崩溃。验证将继续使用恢复的数据，但结果可能已过期。
+  file_panic_error: '验证此文件时发生崩溃: %{error}'
+  file_panic_error_suggestion: 请将此作为 bug 报告，并附上文件类型和规则上下文
   xp_001:
     message: '%{filename} 中的 Claude 特有功能 ''%{feature}'': %{description}'
     suggestion: 移至 CLAUDE.md 或包装在 Claude 特定部分中（例如 '## Claude Code Specific'）
@@ -554,14 +560,20 @@ rules:
     message: Kiro MCP 服务 '%{server}' 在 env '%{env_key}' 中存在潜在硬编码密钥
     suggestion: 使用 ${VAR_NAME} 形式的环境变量引用，避免明文密钥
   kr_mcp_006:
-    message: Kiro MCP 服务 '%{server}' 的 oauth.clientId 配置无效：%{reason}
-    suggestion: 仅在 HTTP(S) 远程 MCP 服务上使用非空字符串 oauth.clientId，或移除 oauth 块
+    message: Kiro MCP 服务 '%{server}' 的 OAuth 配置无效：%{reason}
+    suggestion: 在 HTTP(S) 远程 MCP 服务上使用文档支持的可选 OAuth 字段，或移除 oauth 块
     reasons:
       oauth_object: '''oauth'' 必须是对象'
-      missing_client_id: 配置 'oauth' 时必须提供 'oauth.clientId'
       client_id_string: '''oauth.clientId'' 必须是字符串'
       client_id_non_empty: '''oauth.clientId'' 不能为空'
-      http_url: '''oauth.clientId'' 只能用于 HTTP(S) 远程 MCP 服务器 URL'
+      client_secret_string: '''oauth.clientSecret'' 必须是字符串'
+      client_secret_non_empty: '''oauth.clientSecret'' 不能为空'
+      client_secret_requires_client_id: '''oauth.clientSecret'' 只能与 ''oauth.clientId'' 一起使用'
+      redirect_uri_string: '''oauth.redirectUri'' 必须是字符串'
+      redirect_uri_format: '''oauth.redirectUri'' 必须使用带有效端口的 HTTP 回环地址'
+      oauth_scopes_array: '''oauth.oauthScopes'' 必须是数组'
+      oauth_scopes_strings: '''oauth.oauthScopes'' 中的所有项都必须是字符串'
+      http_url: '''oauth'' 只能用于 HTTP(S) 远程 MCP 服务器 URL'
   cdx_pl_001:
     message: plugin.json 必须位于 .codex-plugin/ 目录中
     suggestion: 将 plugin.json 移至 .codex-plugin/plugin.json

--- a/crates/agnix-cli/src/main.rs
+++ b/crates/agnix-cli/src/main.rs
@@ -914,7 +914,6 @@ fn validate_command(paths: &[PathBuf], cli: &Cli) -> anyhow::Result<()> {
         if !cli.dry_run {
             let ValidationResult {
                 diagnostics: post_fix_diagnostics,
-                files_checked: _,
                 ..
             } = run_validation(paths, &config)?;
 
@@ -954,11 +953,7 @@ fn run_single_validation(
     let mut config = load_config_or_default(config_path.as_ref())?;
     config.set_target(target.into());
 
-    let ValidationResult {
-        diagnostics,
-        files_checked: _,
-        ..
-    } = validate_project(path, &config)?;
+    let ValidationResult { diagnostics, .. } = validate_project(path, &config)?;
 
     println!("{} {}", t!("cli.validating").cyan().bold(), path.display());
     println!();

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -805,14 +805,20 @@ rules:
     message: Kiro MCP server '%{server}' has potential hardcoded secret in env '%{env_key}'
     suggestion: Use environment variable indirection such as ${VAR_NAME} instead of plaintext secrets
   kr_mcp_006:
-    message: 'Kiro MCP server ''%{server}'' has invalid oauth.clientId configuration: %{reason}'
-    suggestion: Use oauth.clientId as a non-empty string only on HTTP(S) remote MCP servers, or remove the oauth block
+    message: 'Kiro MCP server ''%{server}'' has invalid OAuth configuration: %{reason}'
+    suggestion: Use the documented optional OAuth fields on an HTTP(S) remote MCP server, or remove the oauth block
     reasons:
       oauth_object: '''oauth'' must be an object'
-      missing_client_id: '''oauth.clientId'' is required when ''oauth'' is configured'
       client_id_string: '''oauth.clientId'' must be a string'
       client_id_non_empty: '''oauth.clientId'' must not be empty'
-      http_url: '''oauth.clientId'' can only be used with HTTP(S) remote MCP server URLs'
+      client_secret_string: '''oauth.clientSecret'' must be a string'
+      client_secret_non_empty: '''oauth.clientSecret'' must not be empty'
+      client_secret_requires_client_id: '''oauth.clientSecret'' is only meaningful alongside ''oauth.clientId'''
+      redirect_uri_string: '''oauth.redirectUri'' must be a string'
+      redirect_uri_format: '''oauth.redirectUri'' must use an HTTP loopback address with a valid port'
+      oauth_scopes_array: '''oauth.oauthScopes'' must be an array'
+      oauth_scopes_strings: '''oauth.oauthScopes'' entries must all be strings'
+      http_url: '''oauth'' can only be used with HTTP(S) remote MCP server URLs'
   pe_001:
     message: Critical keyword '%{keyword}' at %{percent} percent of document (40-60 percent is the 'lost in the middle' zone)
     suggestion: Move critical content to the start or end of the document for better recall

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -582,14 +582,20 @@ rules:
     message: El servidor MCP Kiro '%{server}' tiene un posible secreto hardcodeado en env '%{env_key}'
     suggestion: Usa referencias de variables de entorno como ${VAR_NAME} en lugar de secretos en texto plano
   kr_mcp_006:
-    message: 'El servidor MCP Kiro ''%{server}'' tiene una configuración oauth.clientId inválida: %{reason}'
-    suggestion: Usa oauth.clientId como cadena no vacía solo en servidores MCP remotos HTTP(S), o elimina el bloque oauth
+    message: 'El servidor MCP Kiro ''%{server}'' tiene una configuración OAuth inválida: %{reason}'
+    suggestion: Usa los campos OAuth opcionales documentados en un servidor MCP remoto HTTP(S), o elimina el bloque oauth
     reasons:
       oauth_object: '''oauth'' debe ser un objeto'
-      missing_client_id: '''oauth.clientId'' es obligatorio cuando ''oauth'' está configurado'
       client_id_string: '''oauth.clientId'' debe ser una cadena'
       client_id_non_empty: '''oauth.clientId'' no debe estar vacío'
-      http_url: '''oauth.clientId'' solo puede usarse con URLs de servidor MCP remoto HTTP(S)'
+      client_secret_string: '''oauth.clientSecret'' debe ser una cadena'
+      client_secret_non_empty: '''oauth.clientSecret'' no debe estar vacío'
+      client_secret_requires_client_id: '''oauth.clientSecret'' solo tiene sentido junto con ''oauth.clientId'''
+      redirect_uri_string: '''oauth.redirectUri'' debe ser una cadena'
+      redirect_uri_format: '''oauth.redirectUri'' debe usar una dirección de bucle local HTTP con un puerto válido'
+      oauth_scopes_array: '''oauth.oauthScopes'' debe ser un arreglo'
+      oauth_scopes_strings: Todas las entradas de 'oauth.oauthScopes' deben ser cadenas
+      http_url: '''oauth'' solo puede usarse con URLs de servidor MCP remoto HTTP(S)'
   cdx_pl_001:
     message: plugin.json debe estar ubicado en el directorio .codex-plugin/
     suggestion: Mueve plugin.json a .codex-plugin/plugin.json

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -560,14 +560,20 @@ rules:
     message: Kiro MCP 服务 '%{server}' 在 env '%{env_key}' 中存在潜在硬编码密钥
     suggestion: 使用 ${VAR_NAME} 形式的环境变量引用，避免明文密钥
   kr_mcp_006:
-    message: Kiro MCP 服务 '%{server}' 的 oauth.clientId 配置无效：%{reason}
-    suggestion: 仅在 HTTP(S) 远程 MCP 服务上使用非空字符串 oauth.clientId，或移除 oauth 块
+    message: Kiro MCP 服务 '%{server}' 的 OAuth 配置无效：%{reason}
+    suggestion: 在 HTTP(S) 远程 MCP 服务上使用文档支持的可选 OAuth 字段，或移除 oauth 块
     reasons:
       oauth_object: '''oauth'' 必须是对象'
-      missing_client_id: 配置 'oauth' 时必须提供 'oauth.clientId'
       client_id_string: '''oauth.clientId'' 必须是字符串'
       client_id_non_empty: '''oauth.clientId'' 不能为空'
-      http_url: '''oauth.clientId'' 只能用于 HTTP(S) 远程 MCP 服务器 URL'
+      client_secret_string: '''oauth.clientSecret'' 必须是字符串'
+      client_secret_non_empty: '''oauth.clientSecret'' 不能为空'
+      client_secret_requires_client_id: '''oauth.clientSecret'' 只能与 ''oauth.clientId'' 一起使用'
+      redirect_uri_string: '''oauth.redirectUri'' 必须是字符串'
+      redirect_uri_format: '''oauth.redirectUri'' 必须使用带有效端口的 HTTP 回环地址'
+      oauth_scopes_array: '''oauth.oauthScopes'' 必须是数组'
+      oauth_scopes_strings: '''oauth.oauthScopes'' 中的所有项都必须是字符串'
+      http_url: '''oauth'' 只能用于 HTTP(S) 远程 MCP 服务器 URL'
   cdx_pl_001:
     message: plugin.json 必须位于 .codex-plugin/ 目录中
     suggestion: 将 plugin.json 移至 .codex-plugin/plugin.json

--- a/crates/agnix-core/src/parsers/frontmatter.rs
+++ b/crates/agnix-core/src/parsers/frontmatter.rs
@@ -269,10 +269,9 @@ fn top_level_yaml_key(line: &str) -> Option<&str> {
     let trimmed = line.trim();
     let key = if let Some(stripped) = trimmed.strip_suffix(':') {
         stripped
-    } else if let Some(idx) = trimmed.find(": ") {
-        &trimmed[..idx]
     } else {
-        return None;
+        let idx = trimmed.find(": ")?;
+        &trimmed[..idx]
     };
     let key = key.trim();
     if key.is_empty() || key.starts_with('-') || key.starts_with('?') {

--- a/crates/agnix-core/src/rules/codex.rs
+++ b/crates/agnix-core/src/rules/codex.rs
@@ -141,15 +141,18 @@ const KNOWN_FEATURE_KEYS: &[&str] = &[
     "auto_compaction",
     "browser_use",
     "browser_use_external",
+    "browser_use_full_cdp_access",
     "child_agents_md",
     "chronicle",
     "code_mode",
+    "code_mode_host",
     "code_mode_only",
     "codex_git_commit",
     "codex_hooks",
     "collab",
     "collaboration_modes",
     "computer_use",
+    "concurrent_reasoning_summaries",
     "connectors",
     "current_time_reminder",
     "default_mode_request_user_input",
@@ -196,12 +199,14 @@ const KNOWN_FEATURE_KEYS: &[&str] = &[
     "request_permissions",
     "request_permissions_tool",
     "request_rule",
+    "resize_all_images",
     "respect_system_proxy",
     "responses_websockets",
     "responses_websockets_v2",
     "rollout_budget",
     "runtime_metrics",
     "search_tool",
+    "secret_auth_storage",
     "shell_snapshot",
     "shell_tool",
     "shell_zsh_fork",
@@ -263,23 +268,29 @@ const KNOWN_SHELL_ENVIRONMENT_POLICY_KEYS: &[&str] = &[
 
 const KNOWN_MCP_SERVER_KEYS: &[&str] = &[
     "args",
+    "auth",
     "bearer_token_env_var",
     "command",
     "cwd",
+    "default_tools_approval_mode",
     "disabled_tools",
     "enabled",
     "enabled_tools",
     "env",
     "env_http_headers",
     "env_vars",
+    "environment_id",
     "http_headers",
+    "name",
     "oauth",
     "oauth_resource",
     "required",
     "scopes",
     "startup_timeout_ms",
     "startup_timeout_sec",
+    "supports_parallel_tool_calls",
     "tool_timeout_sec",
+    "tools",
     "url",
 ];
 
@@ -3713,6 +3724,66 @@ clock_source = "external"
         assert!(
             unexpected.is_empty(),
             "0.142 config surfaces should not be flagged, got: {unexpected:?}"
+        );
+    }
+
+    #[test]
+    fn test_codex_0_144_1_feature_and_mcp_keys_not_flagged() {
+        // Diffed against codex-rs/core/config.schema.json at rust-v0.144.1.
+        // These keys are accepted by the shipped schema and must not trigger
+        // the generic nested-key diagnostic on either TOML or JSON configs.
+        let toml = r#"
+[features]
+browser_use_full_cdp_access = true
+code_mode_host = true
+concurrent_reasoning_summaries = true
+resize_all_images = true
+secret_auth_storage = true
+
+[mcp_servers.chatgpt]
+url = "https://chatgpt.com/mcp"
+auth = "chatgpt"
+default_tools_approval_mode = "prompt"
+environment_id = "production"
+name = "ChatGPT"
+supports_parallel_tool_calls = true
+
+[mcp_servers.chatgpt.tools.search]
+approval_mode = "auto"
+"#;
+        let diagnostics = validate_config(toml);
+        let unexpected: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-006")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "0.144.1 feature and MCP keys should be accepted, got: {unexpected:?}"
+        );
+
+        let json = r#"{
+  "features": {
+    "code_mode_host": true,
+    "concurrent_reasoning_summaries": true
+  },
+  "mcp_servers": {
+    "chatgpt": {
+      "url": "https://chatgpt.com/mcp",
+      "auth": "chatgpt",
+      "supports_parallel_tool_calls": true
+    }
+  }
+}"#;
+        let diagnostics = validate_config_json(json);
+        let unexpected: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CDX-CFG-006")
+            .map(|d| d.message.as_str())
+            .collect();
+        assert!(
+            unexpected.is_empty(),
+            "0.144.1 JSON keys should be accepted, got: {unexpected:?}"
         );
     }
 

--- a/crates/agnix-core/src/rules/codex_requirements.rs
+++ b/crates/agnix-core/src/rules/codex_requirements.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 const RULE_IDS: &[&str] = &["CDX-REQ-000", "CDX-REQ-001"];
 
 /// Known top-level keys of `requirements.toml`, sourced from
-/// `ConfigRequirementsToml` @ openai/codex rust-v0.137.0. Both `features`
+/// `ConfigRequirementsToml` @ openai/codex rust-v0.144.1. Both `features`
 /// (serde rename) and `feature_requirements` (serde alias) are accepted on
 /// disk; the network table is only valid as `experimental_network` (serde
 /// rename - the bare `network` field name is not a valid TOML key).
@@ -38,6 +38,7 @@ const KNOWN_REQUIREMENTS_KEYS: &[&str] = &[
     "features",
     "guardian_policy_config",
     "hooks",
+    "marketplaces",
     "mcp_servers",
     "permissions",
     "plugins",
@@ -236,6 +237,14 @@ some_feature = true
 
 [mcp_servers.docs]
 command = "docs-server"
+
+[marketplaces]
+restrict_to_allowed_sources = true
+
+[marketplaces.allowed_sources.company]
+source = "git"
+url = "https://github.com/example/plugins.git"
+ref = "main"
 
 [apps.example]
 enabled = true

--- a/crates/agnix-core/src/rules/kiro_mcp.rs
+++ b/crates/agnix-core/src/rules/kiro_mcp.rs
@@ -6,7 +6,7 @@
 //! - KR-MCP-003: Missing required args
 //! - KR-MCP-004: Invalid MCP URL
 //! - KR-MCP-005: Duplicate MCP server names
-//! - KR-MCP-006: Invalid OAuth client ID configuration
+//! - KR-MCP-006: Invalid OAuth configuration
 
 use crate::{
     config::PerFileLintConfig,
@@ -179,9 +179,10 @@ impl Validator for KiroMcpValidator {
                 }
             }
 
-            // KR-MCP-006: oauth.clientId is only meaningful on HTTP(S) remote servers
+            // KR-MCP-006: validate the optional OAuth fields documented for
+            // Kiro CLI 2.12 and require OAuth only on HTTP(S) remote servers.
             if config.is_rule_enabled("KR-MCP-006")
-                && let Some(issue) = invalid_oauth_client_id_issue(&server)
+                && let Some(issue) = invalid_oauth_configuration_issue(&server)
             {
                 let reason = issue.localized_reason();
                 diagnostics.push(
@@ -209,22 +210,54 @@ impl Validator for KiroMcpValidator {
     }
 }
 
-fn invalid_oauth_client_id_issue(
+fn invalid_oauth_configuration_issue(
     server: &crate::schemas::kiro_mcp::KiroMcpServerConfig,
-) -> Option<OauthClientIdIssue> {
+) -> Option<OauthConfigurationIssue> {
     let oauth = server.extra.get("oauth")?;
     let Some(oauth) = oauth.as_object() else {
-        return Some(OauthClientIdIssue::OauthMustBeObject);
+        return Some(OauthConfigurationIssue::OauthMustBeObject);
     };
 
-    let Some(client_id) = oauth.get("clientId") else {
-        return Some(OauthClientIdIssue::MissingClientId);
+    let has_client_id = if let Some(client_id) = oauth.get("clientId") {
+        let Some(client_id) = client_id.as_str() else {
+            return Some(OauthConfigurationIssue::ClientIdMustBeString);
+        };
+        if client_id.trim().is_empty() {
+            return Some(OauthConfigurationIssue::EmptyClientId);
+        }
+        true
+    } else {
+        false
     };
-    let Some(client_id) = client_id.as_str() else {
-        return Some(OauthClientIdIssue::ClientIdMustBeString);
-    };
-    if client_id.trim().is_empty() {
-        return Some(OauthClientIdIssue::EmptyClientId);
+
+    if let Some(client_secret) = oauth.get("clientSecret") {
+        let Some(client_secret) = client_secret.as_str() else {
+            return Some(OauthConfigurationIssue::ClientSecretMustBeString);
+        };
+        if client_secret.trim().is_empty() {
+            return Some(OauthConfigurationIssue::EmptyClientSecret);
+        }
+        if !has_client_id {
+            return Some(OauthConfigurationIssue::ClientSecretRequiresClientId);
+        }
+    }
+
+    if let Some(redirect_uri) = oauth.get("redirectUri") {
+        let Some(redirect_uri) = redirect_uri.as_str() else {
+            return Some(OauthConfigurationIssue::RedirectUriMustBeString);
+        };
+        if !is_valid_oauth_redirect_uri(redirect_uri) {
+            return Some(OauthConfigurationIssue::InvalidRedirectUri);
+        }
+    }
+
+    if let Some(oauth_scopes) = oauth.get("oauthScopes") {
+        let Some(oauth_scopes) = oauth_scopes.as_array() else {
+            return Some(OauthConfigurationIssue::OauthScopesMustBeArray);
+        };
+        if oauth_scopes.iter().any(|scope| !scope.is_string()) {
+            return Some(OauthConfigurationIssue::OauthScopesMustContainStrings);
+        }
     }
 
     let is_http_url = server
@@ -233,30 +266,81 @@ fn invalid_oauth_client_id_issue(
         .map(str::trim)
         .is_some_and(|url| url.starts_with("http://") || url.starts_with("https://"));
     if !is_http_url {
-        return Some(OauthClientIdIssue::RequiresHttpUrl);
+        return Some(OauthConfigurationIssue::RequiresHttpUrl);
     }
 
     None
 }
 
+fn is_valid_oauth_redirect_uri(value: &str) -> bool {
+    let value = value.trim();
+    if let Some(port) = value.strip_prefix(':') {
+        return is_valid_port(port);
+    }
+
+    let authority = if let Some(rest) = value.strip_prefix("http://") {
+        rest.split(['/', '?', '#']).next().unwrap_or_default()
+    } else {
+        if value.contains("://") {
+            return false;
+        }
+        value
+    };
+
+    let Some((host, port)) = authority.rsplit_once(':') else {
+        return false;
+    };
+    matches!(host, "localhost" | "127.0.0.1") && is_valid_port(port)
+}
+
+fn is_valid_port(value: &str) -> bool {
+    value.parse::<u16>().is_ok_and(|port| port > 0)
+}
+
 #[derive(Clone, Copy)]
-enum OauthClientIdIssue {
+enum OauthConfigurationIssue {
     OauthMustBeObject,
-    MissingClientId,
     ClientIdMustBeString,
     EmptyClientId,
+    ClientSecretMustBeString,
+    EmptyClientSecret,
+    ClientSecretRequiresClientId,
+    RedirectUriMustBeString,
+    InvalidRedirectUri,
+    OauthScopesMustBeArray,
+    OauthScopesMustContainStrings,
     RequiresHttpUrl,
 }
 
-impl OauthClientIdIssue {
+impl OauthConfigurationIssue {
     fn localized_reason(self) -> String {
         match self {
             Self::OauthMustBeObject => t!("rules.kr_mcp_006.reasons.oauth_object").to_string(),
-            Self::MissingClientId => t!("rules.kr_mcp_006.reasons.missing_client_id").to_string(),
             Self::ClientIdMustBeString => {
                 t!("rules.kr_mcp_006.reasons.client_id_string").to_string()
             }
             Self::EmptyClientId => t!("rules.kr_mcp_006.reasons.client_id_non_empty").to_string(),
+            Self::ClientSecretMustBeString => {
+                t!("rules.kr_mcp_006.reasons.client_secret_string").to_string()
+            }
+            Self::EmptyClientSecret => {
+                t!("rules.kr_mcp_006.reasons.client_secret_non_empty").to_string()
+            }
+            Self::ClientSecretRequiresClientId => {
+                t!("rules.kr_mcp_006.reasons.client_secret_requires_client_id").to_string()
+            }
+            Self::RedirectUriMustBeString => {
+                t!("rules.kr_mcp_006.reasons.redirect_uri_string").to_string()
+            }
+            Self::InvalidRedirectUri => {
+                t!("rules.kr_mcp_006.reasons.redirect_uri_format").to_string()
+            }
+            Self::OauthScopesMustBeArray => {
+                t!("rules.kr_mcp_006.reasons.oauth_scopes_array").to_string()
+            }
+            Self::OauthScopesMustContainStrings => {
+                t!("rules.kr_mcp_006.reasons.oauth_scopes_strings").to_string()
+            }
             Self::RequiresHttpUrl => t!("rules.kr_mcp_006.reasons.http_url").to_string(),
         }
     }
@@ -405,6 +489,29 @@ mod tests {
     }
 
     #[test]
+    fn test_kr_mcp_006_kiro_2_12_oauth_fields_allowed() {
+        let diagnostics = validate(
+            r#"{
+  "mcpServers": {
+    "figma": {
+      "url": "https://mcp.figma.com/mcp",
+      "oauth": {
+        "clientId": "registered-client",
+        "clientSecret": "registered-secret",
+        "redirectUri": "http://localhost:7778/oauth/callback",
+        "oauthScopes": ["files:read"]
+      }
+    }
+  }
+}"#,
+        );
+        assert!(
+            diagnostics.iter().all(|d| d.rule != "KR-MCP-006"),
+            "Kiro 2.12 OAuth fields should be accepted: {diagnostics:?}"
+        );
+    }
+
+    #[test]
     fn test_kr_mcp_006_oauth_must_be_object() {
         let diagnostics = validate(
             r#"{
@@ -437,13 +544,141 @@ mod tests {
     }
 
     #[test]
-    fn test_kr_mcp_006_missing_client_id() {
+    fn test_kr_mcp_006_client_id_is_optional_for_dcr() {
         let diagnostics = validate(
             r#"{
   "mcpServers": {
     "remote": {
       "url": "https://example.com/mcp",
-      "oauth": {}
+      "oauth": {
+        "redirectUri": ":7778",
+        "oauthScopes": ["read"]
+      }
+    }
+  }
+}"#,
+        );
+        assert!(
+            diagnostics.iter().all(|d| d.rule != "KR-MCP-006"),
+            "clientId is optional when Kiro uses dynamic client registration"
+        );
+    }
+
+    #[test]
+    fn test_kr_mcp_006_client_secret_requires_client_id() {
+        let diagnostics = validate(
+            r#"{
+  "mcpServers": {
+    "remote": {
+      "url": "https://example.com/mcp",
+      "oauth": {
+        "clientSecret": "secret"
+      }
+    }
+  }
+}"#,
+        );
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| d.rule == "KR-MCP-006")
+            .expect("clientSecret without clientId should be flagged");
+        assert!(diagnostic.message.contains("clientId"));
+    }
+
+    #[test]
+    fn test_kr_mcp_006_redirect_uri_requires_http_loopback() {
+        for redirect_uri in [
+            "https://localhost:7778/oauth/callback",
+            "http://example.com:7778/oauth/callback",
+            "localhost:not-a-port",
+            ":0",
+        ] {
+            let content = format!(
+                r#"{{
+  "mcpServers": {{
+    "remote": {{
+      "url": "https://example.com/mcp",
+      "oauth": {{
+        "redirectUri": "{redirect_uri}"
+      }}
+    }}
+  }}
+}}"#
+            );
+            let diagnostics = validate(&content);
+            assert!(
+                diagnostics.iter().any(|d| d.rule == "KR-MCP-006"),
+                "invalid redirectUri should be flagged: {redirect_uri}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_kr_mcp_006_documented_redirect_uri_formats_allowed() {
+        for redirect_uri in [
+            "http://localhost:7778/oauth/callback",
+            "127.0.0.1:7778",
+            ":7778",
+        ] {
+            let content = format!(
+                r#"{{
+  "mcpServers": {{
+    "remote": {{
+      "url": "https://example.com/mcp",
+      "oauth": {{
+        "redirectUri": "{redirect_uri}"
+      }}
+    }}
+  }}
+}}"#
+            );
+            let diagnostics = validate(&content);
+            assert!(
+                diagnostics.iter().all(|d| d.rule != "KR-MCP-006"),
+                "documented redirectUri should be accepted: {redirect_uri}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_kr_mcp_006_optional_field_types_are_checked() {
+        let invalid_fragments = [
+            r#""clientId": 42"#,
+            r#""clientId": "id", "clientSecret": []"#,
+            r#""clientId": "id", "clientSecret": """#,
+            r#""redirectUri": 7778"#,
+            r#""oauthScopes": "read""#,
+        ];
+
+        for fields in invalid_fragments {
+            let content = format!(
+                r#"{{
+  "mcpServers": {{
+    "remote": {{
+      "url": "https://example.com/mcp",
+      "oauth": {{ {fields} }}
+    }}
+  }}
+}}"#
+            );
+            let diagnostics = validate(&content);
+            assert!(
+                diagnostics.iter().any(|d| d.rule == "KR-MCP-006"),
+                "invalid OAuth field should be flagged: {fields}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_kr_mcp_006_oauth_scopes_must_be_string_array() {
+        let diagnostics = validate(
+            r#"{
+  "mcpServers": {
+    "remote": {
+      "url": "https://example.com/mcp",
+      "oauth": {
+        "oauthScopes": ["read", 42]
+      }
     }
   }
 }"#,

--- a/crates/agnix-core/src/rules/kiro_mcp.rs
+++ b/crates/agnix-core/src/rules/kiro_mcp.rs
@@ -274,6 +274,8 @@ fn invalid_oauth_configuration_issue(
 
 fn is_valid_oauth_redirect_uri(value: &str) -> bool {
     let value = value.trim();
+    // Kiro's shorthand forms pin only the loopback host and port. Custom callback
+    // paths must use the full http:// URL form.
     if let Some(port) = value.strip_prefix(':') {
         return is_valid_port(port);
     }
@@ -591,6 +593,8 @@ mod tests {
             "https://localhost:7778/oauth/callback",
             "http://example.com:7778/oauth/callback",
             "localhost:not-a-port",
+            "127.0.0.1:7778/oauth/callback",
+            ":7778/oauth/callback",
             ":0",
         ] {
             let content = format!(

--- a/crates/agnix-core/src/rules/skill/helpers.rs
+++ b/crates/agnix-core/src/rules/skill/helpers.rs
@@ -227,20 +227,12 @@ pub(super) fn frontmatter_value_byte_range(
                 // Handle quoted values
                 let (value_start, value_len) = if let Some(inner) = value_str.strip_prefix('"') {
                     // Double-quoted: find closing quote
-                    if let Some(end_quote) = inner.find('"') {
-                        (value_offset_in_line + 1, end_quote) // Skip opening quote
-                    } else {
-                        // Unclosed quote - return None for malformed YAML
-                        return None;
-                    }
+                    let end_quote = inner.find('"')?;
+                    (value_offset_in_line + 1, end_quote) // Skip opening quote
                 } else if let Some(inner) = value_str.strip_prefix('\'') {
                     // Single-quoted: find closing quote
-                    if let Some(end_quote) = inner.find('\'') {
-                        (value_offset_in_line + 1, end_quote) // Skip opening quote
-                    } else {
-                        // Unclosed quote - return None for malformed YAML
-                        return None;
-                    }
+                    let end_quote = inner.find('\'')?;
+                    (value_offset_in_line + 1, end_quote) // Skip opening quote
                 } else {
                     // Unquoted value: take until end of line or comment
                     // Check for both " #" (space-hash) and "\t#" (tab-hash)

--- a/crates/agnix-core/src/schemas/codex.rs
+++ b/crates/agnix-core/src/schemas/codex.rs
@@ -33,7 +33,7 @@ pub const AGENTS_MD_MAX_SIZE: usize = 100_000;
 /// Known valid top-level keys for .codex/config.toml
 ///
 /// Sourced from the upstream JSON schema at
-/// `codex-rs/core/config.schema.json`; current baseline is `rust-v0.142.0`
+/// `codex-rs/core/config.schema.json`; current baseline is `rust-v0.144.1`
 /// (see `.github/tool-release-baselines.json`). Prose overview:
 /// <https://developers.openai.com/codex/>.
 ///

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -166,10 +166,14 @@ rules:
     command_no_timeout_suggestion: Add a "timeout" field (e.g., 600 for command hooks)
     command_exceeds: Command hook at %{location} has timeout %{timeout}s exceeding %{default}s default
     command_exceeds_suggestion: Consider timeout <= %{default}s (10-minute default limit)
-    prompt_no_timeout: Prompt/agent hook at %{location} has no timeout specified
-    prompt_no_timeout_suggestion: Add a "timeout" field (e.g., 30 for prompt/agent hooks)
-    prompt_exceeds: Prompt/agent hook at %{location} has timeout %{timeout}s exceeding %{default}s default
+    prompt_no_timeout: Prompt hook at %{location} has no timeout specified
+    prompt_no_timeout_suggestion: Add a "timeout" field (e.g., 30 for prompt hooks)
+    prompt_exceeds: Prompt hook at %{location} has timeout %{timeout}s exceeding %{default}s default
     prompt_exceeds_suggestion: Consider timeout <= %{default}s (30-second default limit)
+    agent_no_timeout: Agent hook at %{location} has no timeout specified
+    agent_no_timeout_suggestion: Add a "timeout" field (e.g., 60 for agent hooks)
+    agent_exceeds: Agent hook at %{location} has timeout %{timeout}s exceeding %{default}s default
+    agent_exceeds_suggestion: Consider timeout <= %{default}s (60-second default limit)
     assumption: Assumes Claude Code default timeout behavior. Pin claude_code version in .agnix.toml [tool_versions] for version-specific
       validation.
   cc_hk_011:
@@ -376,6 +380,8 @@ rules:
     message: Import cache lock was poisoned by a prior validator panic; recovered stale data
     suggestion: A validator panicked while holding the import cache lock. Validation continues with recovered data, but results
       may be stale.
+  file_panic_error: 'Validation panicked while processing this file: %{error}'
+  file_panic_error_suggestion: Please report this as a bug with the file type and rule context
   xp_001:
     message: 'Claude-specific feature ''%{feature}'' in %{filename}: %{description}'
     suggestion: Move to CLAUDE.md or wrap in a Claude-specific section (e.g., '## Claude Code Specific')
@@ -799,14 +805,20 @@ rules:
     message: Kiro MCP server '%{server}' has potential hardcoded secret in env '%{env_key}'
     suggestion: Use environment variable indirection such as ${VAR_NAME} instead of plaintext secrets
   kr_mcp_006:
-    message: 'Kiro MCP server ''%{server}'' has invalid oauth.clientId configuration: %{reason}'
-    suggestion: Use oauth.clientId as a non-empty string only on HTTP(S) remote MCP servers, or remove the oauth block
+    message: 'Kiro MCP server ''%{server}'' has invalid OAuth configuration: %{reason}'
+    suggestion: Use the documented optional OAuth fields on an HTTP(S) remote MCP server, or remove the oauth block
     reasons:
       oauth_object: '''oauth'' must be an object'
-      missing_client_id: '''oauth.clientId'' is required when ''oauth'' is configured'
       client_id_string: '''oauth.clientId'' must be a string'
       client_id_non_empty: '''oauth.clientId'' must not be empty'
-      http_url: '''oauth.clientId'' can only be used with HTTP(S) remote MCP server URLs'
+      client_secret_string: '''oauth.clientSecret'' must be a string'
+      client_secret_non_empty: '''oauth.clientSecret'' must not be empty'
+      client_secret_requires_client_id: '''oauth.clientSecret'' is only meaningful alongside ''oauth.clientId'''
+      redirect_uri_string: '''oauth.redirectUri'' must be a string'
+      redirect_uri_format: '''oauth.redirectUri'' must use an HTTP loopback address with a valid port'
+      oauth_scopes_array: '''oauth.oauthScopes'' must be an array'
+      oauth_scopes_strings: '''oauth.oauthScopes'' entries must all be strings'
+      http_url: '''oauth'' can only be used with HTTP(S) remote MCP server URLs'
   pe_001:
     message: Critical keyword '%{keyword}' at %{percent} percent of document (40-60 percent is the 'lost in the middle' zone)
     suggestion: Move critical content to the start or end of the document for better recall
@@ -1242,6 +1254,7 @@ core:
     files_pattern_count_limit: Field '%{field}' has %{count} patterns, which exceeds the recommended limit of %{limit}.
     files_pattern_count_limit_suggestion: Consider consolidating patterns or using broader glob expressions
     load_warning: 'Failed to parse config ''%{path}'': %{error}. Using defaults.'
+    load_error: 'Failed to parse config ''%{path}'': %{error}.'
 
 
 # ===========================================================================

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -150,6 +150,10 @@ rules:
     prompt_no_timeout_suggestion: Agrega un campo "timeout" (ej., 30 para hooks de prompt)
     prompt_exceeds: Hook de prompt en %{location} tiene timeout %{timeout}s excediendo el predeterminado de %{default}s
     prompt_exceeds_suggestion: Considera timeout <= %{default}s (limite predeterminado de 30 segundos)
+    agent_no_timeout: Hook de agente en %{location} no tiene timeout especificado
+    agent_no_timeout_suggestion: Agrega un campo "timeout" (ej., 60 para hooks de agente)
+    agent_exceeds: Hook de agente en %{location} tiene timeout %{timeout}s excediendo el predeterminado de %{default}s
+    agent_exceeds_suggestion: Considera timeout <= %{default}s (limite predeterminado de 60 segundos)
     assumption: Asume comportamiento de timeout predeterminado de Claude Code. Fija la version de claude_code en .agnix.toml
       [tool_versions] para validacion especifica de version.
   cc_hk_011:
@@ -296,6 +300,8 @@ rules:
       pueden estar desactualizados
     suggestion: Un validador entró en pánico mientras sostenía el bloqueo de caché de importaciones. La validación continúa
       con datos recuperados, pero los resultados pueden estar desactualizados.
+  file_panic_error: 'La validación entró en pánico al procesar este archivo: %{error}'
+  file_panic_error_suggestion: Reporta esto como bug con el tipo de archivo y el contexto de la regla
   xp_001:
     message: 'Caracteristica especifica de Claude ''%{feature}'' en %{filename}: %{description}'
     suggestion: Mueve a CLAUDE.md o envuelve en una seccion especifica de Claude (ej., '## Claude Code Specific')
@@ -576,14 +582,20 @@ rules:
     message: El servidor MCP Kiro '%{server}' tiene un posible secreto hardcodeado en env '%{env_key}'
     suggestion: Usa referencias de variables de entorno como ${VAR_NAME} en lugar de secretos en texto plano
   kr_mcp_006:
-    message: 'El servidor MCP Kiro ''%{server}'' tiene una configuración oauth.clientId inválida: %{reason}'
-    suggestion: Usa oauth.clientId como cadena no vacía solo en servidores MCP remotos HTTP(S), o elimina el bloque oauth
+    message: 'El servidor MCP Kiro ''%{server}'' tiene una configuración OAuth inválida: %{reason}'
+    suggestion: Usa los campos OAuth opcionales documentados en un servidor MCP remoto HTTP(S), o elimina el bloque oauth
     reasons:
       oauth_object: '''oauth'' debe ser un objeto'
-      missing_client_id: '''oauth.clientId'' es obligatorio cuando ''oauth'' está configurado'
       client_id_string: '''oauth.clientId'' debe ser una cadena'
       client_id_non_empty: '''oauth.clientId'' no debe estar vacío'
-      http_url: '''oauth.clientId'' solo puede usarse con URLs de servidor MCP remoto HTTP(S)'
+      client_secret_string: '''oauth.clientSecret'' debe ser una cadena'
+      client_secret_non_empty: '''oauth.clientSecret'' no debe estar vacío'
+      client_secret_requires_client_id: '''oauth.clientSecret'' solo tiene sentido junto con ''oauth.clientId'''
+      redirect_uri_string: '''oauth.redirectUri'' debe ser una cadena'
+      redirect_uri_format: '''oauth.redirectUri'' debe usar una dirección de bucle local HTTP con un puerto válido'
+      oauth_scopes_array: '''oauth.oauthScopes'' debe ser un arreglo'
+      oauth_scopes_strings: Todas las entradas de 'oauth.oauthScopes' deben ser cadenas
+      http_url: '''oauth'' solo puede usarse con URLs de servidor MCP remoto HTTP(S)'
   cdx_pl_001:
     message: plugin.json debe estar ubicado en el directorio .codex-plugin/
     suggestion: Mueve plugin.json a .codex-plugin/plugin.json
@@ -763,6 +775,7 @@ core:
     files_pattern_count_limit: El campo '%{field}' tiene %{count} patrones, lo que excede el limite recomendado de %{limit}.
     files_pattern_count_limit_suggestion: Considera consolidar patrones o usar expresiones glob mas amplias
     load_warning: 'Error al analizar configuracion ''%{path}'': %{error}. Usando valores predeterminados.'
+    load_error: 'Error al analizar configuracion ''%{path}'': %{error}.'
 
 
 # ===========================================================================

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -146,6 +146,10 @@ rules:
     prompt_no_timeout_suggestion: 添加 "timeout" 字段（例如，prompt hook 使用 30）
     prompt_exceeds: '%{location} 处的 prompt hook 超时 %{timeout}s 超过默认值 %{default}s'
     prompt_exceeds_suggestion: 考虑 timeout <= %{default}s（30秒默认限制）
+    agent_no_timeout: '%{location} 处的 agent hook 未指定超时'
+    agent_no_timeout_suggestion: 添加 "timeout" 字段（例如，agent hook 使用 60）
+    agent_exceeds: '%{location} 处的 agent hook 超时 %{timeout}s 超过默认值 %{default}s'
+    agent_exceeds_suggestion: 考虑 timeout <= %{default}s（60秒默认限制）
     assumption: 假设 Claude Code 默认超时行为。在 .agnix.toml [tool_versions] 中固定 claude_code 版本以进行特定版本验证。
   cc_hk_011:
     message: '%{location} 处的超时值无效：必须是正整数'
@@ -281,6 +285,8 @@ rules:
   cache_poison:
     message: 导入缓存锁被先前的验证器崩溃毒化；恢复的数据可能已过期
     suggestion: 验证器在持有导入缓存锁时崩溃。验证将继续使用恢复的数据，但结果可能已过期。
+  file_panic_error: '验证此文件时发生崩溃: %{error}'
+  file_panic_error_suggestion: 请将此作为 bug 报告，并附上文件类型和规则上下文
   xp_001:
     message: '%{filename} 中的 Claude 特有功能 ''%{feature}'': %{description}'
     suggestion: 移至 CLAUDE.md 或包装在 Claude 特定部分中（例如 '## Claude Code Specific'）
@@ -554,14 +560,20 @@ rules:
     message: Kiro MCP 服务 '%{server}' 在 env '%{env_key}' 中存在潜在硬编码密钥
     suggestion: 使用 ${VAR_NAME} 形式的环境变量引用，避免明文密钥
   kr_mcp_006:
-    message: Kiro MCP 服务 '%{server}' 的 oauth.clientId 配置无效：%{reason}
-    suggestion: 仅在 HTTP(S) 远程 MCP 服务上使用非空字符串 oauth.clientId，或移除 oauth 块
+    message: Kiro MCP 服务 '%{server}' 的 OAuth 配置无效：%{reason}
+    suggestion: 在 HTTP(S) 远程 MCP 服务上使用文档支持的可选 OAuth 字段，或移除 oauth 块
     reasons:
       oauth_object: '''oauth'' 必须是对象'
-      missing_client_id: 配置 'oauth' 时必须提供 'oauth.clientId'
       client_id_string: '''oauth.clientId'' 必须是字符串'
       client_id_non_empty: '''oauth.clientId'' 不能为空'
-      http_url: '''oauth.clientId'' 只能用于 HTTP(S) 远程 MCP 服务器 URL'
+      client_secret_string: '''oauth.clientSecret'' 必须是字符串'
+      client_secret_non_empty: '''oauth.clientSecret'' 不能为空'
+      client_secret_requires_client_id: '''oauth.clientSecret'' 只能与 ''oauth.clientId'' 一起使用'
+      redirect_uri_string: '''oauth.redirectUri'' 必须是字符串'
+      redirect_uri_format: '''oauth.redirectUri'' 必须使用带有效端口的 HTTP 回环地址'
+      oauth_scopes_array: '''oauth.oauthScopes'' 必须是数组'
+      oauth_scopes_strings: '''oauth.oauthScopes'' 中的所有项都必须是字符串'
+      http_url: '''oauth'' 只能用于 HTTP(S) 远程 MCP 服务器 URL'
   cdx_pl_001:
     message: plugin.json 必须位于 .codex-plugin/ 目录中
     suggestion: 将 plugin.json 移至 .codex-plugin/plugin.json
@@ -724,6 +736,7 @@ core:
     files_pattern_count_limit: 字段 '%{field}' 有 %{count} 个模式，超过了建议的 %{limit} 个上限。
     files_pattern_count_limit_suggestion: 考虑合并模式或使用更广泛的 glob 表达式
     load_warning: '解析配置 ''%{path}'' 失败: %{error}。使用默认值。'
+    load_error: '解析配置 ''%{path}'' 失败: %{error}。'
 
 
 # ===========================================================================

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -2,7 +2,7 @@
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
   "total_rules": 432,
-  "last_updated": "2026-06-27",
+  "last_updated": "2026-07-10",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -9042,15 +9042,16 @@
     },
     {
       "id": "KR-MCP-006",
-      "name": "Invalid OAuth Client ID Configuration",
+      "name": "Invalid OAuth Configuration",
       "severity": "MEDIUM",
       "category": "kiro-mcp",
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://kiro.dev/changelog/cli/2-3/"
+          "https://kiro.dev/docs/cli/mcp/configuration/#oauth-configuration",
+          "https://kiro.dev/changelog/cli/2-12/"
         ],
-        "verified_on": "2026-05-14",
+        "verified_on": "2026-07-11",
         "applies_to": {
           "tool": "kiro",
           "version_range": ">=2.3.0"
@@ -9065,8 +9066,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\"mcpServers\": {\"remote\": {\"url\": \"https://example.com/mcp\", \"oauth\": {\"clientId\": \"registered-client\"}}}}",
-      "bad_example": "{\"mcpServers\": {\"local\": {\"command\": \"node\", \"args\": [\"server.js\"], \"oauth\": {\"clientId\": \"registered-client\"}}}}"
+      "good_example": "{\"mcpServers\": {\"remote\": {\"url\": \"https://example.com/mcp\", \"oauth\": {\"clientId\": \"registered-client\", \"clientSecret\": \"registered-secret\", \"redirectUri\": \"http://localhost:7778/oauth/callback\", \"oauthScopes\": [\"read\"]}}}}",
+      "bad_example": "{\"mcpServers\": {\"remote\": {\"url\": \"https://example.com/mcp\", \"oauth\": {\"clientSecret\": \"secret-without-client-id\", \"redirectUri\": \"https://example.com/callback\"}}}}"
     },
     {
       "id": "KR-PW-001",

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -16,31 +16,31 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-02 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
-| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-02 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
-| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-02 | AGM, XP, OC |
-| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-06-27 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-11 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
+| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-11 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
+| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-11 | AGM, XP, OC |
+| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-07-11 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 
 ### A Tier (test on major changes)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-04-22 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-07-02 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-07-02 | CUR |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-07-11 | CLN, CL-SK |
+| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-07-11 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Roo Code | `.roomodes`, `.rooignore`, `.roorules`, `.roo/rules/*.md`, `.roo/rules-{slug}/*.md`, `.roo/mcp.json` | https://github.com/RooCodeInc/Roo-Code | Automated (tool-release-watch.yml) | Quarterly | 2026-06-02 | ROO |
-| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-07-02 | AMP, AMP-SK |
+| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-07-11 | AMP, AMP-SK |
 
 ### C Tier (community reports fixes only)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-06-27 | GM |
+| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-07-11 | GM |
 
 ### D Tier (no support, nice to have)
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -3068,11 +3068,11 @@ Validates Codex's admin-written managed `requirements.toml` (system location: `/
 **Source**: kiro.dev/docs/mcp
 
 <a id="kr-mcp-006"></a>
-### KR-MCP-006 [MEDIUM] Invalid OAuth Client ID Configuration
-**Requirement**: `oauth.clientId` SHOULD be a non-empty string and only be used with HTTP(S) remote MCP server URLs.
-**Detection**: Check each MCP server `oauth` block for a non-empty string `clientId`, then require the same server to use an `http://` or `https://` URL.
-**Fix**: No auto-fix (set `oauth.clientId` on an HTTP(S) remote MCP server, or remove the OAuth block).
-**Source**: kiro.dev/changelog/cli/2-3/
+### KR-MCP-006 [MEDIUM] Invalid OAuth Configuration
+**Requirement**: An `oauth` block SHOULD be an object on an HTTP(S) remote MCP server. Its optional `clientId`, `clientSecret`, and `redirectUri` fields SHOULD be valid strings, `clientSecret` requires `clientId`, `redirectUri` SHOULD use a documented HTTP loopback form, and `oauthScopes` SHOULD be an array of strings. `clientId` is optional because Kiro uses Dynamic Client Registration when it is absent.
+**Detection**: Validate each MCP server `oauth` block against the Kiro CLI 2.12 OAuth field types and relationships, including the loopback redirect host and port constraints.
+**Fix**: No auto-fix (correct the OAuth fields on an HTTP(S) remote MCP server, or remove the block).
+**Source**: kiro.dev/docs/cli/mcp/configuration/#oauth-configuration, kiro.dev/changelog/cli/2-12/
 
 ---
 

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -2,7 +2,7 @@
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
   "total_rules": 432,
-  "last_updated": "2026-06-27",
+  "last_updated": "2026-07-10",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -9042,15 +9042,16 @@
     },
     {
       "id": "KR-MCP-006",
-      "name": "Invalid OAuth Client ID Configuration",
+      "name": "Invalid OAuth Configuration",
       "severity": "MEDIUM",
       "category": "kiro-mcp",
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://kiro.dev/changelog/cli/2-3/"
+          "https://kiro.dev/docs/cli/mcp/configuration/#oauth-configuration",
+          "https://kiro.dev/changelog/cli/2-12/"
         ],
-        "verified_on": "2026-05-14",
+        "verified_on": "2026-07-11",
         "applies_to": {
           "tool": "kiro",
           "version_range": ">=2.3.0"
@@ -9065,8 +9066,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\"mcpServers\": {\"remote\": {\"url\": \"https://example.com/mcp\", \"oauth\": {\"clientId\": \"registered-client\"}}}}",
-      "bad_example": "{\"mcpServers\": {\"local\": {\"command\": \"node\", \"args\": [\"server.js\"], \"oauth\": {\"clientId\": \"registered-client\"}}}}"
+      "good_example": "{\"mcpServers\": {\"remote\": {\"url\": \"https://example.com/mcp\", \"oauth\": {\"clientId\": \"registered-client\", \"clientSecret\": \"registered-secret\", \"redirectUri\": \"http://localhost:7778/oauth/callback\", \"oauthScopes\": [\"read\"]}}}}",
+      "bad_example": "{\"mcpServers\": {\"remote\": {\"url\": \"https://example.com/mcp\", \"oauth\": {\"clientSecret\": \"secret-without-client-id\", \"redirectUri\": \"https://example.com/callback\"}}}}"
     },
     {
       "id": "KR-PW-001",

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -380,6 +380,8 @@ rules:
     message: Import cache lock was poisoned by a prior validator panic; recovered stale data
     suggestion: A validator panicked while holding the import cache lock. Validation continues with recovered data, but results
       may be stale.
+  file_panic_error: 'Validation panicked while processing this file: %{error}'
+  file_panic_error_suggestion: Please report this as a bug with the file type and rule context
   xp_001:
     message: 'Claude-specific feature ''%{feature}'' in %{filename}: %{description}'
     suggestion: Move to CLAUDE.md or wrap in a Claude-specific section (e.g., '## Claude Code Specific')
@@ -803,14 +805,20 @@ rules:
     message: Kiro MCP server '%{server}' has potential hardcoded secret in env '%{env_key}'
     suggestion: Use environment variable indirection such as ${VAR_NAME} instead of plaintext secrets
   kr_mcp_006:
-    message: 'Kiro MCP server ''%{server}'' has invalid oauth.clientId configuration: %{reason}'
-    suggestion: Use oauth.clientId as a non-empty string only on HTTP(S) remote MCP servers, or remove the oauth block
+    message: 'Kiro MCP server ''%{server}'' has invalid OAuth configuration: %{reason}'
+    suggestion: Use the documented optional OAuth fields on an HTTP(S) remote MCP server, or remove the oauth block
     reasons:
       oauth_object: '''oauth'' must be an object'
-      missing_client_id: '''oauth.clientId'' is required when ''oauth'' is configured'
       client_id_string: '''oauth.clientId'' must be a string'
       client_id_non_empty: '''oauth.clientId'' must not be empty'
-      http_url: '''oauth.clientId'' can only be used with HTTP(S) remote MCP server URLs'
+      client_secret_string: '''oauth.clientSecret'' must be a string'
+      client_secret_non_empty: '''oauth.clientSecret'' must not be empty'
+      client_secret_requires_client_id: '''oauth.clientSecret'' is only meaningful alongside ''oauth.clientId'''
+      redirect_uri_string: '''oauth.redirectUri'' must be a string'
+      redirect_uri_format: '''oauth.redirectUri'' must use an HTTP loopback address with a valid port'
+      oauth_scopes_array: '''oauth.oauthScopes'' must be an array'
+      oauth_scopes_strings: '''oauth.oauthScopes'' entries must all be strings'
+      http_url: '''oauth'' can only be used with HTTP(S) remote MCP server URLs'
   pe_001:
     message: Critical keyword '%{keyword}' at %{percent} percent of document (40-60 percent is the 'lost in the middle' zone)
     suggestion: Move critical content to the start or end of the document for better recall

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -300,6 +300,8 @@ rules:
       pueden estar desactualizados
     suggestion: Un validador entró en pánico mientras sostenía el bloqueo de caché de importaciones. La validación continúa
       con datos recuperados, pero los resultados pueden estar desactualizados.
+  file_panic_error: 'La validación entró en pánico al procesar este archivo: %{error}'
+  file_panic_error_suggestion: Reporta esto como bug con el tipo de archivo y el contexto de la regla
   xp_001:
     message: 'Caracteristica especifica de Claude ''%{feature}'' en %{filename}: %{description}'
     suggestion: Mueve a CLAUDE.md o envuelve en una seccion especifica de Claude (ej., '## Claude Code Specific')
@@ -580,14 +582,20 @@ rules:
     message: El servidor MCP Kiro '%{server}' tiene un posible secreto hardcodeado en env '%{env_key}'
     suggestion: Usa referencias de variables de entorno como ${VAR_NAME} en lugar de secretos en texto plano
   kr_mcp_006:
-    message: 'El servidor MCP Kiro ''%{server}'' tiene una configuración oauth.clientId inválida: %{reason}'
-    suggestion: Usa oauth.clientId como cadena no vacía solo en servidores MCP remotos HTTP(S), o elimina el bloque oauth
+    message: 'El servidor MCP Kiro ''%{server}'' tiene una configuración OAuth inválida: %{reason}'
+    suggestion: Usa los campos OAuth opcionales documentados en un servidor MCP remoto HTTP(S), o elimina el bloque oauth
     reasons:
       oauth_object: '''oauth'' debe ser un objeto'
-      missing_client_id: '''oauth.clientId'' es obligatorio cuando ''oauth'' está configurado'
       client_id_string: '''oauth.clientId'' debe ser una cadena'
       client_id_non_empty: '''oauth.clientId'' no debe estar vacío'
-      http_url: '''oauth.clientId'' solo puede usarse con URLs de servidor MCP remoto HTTP(S)'
+      client_secret_string: '''oauth.clientSecret'' debe ser una cadena'
+      client_secret_non_empty: '''oauth.clientSecret'' no debe estar vacío'
+      client_secret_requires_client_id: '''oauth.clientSecret'' solo tiene sentido junto con ''oauth.clientId'''
+      redirect_uri_string: '''oauth.redirectUri'' debe ser una cadena'
+      redirect_uri_format: '''oauth.redirectUri'' debe usar una dirección de bucle local HTTP con un puerto válido'
+      oauth_scopes_array: '''oauth.oauthScopes'' debe ser un arreglo'
+      oauth_scopes_strings: Todas las entradas de 'oauth.oauthScopes' deben ser cadenas
+      http_url: '''oauth'' solo puede usarse con URLs de servidor MCP remoto HTTP(S)'
   cdx_pl_001:
     message: plugin.json debe estar ubicado en el directorio .codex-plugin/
     suggestion: Mueve plugin.json a .codex-plugin/plugin.json

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -285,6 +285,8 @@ rules:
   cache_poison:
     message: 导入缓存锁被先前的验证器崩溃毒化；恢复的数据可能已过期
     suggestion: 验证器在持有导入缓存锁时崩溃。验证将继续使用恢复的数据，但结果可能已过期。
+  file_panic_error: '验证此文件时发生崩溃: %{error}'
+  file_panic_error_suggestion: 请将此作为 bug 报告，并附上文件类型和规则上下文
   xp_001:
     message: '%{filename} 中的 Claude 特有功能 ''%{feature}'': %{description}'
     suggestion: 移至 CLAUDE.md 或包装在 Claude 特定部分中（例如 '## Claude Code Specific'）
@@ -558,14 +560,20 @@ rules:
     message: Kiro MCP 服务 '%{server}' 在 env '%{env_key}' 中存在潜在硬编码密钥
     suggestion: 使用 ${VAR_NAME} 形式的环境变量引用，避免明文密钥
   kr_mcp_006:
-    message: Kiro MCP 服务 '%{server}' 的 oauth.clientId 配置无效：%{reason}
-    suggestion: 仅在 HTTP(S) 远程 MCP 服务上使用非空字符串 oauth.clientId，或移除 oauth 块
+    message: Kiro MCP 服务 '%{server}' 的 OAuth 配置无效：%{reason}
+    suggestion: 在 HTTP(S) 远程 MCP 服务上使用文档支持的可选 OAuth 字段，或移除 oauth 块
     reasons:
       oauth_object: '''oauth'' 必须是对象'
-      missing_client_id: 配置 'oauth' 时必须提供 'oauth.clientId'
       client_id_string: '''oauth.clientId'' 必须是字符串'
       client_id_non_empty: '''oauth.clientId'' 不能为空'
-      http_url: '''oauth.clientId'' 只能用于 HTTP(S) 远程 MCP 服务器 URL'
+      client_secret_string: '''oauth.clientSecret'' 必须是字符串'
+      client_secret_non_empty: '''oauth.clientSecret'' 不能为空'
+      client_secret_requires_client_id: '''oauth.clientSecret'' 只能与 ''oauth.clientId'' 一起使用'
+      redirect_uri_string: '''oauth.redirectUri'' 必须是字符串'
+      redirect_uri_format: '''oauth.redirectUri'' 必须使用带有效端口的 HTTP 回环地址'
+      oauth_scopes_array: '''oauth.oauthScopes'' 必须是数组'
+      oauth_scopes_strings: '''oauth.oauthScopes'' 中的所有项都必须是字符串'
+      http_url: '''oauth'' 只能用于 HTTP(S) 远程 MCP 服务器 URL'
   cdx_pl_001:
     message: plugin.json 必须位于 .codex-plugin/ 目录中
     suggestion: 将 plugin.json 移至 .codex-plugin/plugin.json

--- a/website/docs/rules/generated/kr-mcp-006.md
+++ b/website/docs/rules/generated/kr-mcp-006.md
@@ -1,9 +1,9 @@
 ---
 id: kr-mcp-006
-title: "KR-MCP-006: Invalid OAuth Client ID Configuration - Kiro MCP"
+title: "KR-MCP-006: Invalid OAuth Configuration - Kiro MCP"
 sidebar_label: "KR-MCP-006"
-description: "agnix rule KR-MCP-006 checks for invalid oauth client id configuration in kiro mcp files. Severity: MEDIUM. See examples and fix guidance."
-keywords: ["KR-MCP-006", "invalid oauth client id configuration", "kiro mcp", "validation", "agnix", "linter"]
+description: "agnix rule KR-MCP-006 checks for invalid oauth configuration in kiro mcp files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["KR-MCP-006", "invalid oauth configuration", "kiro mcp", "validation", "agnix", "linter"]
 ---
 
 ## Summary
@@ -13,7 +13,7 @@ keywords: ["KR-MCP-006", "invalid oauth client id configuration", "kiro mcp", "v
 - **Category**: `Kiro MCP`
 - **Normative Level**: `SHOULD`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-05-14`
+- **Verified On**: `2026-07-11`
 
 ## Applicability
 
@@ -23,7 +23,8 @@ keywords: ["KR-MCP-006", "invalid oauth client id configuration", "kiro mcp", "v
 
 ## Evidence Sources
 
-- https://kiro.dev/changelog/cli/2-3/
+- https://kiro.dev/docs/cli/mcp/configuration/#oauth-configuration
+- https://kiro.dev/changelog/cli/2-12/
 
 ## Test Coverage Metadata
 
@@ -38,11 +39,11 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ### Invalid
 
 ```json
-{"mcpServers": {"local": {"command": "node", "args": ["server.js"], "oauth": {"clientId": "registered-client"}}}}
+{"mcpServers": {"remote": {"url": "https://example.com/mcp", "oauth": {"clientSecret": "secret-without-client-id", "redirectUri": "https://example.com/callback"}}}}
 ```
 
 ### Valid
 
 ```json
-{"mcpServers": {"remote": {"url": "https://example.com/mcp", "oauth": {"clientId": "registered-client"}}}}
+{"mcpServers": {"remote": {"url": "https://example.com/mcp", "oauth": {"clientId": "registered-client", "clientSecret": "registered-secret", "redirectUri": "http://localhost:7778/oauth/callback", "oauthScopes": ["read"]}}}}
 ```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -318,7 +318,7 @@ This section contains all `432` validation rules generated from `knowledge-base/
 | [KR-MCP-003](./generated/kr-mcp-003.md) | Missing Required Args | MEDIUM | Kiro MCP | No |
 | [KR-MCP-004](./generated/kr-mcp-004.md) | Invalid MCP URL | HIGH | Kiro MCP | No |
 | [KR-MCP-005](./generated/kr-mcp-005.md) | Duplicate MCP Server Names | MEDIUM | Kiro MCP | No |
-| [KR-MCP-006](./generated/kr-mcp-006.md) | Invalid OAuth Client ID Configuration | MEDIUM | Kiro MCP | No |
+| [KR-MCP-006](./generated/kr-mcp-006.md) | Invalid OAuth Configuration | MEDIUM | Kiro MCP | No |
 | [KR-PW-001](./generated/kr-pw-001.md) | Missing Required POWER.md Frontmatter Fields | HIGH | Kiro Powers | No |
 | [KR-PW-002](./generated/kr-pw-002.md) | Empty POWER.md Keywords Array | MEDIUM | Kiro Powers | No |
 | [KR-PW-003](./generated/kr-pw-003.md) | Empty POWER.md Body | MEDIUM | Kiro Powers | No |


### PR DESCRIPTION
## Summary

- update all eight tracked tool baselines and research review dates from a fresh live release sweep
- accept Codex CLI 0.144.1 feature, MCP, and managed-requirements keys
- validate Kiro CLI 2.12 OAuth fields, including DCR-compatible optional client IDs, loopback redirects, client secrets, and scopes
- restore canonical locale parity across the root, core, CLI, and LSP mirrors
- update generated rule metadata, documentation, changelog entries, and focused regression coverage

## Root cause

The automated release watch correctly detected upstream changes, but the repository baselines and research dates had not yet been reconciled. Codex and Kiro also introduced schema changes that would otherwise produce false positives. Independently, the locale mirrors on main had drifted from the canonical root catalogs, which caused the Linux locale-sync gate to fail.

## Validation

- live release sweep: 12 sources matched, 0 new, 0 skipped
- `cargo test --workspace`
- focused Codex and Kiro regression tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets` with only five untouched Rust 1.97 baseline lints allowed
- `bash scripts/check-locale-sync.sh`
- `node scripts/sync-rule-bookkeeping.js --check`
- `cargo run -p agnix-cli --bin agnix -- . --strict`

Closes #1181
Closes #1182
Closes #1183
Closes #1184
Closes #1185
Closes #1186
Closes #1187
Closes #1188