### PR TITLE
feat: add CC-SET-014, CC-SET-015, CC-HK-028 for Claude Code v2.1.207 changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 432 rules, 75+ sources, rules.json
+knowledge-base/     # 435 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-432 rules defined in `knowledge-base/rules.json` (source of truth)
+435 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 432 validation rules across 40 validators
+- 435 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SET-014: autoMode Setting Ignored in settings.local.json** (#1203). Claude Code v2.1.207 stopped reading `autoMode` from repo-resident `.claude/settings.local.json`; the new rule warns when the key is present there so users move it to `~/.claude/settings.json`.
+- **CC-SET-015: Dead pluginConfigs in Project-Level Settings** (#1203). Claude Code v2.1.207 removed support for `pluginConfigs` in project-level `.claude/settings.json` and `.claude/settings.local.json`; plugin option values are now only read from user settings, `--settings` files, and managed settings. The new rule warns on presence in the wrong tier.
+- **CC-HK-028: Rejected user_config Interpolation in Shell-Form Command** (#1203). Claude Code v2.1.207 rejects `${user_config.*}` in shell-form hook command strings at load time as a shell-injection fix; the rule flags (error) any command string containing the pattern and directs users to `$CLAUDE_PLUGIN_OPTION_<KEY>` or environment-passing instead. Rule count 432 → 435.
+
 ### Changed
 - **Tool release baselines**. Triaged the current release-watch batch and advanced Claude Code to `v2.1.206`, Codex CLI to `rust-v0.144.1`, OpenCode to `v1.17.18`, Kiro CLI to `2.12.0`, Cline to `cli-v3.0.39`, Cursor to `3.11.13`, amp to `the-dial`, and Gemini CLI to `v0.50.0` (closes #1181 through #1188). Releases without validated schema changes were classified as runtime, UI, provider, packaging, or news updates.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 432 rules, 75+ sources, rules.json
+knowledge-base/     # 435 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-432 rules defined in `knowledge-base/rules.json` (source of truth)
+435 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 432 validation rules across 40 validators
+- 435 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,11 @@ Rule IDs follow the format `[PREFIX]-[NUMBER]` where the prefix indicates the ru
 | `AMP-SK-` | 1 | AMP-SK-001 |
 | `AS-` | 14 | AS-001 through AS-006, AS-008 through AS-009, AS-011 through AS-013, AS-015 through AS-017 |
 | `CC-AG-` | 17 | CC-AG-001 through CC-AG-015, CC-AG-017, CC-AG-019 |
-| `CC-HK-` | 27 | CC-HK-001 through CC-HK-027 |
+| `CC-HK-` | 28 | CC-HK-001 through CC-HK-028 |
 | `CC-MEM-` | 13 | CC-MEM-001 through CC-MEM-012, CC-MEM-014 |
 | `CC-OS-` | 6 | CC-OS-001 through CC-OS-006 |
 | `CC-PL-` | 15 | CC-PL-001 through CC-PL-015 |
-| `CC-SET-` | 13 | CC-SET-001 through CC-SET-013 |
+| `CC-SET-` | 15 | CC-SET-001 through CC-SET-015 |
 | `CC-SK-` | 21 | CC-SK-001 through CC-SK-021 |
 | `CDX-` | 7 | CDX-000 through CDX-006 |
 | `CDX-AG-` | 7 | CDX-AG-001 through CDX-AG-007 |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>432 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>435 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 432 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 435 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -8,13 +8,13 @@
 | Type | Files | Rules |
 |------|-------|-------|
 | Skills | SKILL.md | 35 |
-| Hooks | settings.json | 27 |
+| Hooks | settings.json | 28 |
 | Memory (Claude Code) | CLAUDE.md, CLAUDE.local.md, .claude/rules/*.md | 13 |
 | Instructions (Cross-Tool) | AGENTS.md, AGENTS.local.md, AGENTS.override.md | 6 |
 | Agents | agents/*.md | 17 |
 | Plugins | plugin.json | 15 |
 | Claude Output Styles | .claude/output-styles/*.md | 6 |
-| Claude Settings | .claude/settings.json | 13 |
+| Claude Settings | .claude/settings.json | 15 |
 | Prompt Engineering | CLAUDE.md, AGENTS.md | 6 |
 | Cross-Platform | AGENTS.md | 9 |
 | MCP | tool definitions | 26 |

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # agnix Technical Reference
 
-> Linter for agent configs. 432 rules across 40 categories.
+> Linter for agent configs. 435 rules across 40 categories.
 
 
 ## What agnix Validates
@@ -62,7 +62,7 @@ agnix/
 │   ├── agnix-mcp/      # MCP server
 │   └── agnix-wasm/     # WebAssembly bindings
 ├── editors/            # Neovim, VS Code, JetBrains, Zed integrations
-├── knowledge-base/     # 432 rules documented
+├── knowledge-base/     # 435 rules documented
 
 ├── scripts/            # Build/dev automation scripts
 ├── website/            # Docusaurus documentation website

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -1218,6 +1218,21 @@ rules:
       auto-mode setting as a strict true/false toggle
     suggestion: Set autoMode.classifyAllShell to an unquoted true or false, or remove it to keep the default auto-mode
       classifier scope.
+  cc_set_014:
+    message: autoMode in .claude/settings.local.json is silently ignored as of Claude Code 2.1.207; the key is only read
+      from ~/.claude/settings.json
+    suggestion: Move autoMode configuration to ~/.claude/settings.json (your global user settings file) where Claude Code
+      2.1.207+ reads it.
+  cc_set_015:
+    message: pluginConfigs in project-level .claude settings is silently ignored since Claude Code 2.1.207; plugin option
+      values are only read from user settings, --settings files, and managed settings
+    suggestion: Move pluginConfigs to ~/.claude/settings.json (user-level), pass it via the --settings flag, or configure
+      it in managed settings; remove it from the project-level file.
+  cc_hk_028:
+    message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
+      load time as a shell-injection fix
+    suggestion: "Read the value inside the script via $CLAUDE_PLUGIN_OPTION_<KEY> (plugin hooks) or pass it through the\
+      \ environment; shell-form command strings can no longer interpolate ${user_config.*}."
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -742,6 +742,17 @@ rules:
       documenta esta configuracion de auto-mode como un interruptor true/false estricto
     suggestion: Establece autoMode.classifyAllShell en true o false sin comillas, o quitalo para conservar el alcance
       predeterminado del clasificador auto-mode.
+  cc_set_014:
+    message: autoMode en .claude/settings.local.json es ignorado silenciosamente desde Claude Code 2.1.207; la clave solo
+      se lee desde ~/.claude/settings.json
+    suggestion: Mueve la configuracion de autoMode a ~/.claude/settings.json (tu archivo de configuracion global de usuario)
+      donde Claude Code 2.1.207+ la lee.
+  cc_set_015:
+    message: pluginConfigs en la configuracion .claude a nivel de proyecto se ignora silenciosamente desde Claude Code
+      2.1.207; los valores de opciones de plugin solo se leen desde la configuracion de usuario, archivos --settings y
+      configuracion administrada
+    suggestion: Mueve pluginConfigs a ~/.claude/settings.json (nivel de usuario), pasalo mediante el indicador --settings,
+      o configuralo en la configuracion administrada; eliminalo del archivo a nivel de proyecto.
 
 
 # ===========================================================================

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -704,6 +704,12 @@ rules:
   cc_set_013:
     message: autoMode.classifyAllShell 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.193+ 将该 auto-mode 设置记录为严格的 true/false 开关
     suggestion: 将 autoMode.classifyAllShell 设置为不带引号的 true 或 false，或移除此字段以保留默认的 auto-mode 分类器范围。
+  cc_set_014:
+    message: Claude Code 2.1.207 起，.claude/settings.local.json 中的 autoMode 将被静默忽略；该键仅从 ~/.claude/settings.json 读取
+    suggestion: 将 autoMode 配置移至 ~/.claude/settings.json（全局用户配置文件），Claude Code 2.1.207+ 将从该文件读取。
+  cc_set_015:
+    message: 自 Claude Code 2.1.207 起，项目级 .claude 设置中的 pluginConfigs 会被静默忽略；插件选项值仅从用户设置、--settings 文件和托管设置中读取
+    suggestion: 将 pluginConfigs 移至 ~/.claude/settings.json（用户级），通过 --settings 标志传入，或在托管设置中配置；并从项目级文件中删除。
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -1218,6 +1218,21 @@ rules:
       auto-mode setting as a strict true/false toggle
     suggestion: Set autoMode.classifyAllShell to an unquoted true or false, or remove it to keep the default auto-mode
       classifier scope.
+  cc_set_014:
+    message: autoMode in .claude/settings.local.json is silently ignored as of Claude Code 2.1.207; the key is only read
+      from ~/.claude/settings.json
+    suggestion: Move autoMode configuration to ~/.claude/settings.json (your global user settings file) where Claude Code
+      2.1.207+ reads it.
+  cc_set_015:
+    message: pluginConfigs in project-level .claude settings is silently ignored since Claude Code 2.1.207; plugin option
+      values are only read from user settings, --settings files, and managed settings
+    suggestion: Move pluginConfigs to ~/.claude/settings.json (user-level), pass it via the --settings flag, or configure
+      it in managed settings; remove it from the project-level file.
+  cc_hk_028:
+    message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
+      load time as a shell-injection fix
+    suggestion: "Read the value inside the script via $CLAUDE_PLUGIN_OPTION_<KEY> (plugin hooks) or pass it through the\
+      \ environment; shell-form command strings can no longer interpolate ${user_config.*}."
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -742,6 +742,17 @@ rules:
       documenta esta configuracion de auto-mode como un interruptor true/false estricto
     suggestion: Establece autoMode.classifyAllShell en true o false sin comillas, o quitalo para conservar el alcance
       predeterminado del clasificador auto-mode.
+  cc_set_014:
+    message: autoMode en .claude/settings.local.json es ignorado silenciosamente desde Claude Code 2.1.207; la clave solo
+      se lee desde ~/.claude/settings.json
+    suggestion: Mueve la configuracion de autoMode a ~/.claude/settings.json (tu archivo de configuracion global de usuario)
+      donde Claude Code 2.1.207+ la lee.
+  cc_set_015:
+    message: pluginConfigs en la configuracion .claude a nivel de proyecto se ignora silenciosamente desde Claude Code
+      2.1.207; los valores de opciones de plugin solo se leen desde la configuracion de usuario, archivos --settings y
+      configuracion administrada
+    suggestion: Mueve pluginConfigs a ~/.claude/settings.json (nivel de usuario), pasalo mediante el indicador --settings,
+      o configuralo en la configuracion administrada; eliminalo del archivo a nivel de proyecto.
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -704,6 +704,12 @@ rules:
   cc_set_013:
     message: autoMode.classifyAllShell 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.193+ 将该 auto-mode 设置记录为严格的 true/false 开关
     suggestion: 将 autoMode.classifyAllShell 设置为不带引号的 true 或 false，或移除此字段以保留默认的 auto-mode 分类器范围。
+  cc_set_014:
+    message: Claude Code 2.1.207 起，.claude/settings.local.json 中的 autoMode 将被静默忽略；该键仅从 ~/.claude/settings.json 读取
+    suggestion: 将 autoMode 配置移至 ~/.claude/settings.json（全局用户配置文件），Claude Code 2.1.207+ 将从该文件读取。
+  cc_set_015:
+    message: 自 Claude Code 2.1.207 起，项目级 .claude 设置中的 pluginConfigs 会被静默忽略；插件选项值仅从用户设置、--settings 文件和托管设置中读取
+    suggestion: 将 pluginConfigs 移至 ~/.claude/settings.json（用户级），通过 --settings 标志传入，或在托管设置中配置；并从项目级文件中删除。
 
 
 # ===========================================================================

--- a/crates/agnix-core/src/file_types/detection.rs
+++ b/crates/agnix-core/src/file_types/detection.rs
@@ -426,6 +426,19 @@ pub fn detect_file_type(path: &Path) -> FileType {
         {
             FileType::CursorHooks
         }
+        // Claude Code plugin hooks configuration (<plugin-root>/hooks/hooks.json).
+        // Path-only heuristic: any hooks/hooks.json that is not the Copilot
+        // (.github/hooks/) or Cursor (.cursor/) layout is treated as Claude hooks.
+        // Accepted trade-off (same reasoning as CodexRequirements below): an
+        // unrelated project keeping a hooks/hooks.json would be linted as Claude
+        // hooks; the layout is uncommon enough to accept.
+        "hooks.json"
+            if parent_eq_ignore_ascii_case(parent, "hooks")
+                && !parent_eq_ignore_ascii_case(grandparent, ".github")
+                && !parent_eq_ignore_ascii_case(grandparent, ".cursor") =>
+        {
+            FileType::Hooks
+        }
         // Cursor cloud-agent environment configuration (.cursor/environment.json)
         name if name.eq_ignore_ascii_case("environment.json")
             && parent.is_some_and(|p| p.eq_ignore_ascii_case(".cursor")) =>
@@ -1631,6 +1644,37 @@ mod tests {
         assert_ne!(
             detect_file_type(Path::new(".kiro/settings/not-mcp.json")),
             FileType::KiroMcp
+        );
+    }
+
+    #[test]
+    fn detect_plugin_hooks_json_as_hooks() {
+        // Claude Code plugin hooks/hooks.json → FileType::Hooks
+        assert_eq!(
+            detect_file_type(Path::new("my-plugin/hooks/hooks.json")),
+            FileType::Hooks
+        );
+        assert_eq!(
+            detect_file_type(Path::new("project/plugins/my-plugin/hooks/hooks.json")),
+            FileType::Hooks
+        );
+    }
+
+    #[test]
+    fn detect_github_hooks_still_copilot_hooks() {
+        // .github/hooks/hooks.json must remain CopilotHooks
+        assert_eq!(
+            detect_file_type(Path::new(".github/hooks/hooks.json")),
+            FileType::CopilotHooks
+        );
+    }
+
+    #[test]
+    fn detect_cursor_hooks_still_cursor_hooks() {
+        // .cursor/hooks.json must remain CursorHooks (cursor guard)
+        assert_eq!(
+            detect_file_type(Path::new(".cursor/hooks.json")),
+            FileType::CursorHooks
         );
     }
 }

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -18,6 +18,8 @@
 //! - `respondToBashCommands` boolean check (CC-SET-011, added in Claude Code v2.1.186).
 //! - `sandbox.credentials` shape check (CC-SET-012, added in Claude Code v2.1.187).
 //! - `autoMode.classifyAllShell` boolean check (CC-SET-013, added in Claude Code v2.1.193).
+//! - autoMode ignored in settings.local.json (CC-SET-014, changed in Claude Code v2.1.207).
+//! - pluginConfigs dead in project-level settings (CC-SET-015, changed in Claude Code v2.1.207).
 //!
 //! Runs on FileType::Hooks (which covers `.claude/settings.json` -
 //! see `file_types/detection.rs`). Skips non-Claude Code settings paths
@@ -45,6 +47,8 @@ const RULE_IDS: &[&str] = &[
     "CC-SET-011",
     "CC-SET-012",
     "CC-SET-013",
+    "CC-SET-014",
+    "CC-SET-015",
 ];
 
 /// Allowed values for `worktree.baseRef` per Claude Code v2.1.133 release notes.
@@ -142,6 +146,14 @@ impl Validator for ClaudeSettingsValidator {
 
         if config.is_rule_enabled("CC-SET-013") {
             validate_auto_mode_classify_all_shell(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-014") {
+            validate_auto_mode_in_settings_local(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-015") {
+            validate_plugin_configs_scope(path, content, &value, &mut diagnostics);
         }
 
         diagnostics
@@ -1017,6 +1029,103 @@ fn validate_auto_mode_classify_all_shell(
             t!("rules.cc_set_013.message", actual = actual),
         )
         .with_suggestion(t!("rules.cc_set_013.suggestion")),
+    );
+}
+
+/// CC-SET-014: Warn when `autoMode` appears in `.claude/settings.local.json`.
+///
+/// Claude Code v2.1.207 stopped reading `autoMode` from the repo-resident
+/// `.claude/settings.local.json`; the key is silently ignored there. Auto
+/// mode configuration must live in `~/.claude/settings.json` instead.
+///
+/// Fires on any non-null value — the problem is presence in the wrong file,
+/// not value shape (CC-SET-013 covers the classifyAllShell shape and can
+/// co-fire). `null` is treated as field-absent, consistent with the rest of
+/// the CC-SET family. Does NOT fire on `settings.json` or
+/// `managed-settings.json` — `autoMode` is still read from those.
+fn validate_auto_mode_in_settings_local(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let is_local = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n == "settings.local.json")
+        .unwrap_or(false);
+    if !is_local {
+        return;
+    }
+
+    let Some(field_value) = value.get("autoMode") else {
+        return;
+    };
+    if field_value.is_null() {
+        return;
+    }
+
+    let line = find_key_line(content, "autoMode").unwrap_or(1);
+
+    diagnostics.push(
+        Diagnostic::warning(
+            path.to_path_buf(),
+            line,
+            0,
+            "CC-SET-014",
+            t!("rules.cc_set_014.message"),
+        )
+        .with_suggestion(t!("rules.cc_set_014.suggestion")),
+    );
+}
+
+/// CC-SET-015: Warn on `pluginConfigs` in project-level settings files.
+///
+/// Claude Code v2.1.207 changed where plugin option values are read: only
+/// user-level settings (`~/.claude/settings.json`), `--settings` files, and
+/// managed settings are honored. Repo-resident `.claude/settings.json` and
+/// `.claude/settings.local.json` no longer supply `pluginConfigs`; the key
+/// is silently ignored there. `managed-settings.json` IS honored, so it is
+/// skipped.
+///
+/// Fires on any non-null value; `null` is treated as field-absent,
+/// consistent with the CC-SET family. Note agnix lints repo checkouts —
+/// a user linting their home directory would hit a false positive on
+/// `~/.claude/settings.json`, the same accepted ambiguity discussed in the
+/// CC-SET-002 doc comment.
+fn validate_plugin_configs_scope(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let is_managed = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n == "managed-settings.json")
+        .unwrap_or(false);
+    if is_managed {
+        return;
+    }
+
+    let Some(field_value) = value.get("pluginConfigs") else {
+        return;
+    };
+    if field_value.is_null() {
+        return;
+    }
+
+    let line = find_key_line(content, "pluginConfigs").unwrap_or(1);
+
+    diagnostics.push(
+        Diagnostic::warning(
+            path.to_path_buf(),
+            line,
+            0,
+            "CC-SET-015",
+            t!("rules.cc_set_015.message"),
+        )
+        .with_suggestion(t!("rules.cc_set_015.suggestion")),
     );
 }
 
@@ -2599,5 +2708,200 @@ mod tests {
             &config,
         );
         assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-013"));
+    }
+
+    // ===== CC-SET-014: autoMode in settings.local.json =====
+
+    #[test]
+    fn test_auto_mode_in_settings_local_flags() {
+        let content = r#"{"autoMode": {"classifyAllShell": true}}"#;
+        let diagnostics = validate_at(".claude/settings.local.json", content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-014")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].level, crate::diagnostics::DiagnosticLevel::Warning);
+    }
+
+    #[test]
+    fn test_auto_mode_in_settings_json_does_not_flag() {
+        // autoMode is still read from settings.json — must not fire CC-SET-014.
+        let content = r#"{"autoMode": {"classifyAllShell": true}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-014"));
+    }
+
+    #[test]
+    fn test_auto_mode_in_managed_settings_does_not_flag() {
+        // managed-settings.json is honored — must not fire CC-SET-014.
+        let content = r#"{"autoMode": {"classifyAllShell": true}}"#;
+        let diagnostics = validate_at(".claude/managed-settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-014"));
+    }
+
+    #[test]
+    fn test_auto_mode_absent_in_settings_local_is_fine() {
+        let content = r#"{"model": "claude-sonnet-4"}"#;
+        let diagnostics = validate_at(".claude/settings.local.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-014"));
+    }
+
+    #[test]
+    fn test_auto_mode_null_in_settings_local_is_fine() {
+        let content = r#"{"autoMode": null}"#;
+        let diagnostics = validate_at(".claude/settings.local.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-014"));
+    }
+
+    #[test]
+    fn test_auto_mode_in_settings_local_fires_for_any_non_null_type() {
+        // object, string, bool, number, array — all must produce exactly 1 CC-SET-014
+        for content in &[
+            r#"{"autoMode": {"classifyAllShell": true}}"#,
+            r#"{"autoMode": "enabled"}"#,
+            r#"{"autoMode": true}"#,
+            r#"{"autoMode": 1}"#,
+            r#"{"autoMode": []}"#,
+        ] {
+            let diagnostics = validate_at(".claude/settings.local.json", content);
+            let count = diagnostics
+                .iter()
+                .filter(|d| d.rule == "CC-SET-014")
+                .count();
+            assert_eq!(count, 1, "expected 1 CC-SET-014 for content: {}", content);
+        }
+    }
+
+    #[test]
+    fn test_auto_mode_in_settings_local_line_points_at_key() {
+        let content =
+            "{\n  \"model\": \"claude-sonnet-4\",\n  \"autoMode\": {\"classifyAllShell\": true}\n}";
+        let diagnostics = validate_at(".claude/settings.local.json", content);
+        let hit = diagnostics
+            .iter()
+            .find(|d| d.rule == "CC-SET-014")
+            .expect("CC-SET-014 diagnostic");
+        assert_eq!(hit.line, 3, "line must point at the autoMode key");
+    }
+
+    #[test]
+    fn test_auto_mode_in_settings_local_can_be_disabled() {
+        let mut builder = LintConfig::builder();
+        builder.disable_rule("CC-SET-014");
+        let config = builder.build().unwrap();
+        let validator = ClaudeSettingsValidator;
+        let path = PathBuf::from(".claude/settings.local.json");
+        let diagnostics = validator.validate(
+            &path,
+            r#"{"autoMode": {"classifyAllShell": true}}"#,
+            &config,
+        );
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-014"));
+    }
+
+    #[test]
+    fn test_auto_mode_in_settings_local_coexists_with_cc_set_013() {
+        // classifyAllShell with a bad type in settings.local.json should fire
+        // both CC-SET-013 (wrong type) and CC-SET-014 (wrong file).
+        let content = r#"{"autoMode": {"classifyAllShell": "true"}}"#;
+        let diagnostics = validate_at(".claude/settings.local.json", content);
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-013"));
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-014"));
+    }
+
+    // ===== CC-SET-015: pluginConfigs in project-level settings =====
+
+    #[test]
+    fn test_plugin_configs_in_settings_json_flags() {
+        let content = r#"{"pluginConfigs": {"my-plugin": {"apiKey": "abc"}}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-015")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].level, crate::diagnostics::DiagnosticLevel::Warning);
+    }
+
+    #[test]
+    fn test_plugin_configs_in_settings_local_flags() {
+        let content = r#"{"pluginConfigs": {"my-plugin": {"apiKey": "abc"}}}"#;
+        let diagnostics = validate_at(".claude/settings.local.json", content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-015")
+            .collect();
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn test_plugin_configs_in_managed_settings_does_not_flag() {
+        // managed-settings is an honored tier — must not fire CC-SET-015.
+        let content = r#"{"pluginConfigs": {"my-plugin": {"apiKey": "abc"}}}"#;
+        let diagnostics = validate_at(".claude/managed-settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-015"));
+    }
+
+    #[test]
+    fn test_plugin_configs_absent_is_fine() {
+        let content = r#"{"model": "claude-sonnet-4"}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-015"));
+    }
+
+    #[test]
+    fn test_plugin_configs_null_is_fine() {
+        let content = r#"{"pluginConfigs": null}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-015"));
+    }
+
+    #[test]
+    fn test_plugin_configs_empty_object_flags() {
+        // An empty object is still a non-null value — the presence of the key
+        // is the problem regardless of whether nested config is populated.
+        let content = r#"{"pluginConfigs": {}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-015")
+            .collect();
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn test_plugin_configs_line_points_at_key() {
+        let content = "{\n  \"model\": \"claude-sonnet-4\",\n  \"pluginConfigs\": {\"p\": {}}\n}";
+        let diagnostics = validate_at(".claude/settings.json", content);
+        let hit = diagnostics
+            .iter()
+            .find(|d| d.rule == "CC-SET-015")
+            .expect("CC-SET-015 diagnostic");
+        assert_eq!(hit.line, 3, "line must point at the pluginConfigs key");
+    }
+
+    #[test]
+    fn test_plugin_configs_can_be_disabled() {
+        let mut builder = LintConfig::builder();
+        builder.disable_rule("CC-SET-015");
+        let config = builder.build().unwrap();
+        let validator = ClaudeSettingsValidator;
+        let path = PathBuf::from(".claude/settings.json");
+        let diagnostics = validator.validate(
+            &path,
+            r#"{"pluginConfigs": {"my-plugin": {"apiKey": "abc"}}}"#,
+            &config,
+        );
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-015"));
+    }
+
+    #[test]
+    fn test_plugin_configs_coexists_with_other_cc_set_rules() {
+        // Both CC-SET-002 (channelsEnabled) and CC-SET-015 fire independently.
+        let content = r#"{"channelsEnabled": "true", "pluginConfigs": {"p": {}}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-002"));
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-015"));
     }
 }

--- a/crates/agnix-core/src/rules/hooks/mod.rs
+++ b/crates/agnix-core/src/rules/hooks/mod.rs
@@ -1,4 +1,4 @@
-//! Hooks validation rules (CC-HK-001 to CC-HK-027)
+//! Hooks validation rules (CC-HK-001 to CC-HK-028)
 
 use crate::{
     config::PerFileLintConfig,
@@ -40,6 +40,7 @@ const RULE_IDS: &[&str] = &[
     "CC-HK-025",
     "CC-HK-026",
     "CC-HK-027",
+    "CC-HK-028",
 ];
 
 pub struct HooksValidator;
@@ -118,6 +119,33 @@ fn validate_cc_hk_009_dangerous_patterns(
                 t!("rules.cc_hk_009.message", reason = reason),
             )
             .with_suggestion(t!("rules.cc_hk_009.suggestion", pattern = pattern)),
+        );
+    }
+}
+
+/// CC-HK-028: `${user_config.*}` interpolation in a shell-form command string.
+///
+/// Claude Code v2.1.207 rejects `${user_config.<key>}` inside a command
+/// hook's shell-form `command` string at load time (shell-injection fix).
+/// Values must instead be read inside the script via
+/// `$CLAUDE_PLUGIN_OPTION_<KEY>` (plugin hooks) or passed through the
+/// environment.
+fn validate_cc_hk_028_user_config_interpolation(
+    command: &str,
+    hook_location: &str,
+    path: &Path,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if command.contains("${user_config.") {
+        diagnostics.push(
+            Diagnostic::error(
+                path.to_path_buf(),
+                1,
+                0,
+                "CC-HK-028",
+                t!("rules.cc_hk_028.message", location = hook_location),
+            )
+            .with_suggestion(t!("rules.cc_hk_028.suggestion")),
         );
     }
 }
@@ -639,6 +667,16 @@ impl Validator for HooksValidator {
                                 if config.is_rule_enabled("CC-HK-009") {
                                     validate_cc_hk_009_dangerous_patterns(
                                         cmd,
+                                        path,
+                                        &mut diagnostics,
+                                    );
+                                }
+
+                                // CC-HK-028: ${user_config.*} interpolation rejected at load time
+                                if config.is_rule_enabled("CC-HK-028") {
+                                    validate_cc_hk_028_user_config_interpolation(
+                                        cmd,
+                                        &hook_location,
                                         path,
                                         &mut diagnostics,
                                     );

--- a/crates/agnix-core/src/rules/hooks/tests.rs
+++ b/crates/agnix-core/src/rules/hooks/tests.rs
@@ -5111,3 +5111,164 @@ fn test_cc_hk_mcp_tool_both_missing_flags_both() {
     assert_eq!(cc_026.len(), 1);
     assert_eq!(cc_027.len(), 1);
 }
+
+// ===== Detection safety gate: hooks validator is quiet on non-hooks JSON =====
+
+#[test]
+fn test_hooks_validator_quiet_on_json_without_hooks_key() {
+    // Safety gate for detection.rs extension: if a hooks/hooks.json path routes
+    // to the HooksValidator, a JSON object without a "hooks" key must produce
+    // NO spurious diagnostics (SettingsSchema.hooks defaults to empty map).
+    let contents = [r#"{}"#, r#"{"foo": 1}"#, r#"{"unrelated": true}"#];
+    for content in &contents {
+        let validator = HooksValidator;
+        let path = std::path::Path::new("my-plugin/hooks/hooks.json");
+        let diagnostics = validator.validate(path, content, &LintConfig::default());
+        // Filter out CC-HK-010 (timeout) and CC-HK-012 (parse) which might
+        // fire on structural issues; we care about zero spurious structural errors.
+        let non_timeout: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule != "CC-HK-010" && d.rule != "CC-HK-012")
+            .collect();
+        assert!(
+            non_timeout.is_empty(),
+            "hooks validator must be quiet on non-hooks JSON {}: got {:?}",
+            content,
+            non_timeout
+                .iter()
+                .map(|d| (&d.rule, &d.message))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+// ===== CC-HK-028: ${user_config.*} interpolation rejected =====
+
+#[test]
+fn test_cc_hk_028_user_config_interpolation_flags() {
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        { "type": "command", "command": "my-script ${user_config.api_key}", "timeout": 30 }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    let diagnostics = validate(content);
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-HK-028")
+        .collect();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].level, DiagnosticLevel::Error);
+}
+
+#[test]
+fn test_cc_hk_028_env_var_alternative_is_fine() {
+    // $CLAUDE_PLUGIN_OPTION_API_KEY is the documented replacement — must not flag.
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        { "type": "command", "command": "my-script $CLAUDE_PLUGIN_OPTION_API_KEY", "timeout": 30 }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    let diagnostics = validate(content);
+    assert!(diagnostics.iter().all(|d| d.rule != "CC-HK-028"));
+}
+
+#[test]
+fn test_cc_hk_028_prompt_type_does_not_flag() {
+    // The rule only inspects command-type command strings, not prompt strings.
+    let content = r#"{
+        "hooks": {
+            "Stop": [
+                {
+                    "hooks": [
+                        { "type": "prompt", "prompt": "Use ${user_config.label} format", "timeout": 30 }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    let diagnostics = validate(content);
+    assert!(
+        diagnostics.iter().all(|d| d.rule != "CC-HK-028"),
+        "CC-HK-028 must not fire on prompt-type hooks"
+    );
+}
+
+#[test]
+fn test_cc_hk_028_two_hooks_one_bad_one_diagnostic() {
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        { "type": "command", "command": "safe-cmd $ENV_VAR", "timeout": 30 },
+                        { "type": "command", "command": "bad-cmd ${user_config.key}", "timeout": 30 }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    let diagnostics = validate(content);
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-HK-028")
+        .collect();
+    assert_eq!(hits.len(), 1);
+}
+
+#[test]
+fn test_cc_hk_028_multiple_refs_in_one_command_one_diagnostic() {
+    // Multiple ${user_config.*} references in a single command string → 1 diagnostic.
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        { "type": "command", "command": "cmd ${user_config.a} ${user_config.b}", "timeout": 30 }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    let diagnostics = validate(content);
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-HK-028")
+        .collect();
+    assert_eq!(hits.len(), 1);
+}
+
+#[test]
+fn test_cc_hk_028_can_be_disabled() {
+    let mut config = LintConfig::default();
+    config.rules_mut().disabled_rules = vec!["CC-HK-028".to_string()];
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        { "type": "command", "command": "cmd ${user_config.key}", "timeout": 30 }
+                    ]
+                }
+            ]
+        }
+    }"#;
+    let diagnostics = validate_with_config(content, &config);
+    assert!(diagnostics.iter().all(|d| d.rule != "CC-HK-028"));
+}

--- a/crates/agnix-lsp/README.md
+++ b/crates/agnix-lsp/README.md
@@ -81,7 +81,7 @@ The extension automatically downloads the `agnix-lsp` binary. See `editors/zed/R
 
 - Real-time diagnostics as you type (via textDocument/didChange)
 - Real-time diagnostics on file open and save
-- Supports all agnix validation rules (432 rules)
+- Supports all agnix validation rules (435 rules)
 - Project-level validation for cross-file rules (AGM-006, XP-004/005/006, VER-001)
 
 - Maps diagnostic severity levels (Error, Warning, Info)

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -1218,6 +1218,21 @@ rules:
       auto-mode setting as a strict true/false toggle
     suggestion: Set autoMode.classifyAllShell to an unquoted true or false, or remove it to keep the default auto-mode
       classifier scope.
+  cc_set_014:
+    message: autoMode in .claude/settings.local.json is silently ignored as of Claude Code 2.1.207; the key is only read
+      from ~/.claude/settings.json
+    suggestion: Move autoMode configuration to ~/.claude/settings.json (your global user settings file) where Claude Code
+      2.1.207+ reads it.
+  cc_set_015:
+    message: pluginConfigs in project-level .claude settings is silently ignored since Claude Code 2.1.207; plugin option
+      values are only read from user settings, --settings files, and managed settings
+    suggestion: Move pluginConfigs to ~/.claude/settings.json (user-level), pass it via the --settings flag, or configure
+      it in managed settings; remove it from the project-level file.
+  cc_hk_028:
+    message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
+      load time as a shell-injection fix
+    suggestion: "Read the value inside the script via $CLAUDE_PLUGIN_OPTION_<KEY> (plugin hooks) or pass it through the\
+      \ environment; shell-form command strings can no longer interpolate ${user_config.*}."
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -742,6 +742,17 @@ rules:
       documenta esta configuracion de auto-mode como un interruptor true/false estricto
     suggestion: Establece autoMode.classifyAllShell en true o false sin comillas, o quitalo para conservar el alcance
       predeterminado del clasificador auto-mode.
+  cc_set_014:
+    message: autoMode en .claude/settings.local.json es ignorado silenciosamente desde Claude Code 2.1.207; la clave solo
+      se lee desde ~/.claude/settings.json
+    suggestion: Mueve la configuracion de autoMode a ~/.claude/settings.json (tu archivo de configuracion global de usuario)
+      donde Claude Code 2.1.207+ la lee.
+  cc_set_015:
+    message: pluginConfigs en la configuracion .claude a nivel de proyecto se ignora silenciosamente desde Claude Code
+      2.1.207; los valores de opciones de plugin solo se leen desde la configuracion de usuario, archivos --settings y
+      configuracion administrada
+    suggestion: Mueve pluginConfigs a ~/.claude/settings.json (nivel de usuario), pasalo mediante el indicador --settings,
+      o configuralo en la configuracion administrada; eliminalo del archivo a nivel de proyecto.
 
 
 # ===========================================================================

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -704,6 +704,12 @@ rules:
   cc_set_013:
     message: autoMode.classifyAllShell 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.193+ 将该 auto-mode 设置记录为严格的 true/false 开关
     suggestion: 将 autoMode.classifyAllShell 设置为不带引号的 true 或 false，或移除此字段以保留默认的 auto-mode 分类器范围。
+  cc_set_014:
+    message: Claude Code 2.1.207 起，.claude/settings.local.json 中的 autoMode 将被静默忽略；该键仅从 ~/.claude/settings.json 读取
+    suggestion: 将 autoMode 配置移至 ~/.claude/settings.json（全局用户配置文件），Claude Code 2.1.207+ 将从该文件读取。
+  cc_set_015:
+    message: 自 Claude Code 2.1.207 起，项目级 .claude 设置中的 pluginConfigs 会被静默忽略；插件选项值仅从用户设置、--settings 文件和托管设置中读取
+    suggestion: 将 pluginConfigs 移至 ~/.claude/settings.json（用户级），通过 --settings 标志传入，或在托管设置中配置；并从项目级文件中删除。
 
 
 # ===========================================================================

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 432,
-  "last_updated": "2026-07-10",
+  "total_rules": 435,
+  "last_updated": "2026-07-15",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -2060,6 +2060,47 @@
       "bad_example": "{ \"type\": \"mcp_tool\", \"server\": \"my_server\" }"
     },
     {
+      "id": "CC-HK-028",
+      "name": "Rejected user_config Interpolation in Shell-Form Command",
+      "severity": "HIGH",
+      "category": "claude-hooks",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+        ],
+        "verified_on": "2026-07-15",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.207"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{ \"type\": \"command\", \"command\": \"my-script $CLAUDE_PLUGIN_OPTION_API_KEY\" }",
+      "bad_example": "{ \"type\": \"command\", \"command\": \"my-script ${user_config.api_key}\" }",
+      "security": {
+        "cwe": [
+          "CWE-78"
+        ],
+        "owasp": [
+          "A03:2021"
+        ],
+        "vulnerability_class": "command-injection",
+        "subcategory": "vuln",
+        "confidence": "HIGH",
+        "likelihood": "MEDIUM",
+        "impact": "HIGH"
+      }
+    },
+    {
       "id": "CC-MEM-001",
       "name": "Invalid Import Path",
       "severity": "HIGH",
@@ -3974,6 +4015,62 @@
       },
       "good_example": "{\n  \"autoMode\": {\"classifyAllShell\": true}\n}",
       "bad_example": "{\n  \"autoMode\": {\"classifyAllShell\": \"true\"}\n}"
+    },
+    {
+      "id": "CC-SET-014",
+      "name": "autoMode Setting Ignored in settings.local.json",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+        ],
+        "verified_on": "2026-07-15",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.207"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"model\": \"claude-sonnet-4\"\n}",
+      "bad_example": "{\n  \"autoMode\": {\"classifyAllShell\": true}\n}"
+    },
+    {
+      "id": "CC-SET-015",
+      "name": "Dead pluginConfigs in Project-Level Settings",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+        ],
+        "verified_on": "2026-07-15",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.207"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"model\": \"claude-sonnet-4\"\n}",
+      "bad_example": "{\n  \"pluginConfigs\": {\"my-plugin\": {\"apiKey\": \"abc\"}}\n}"
     },
     {
       "id": "CDX-000",
@@ -12479,7 +12576,7 @@
     },
     "claude-hooks": {
       "prefix": "CC-HK",
-      "count": 27,
+      "count": 28,
       "description": "Claude Code Hooks rules"
     },
     "claude-agents": {
@@ -12659,7 +12756,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 13,
+      "count": 15,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -300,6 +300,6 @@ cargo install agnix-lsp
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for frontmatter fields
-- 432 validation rules
+- 435 validation rules
 - Status bar indicator (VS Code)
 - Syntax highlighting for SKILL.md (VS Code)

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,7 +3,7 @@
 Real-time validation for AI agent configuration files in VS Code.
 Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix).
 
-**432 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
+**435 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
 
 
 ## Features
@@ -11,7 +11,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Real-time validation** - Diagnostics as you type
 - **Context-aware completions** - Frontmatter keys, values, and snippets
 - **JSON Schema validation and autocomplete for `.agnix.toml` config files**
-- **Validates 432 rules** - From official specs and best practices
+- **Validates 435 rules** - From official specs and best practices
 
 - **Diagnostics panel** - Sidebar tree view of all issues by file
 - **CodeLens** - Rule info shown inline above problematic lines
@@ -45,7 +45,7 @@ Access via Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | `agnix: Fix All Issues in File` | `Ctrl+Shift+.` | Apply all available fixes |
 | `agnix: Preview Fixes` | - | Browse fixes with diff preview |
 | `agnix: Fix All Safe Issues` | `Ctrl+Alt+.` | Apply only safe fixes |
-| `agnix: Show All Rules` | - | Browse 432 rules by category |
+| `agnix: Show All Rules` | - | Browse 435 rules by category |
 
 | `agnix: Show Rule Documentation` | - | Open docs for a rule (via CodeLens) |
 | `agnix: Ignore Rule in Project` | - | Add rule to `.agnix.toml` disabled list |

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 432 validation rules across 40 categories, sourced from 75+ references
+> 435 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 432 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 435 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (432 rules)
+├── VALIDATION-RULES.md             # Master validation reference (435 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **432 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **435 rules** |
 
 
 ### Validation Rules by Category
@@ -93,11 +93,11 @@ knowledge-base/
 | Amp Checks | 4 | 2 | 2 | 0 | 3 |
 | Amp Skills | 1 | 0 | 1 | 0 | 1 |
 | Claude Agents | 17 | 12 | 4 | 1 | 10 |
-| Claude Hooks | 27 | 14 | 8 | 5 | 16 |
+| Claude Hooks | 28 | 15 | 8 | 5 | 16 |
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 13 | 0 | 13 | 0 | 0 |
+| Claude Settings | 15 | 0 | 15 | 0 | 0 |
 | Claude Skills | 21 | 11 | 9 | 1 | 13 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **432** | **212** | **191** | **29** | **127** |
+| **TOTAL** | **435** | **213** | **193** | **29** | **127** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 432 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 435 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     432 rules
+Validation Rules:     435 rules
 Auto-Fixable Rules:   127 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 432 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 435 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -454,6 +454,20 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 **Fix**: Manual - set `autoMode.classifyAllShell` to an unquoted `true` or `false`.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.193 (added `autoMode.classifyAllShell`)
 
+<a id="cc-set-014"></a>
+### CC-SET-014 [MEDIUM] autoMode Setting Ignored in settings.local.json
+**Requirement**: `autoMode` SHOULD NOT be placed in `.claude/settings.local.json`. As of Claude Code v2.1.207, auto mode no longer reads `autoMode` from the repo-resident local settings file; the key is silently ignored there and is only read from `~/.claude/settings.json`.
+**Detection**: Parse `.claude/settings.local.json` only (not `settings.json`, not `managed-settings.json`); flag (warning) any non-null value for the top-level `autoMode` key. Fires on any value type — the rule is about presence in the wrong file, not value shape. `null` values and absent keys are not flagged.
+**Fix**: Manual - move `autoMode` (with its nested keys) from `.claude/settings.local.json` to `~/.claude/settings.json`.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.207 (auto mode no longer reads `autoMode` from repo-resident `settings.local.json`)
+
+<a id="cc-set-015"></a>
+### CC-SET-015 [MEDIUM] Dead pluginConfigs in Project-Level Settings
+**Requirement**: `pluginConfigs` SHOULD NOT be present in project-level `.claude/settings.json` or `.claude/settings.local.json` for Claude Code 2.1.207+. As of that release, plugin option values are only read from user-level settings (`~/.claude/settings.json`), `--settings` files, and managed settings; project-level `pluginConfigs` is silently ignored.
+**Detection**: Parse `settings.json` / `settings.local.json` under `.claude/`; flag (warning) any non-null value for the top-level `pluginConfigs` key. `null` values and absent keys are not flagged. `managed-settings.json` is excluded — the managed tier is still honored.
+**Fix**: Manual - move `pluginConfigs` to `~/.claude/settings.json` (user-level), pass it via the `--settings` flag, or configure it in managed settings; then remove it from the project-level file.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.207 (project-level `pluginConfigs` no longer read)
+
 ---
 
 ## PER-CLIENT SKILL RULES
@@ -857,6 +871,13 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 **Detection**: Walk `hooks.*[*].hooks[*]`; for entries with `type == "mcp_tool"`, flag when `tool` is absent, not a string, or the empty string
 **Fix**: Manual (add `"tool": "<tool-name>"`)
 **Source**: code.claude.com/docs/en/hooks#mcp-tool-hook-fields (Claude Code v2.1.118+)
+
+<a id="cc-hk-028"></a>
+### CC-HK-028 [HIGH] Rejected user_config Interpolation in Shell-Form Command
+**Requirement**: A command hook's `command` string MUST NOT contain `${user_config.*}` interpolation. Claude Code v2.1.207 rejects it at load time as a shell-injection fix; values must be read inside the script via `$CLAUDE_PLUGIN_OPTION_<KEY>` (plugin hooks) or passed through the environment.
+**Detection**: Walk command-type hook entries; flag (error) when the `command` string contains the substring `${user_config.`.
+**Fix**: Manual - replace `${user_config.<key>}` with `$CLAUDE_PLUGIN_OPTION_<KEY>` read inside the script, or restructure to pass the value via the environment.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.207 (shell-injection fix rejecting `${user_config.*}` in shell-form commands)
 
 ---
 
@@ -3469,11 +3490,11 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Amp Checks | 4 | 2 | 2 | 0 | 3 |
 | Amp Skills | 1 | 0 | 1 | 0 | 1 |
 | Claude Agents | 17 | 12 | 4 | 1 | 10 |
-| Claude Hooks | 27 | 14 | 8 | 5 | 16 |
+| Claude Hooks | 28 | 15 | 8 | 5 | 16 |
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 13 | 0 | 13 | 0 | 0 |
+| Claude Settings | 15 | 0 | 15 | 0 | 0 |
 | Claude Skills | 21 | 11 | 9 | 1 | 13 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -3504,7 +3525,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **432** | **212** | **191** | **29** | **127** |
+| **TOTAL** | **435** | **213** | **193** | **29** | **127** |
 
 
 ---
@@ -3534,8 +3555,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 432 validation rules across 40 categories
+**Total Coverage**: 435 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 212 HIGH, 191 MEDIUM, 29 LOW
+**Certainty**: 213 HIGH, 193 MEDIUM, 29 LOW
 **Auto-Fixable**: 127 rules (29%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 432,
-  "last_updated": "2026-07-10",
+  "total_rules": 435,
+  "last_updated": "2026-07-15",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -2060,6 +2060,47 @@
       "bad_example": "{ \"type\": \"mcp_tool\", \"server\": \"my_server\" }"
     },
     {
+      "id": "CC-HK-028",
+      "name": "Rejected user_config Interpolation in Shell-Form Command",
+      "severity": "HIGH",
+      "category": "claude-hooks",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+        ],
+        "verified_on": "2026-07-15",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.207"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{ \"type\": \"command\", \"command\": \"my-script $CLAUDE_PLUGIN_OPTION_API_KEY\" }",
+      "bad_example": "{ \"type\": \"command\", \"command\": \"my-script ${user_config.api_key}\" }",
+      "security": {
+        "cwe": [
+          "CWE-78"
+        ],
+        "owasp": [
+          "A03:2021"
+        ],
+        "vulnerability_class": "command-injection",
+        "subcategory": "vuln",
+        "confidence": "HIGH",
+        "likelihood": "MEDIUM",
+        "impact": "HIGH"
+      }
+    },
+    {
       "id": "CC-MEM-001",
       "name": "Invalid Import Path",
       "severity": "HIGH",
@@ -3974,6 +4015,62 @@
       },
       "good_example": "{\n  \"autoMode\": {\"classifyAllShell\": true}\n}",
       "bad_example": "{\n  \"autoMode\": {\"classifyAllShell\": \"true\"}\n}"
+    },
+    {
+      "id": "CC-SET-014",
+      "name": "autoMode Setting Ignored in settings.local.json",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+        ],
+        "verified_on": "2026-07-15",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.207"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"model\": \"claude-sonnet-4\"\n}",
+      "bad_example": "{\n  \"autoMode\": {\"classifyAllShell\": true}\n}"
+    },
+    {
+      "id": "CC-SET-015",
+      "name": "Dead pluginConfigs in Project-Level Settings",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+        ],
+        "verified_on": "2026-07-15",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.207"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"model\": \"claude-sonnet-4\"\n}",
+      "bad_example": "{\n  \"pluginConfigs\": {\"my-plugin\": {\"apiKey\": \"abc\"}}\n}"
     },
     {
       "id": "CDX-000",
@@ -12479,7 +12576,7 @@
     },
     "claude-hooks": {
       "prefix": "CC-HK",
-      "count": 27,
+      "count": 28,
       "description": "Claude Code Hooks rules"
     },
     "claude-agents": {
@@ -12659,7 +12756,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 13,
+      "count": 15,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1218,6 +1218,21 @@ rules:
       auto-mode setting as a strict true/false toggle
     suggestion: Set autoMode.classifyAllShell to an unquoted true or false, or remove it to keep the default auto-mode
       classifier scope.
+  cc_set_014:
+    message: autoMode in .claude/settings.local.json is silently ignored as of Claude Code 2.1.207; the key is only read
+      from ~/.claude/settings.json
+    suggestion: Move autoMode configuration to ~/.claude/settings.json (your global user settings file) where Claude Code
+      2.1.207+ reads it.
+  cc_set_015:
+    message: pluginConfigs in project-level .claude settings is silently ignored since Claude Code 2.1.207; plugin option
+      values are only read from user settings, --settings files, and managed settings
+    suggestion: Move pluginConfigs to ~/.claude/settings.json (user-level), pass it via the --settings flag, or configure
+      it in managed settings; remove it from the project-level file.
+  cc_hk_028:
+    message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
+      load time as a shell-injection fix
+    suggestion: "Read the value inside the script via $CLAUDE_PLUGIN_OPTION_<KEY> (plugin hooks) or pass it through the\
+      \ environment; shell-form command strings can no longer interpolate ${user_config.*}."
   cdx_pl_015:
     message: '''skills'' must be a string path, not %{actual}'
     suggestion: Set 'skills' to a relative path string such as './skills', or remove the field

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -742,6 +742,17 @@ rules:
       documenta esta configuracion de auto-mode como un interruptor true/false estricto
     suggestion: Establece autoMode.classifyAllShell en true o false sin comillas, o quitalo para conservar el alcance
       predeterminado del clasificador auto-mode.
+  cc_set_014:
+    message: autoMode en .claude/settings.local.json es ignorado silenciosamente desde Claude Code 2.1.207; la clave solo
+      se lee desde ~/.claude/settings.json
+    suggestion: Mueve la configuracion de autoMode a ~/.claude/settings.json (tu archivo de configuracion global de usuario)
+      donde Claude Code 2.1.207+ la lee.
+  cc_set_015:
+    message: pluginConfigs en la configuracion .claude a nivel de proyecto se ignora silenciosamente desde Claude Code
+      2.1.207; los valores de opciones de plugin solo se leen desde la configuracion de usuario, archivos --settings y
+      configuracion administrada
+    suggestion: Mueve pluginConfigs a ~/.claude/settings.json (nivel de usuario), pasalo mediante el indicador --settings,
+      o configuralo en la configuracion administrada; eliminalo del archivo a nivel de proyecto.
 
 
 # ===========================================================================

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -704,6 +704,12 @@ rules:
   cc_set_013:
     message: autoMode.classifyAllShell 存在时必须是布尔值 (实际为 %{actual}); Claude Code 2.1.193+ 将该 auto-mode 设置记录为严格的 true/false 开关
     suggestion: 将 autoMode.classifyAllShell 设置为不带引号的 true 或 false，或移除此字段以保留默认的 auto-mode 分类器范围。
+  cc_set_014:
+    message: Claude Code 2.1.207 起，.claude/settings.local.json 中的 autoMode 将被静默忽略；该键仅从 ~/.claude/settings.json 读取
+    suggestion: 将 autoMode 配置移至 ~/.claude/settings.json（全局用户配置文件），Claude Code 2.1.207+ 将从该文件读取。
+  cc_set_015:
+    message: 自 Claude Code 2.1.207 起，项目级 .claude 设置中的 pluginConfigs 会被静默忽略；插件选项值仅从用户设置、--settings 文件和托管设置中读取
+    suggestion: 将 pluginConfigs 移至 ~/.claude/settings.json（用户级），通过 --settings 标志传入，或在托管设置中配置；并从项目级文件中删除。
 
 
 # ===========================================================================

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.37.5",
-  "description": "Lint agent configurations before they break your workflow. 432 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 435 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "aviarchi1994@gmail.com",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 432 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 435 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 432 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 435 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 432 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 435 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 432 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 435 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -73,6 +73,6 @@ GitHub Copilot validation is enabled by default and can be targeted in config wi
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 432 rules
+- [Rules Reference](./rules/index.md) - browse all 435 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 432 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 435 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 432 rules derived from official specs and real-world testing
+- **Validates** configuration files against 435 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 432 validation rules
+- [Rules Reference](./rules/index.md) - browse all 435 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics

--- a/website/docs/rules/generated/cc-hk-028.md
+++ b/website/docs/rules/generated/cc-hk-028.md
@@ -1,0 +1,48 @@
+---
+id: cc-hk-028
+title: "CC-HK-028: Rejected user_config Interpolation in Shell-Form Command"
+sidebar_label: "CC-HK-028"
+description: "agnix rule CC-HK-028 checks for rejected user_config interpolation in shell-form command in claude hooks files. Severity: HIGH. See examples and fix guidance."
+keywords: ["CC-HK-028", "rejected user_config interpolation in shell-form command", "claude hooks", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-HK-028`
+- **Severity**: `HIGH`
+- **Category**: `Claude Hooks`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-07-15`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.207`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.207
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{ "type": "command", "command": "my-script ${user_config.api_key}" }
+```
+
+### Valid
+
+```json
+{ "type": "command", "command": "my-script $CLAUDE_PLUGIN_OPTION_API_KEY" }
+```

--- a/website/docs/rules/generated/cc-set-014.md
+++ b/website/docs/rules/generated/cc-set-014.md
@@ -1,0 +1,52 @@
+---
+id: cc-set-014
+title: "CC-SET-014: autoMode Setting Ignored in settings.local.json"
+sidebar_label: "CC-SET-014"
+description: "agnix rule CC-SET-014 checks for automode setting ignored in settings.local.json in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-014", "automode setting ignored in settings.local.json", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-014`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `SHOULD`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-07-15`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.207`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.207
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "autoMode": {"classifyAllShell": true}
+}
+```
+
+### Valid
+
+```json
+{
+  "model": "claude-sonnet-4"
+}
+```

--- a/website/docs/rules/generated/cc-set-015.md
+++ b/website/docs/rules/generated/cc-set-015.md
@@ -1,0 +1,52 @@
+---
+id: cc-set-015
+title: "CC-SET-015: Dead pluginConfigs in Project-Level Settings"
+sidebar_label: "CC-SET-015"
+description: "agnix rule CC-SET-015 checks for dead pluginconfigs in project-level settings in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-015", "dead pluginconfigs in project-level settings", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-015`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `SHOULD`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-07-15`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.207`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.207
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "pluginConfigs": {"my-plugin": {"apiKey": "abc"}}
+}
+```
+
+### Valid
+
+```json
+{
+  "model": "claude-sonnet-4"
+}
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `432` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `435` validation rules generated from `knowledge-base/rules.json`.
 `127` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -74,6 +74,7 @@ This section contains all `432` validation rules generated from `knowledge-base/
 | [CC-HK-025](./generated/cc-hk-025.md) | Invalid Matcher Value | LOW | Claude Hooks | Yes (unsafe) |
 | [CC-HK-026](./generated/cc-hk-026.md) | MCP Tool Hook Missing Server | HIGH | Claude Hooks | No |
 | [CC-HK-027](./generated/cc-hk-027.md) | MCP Tool Hook Missing Tool | HIGH | Claude Hooks | No |
+| [CC-HK-028](./generated/cc-hk-028.md) | Rejected user_config Interpolation in Shell-Form Command | HIGH | Claude Hooks | No |
 | [CC-MEM-001](./generated/cc-mem-001.md) | Invalid Import Path | HIGH | Claude Memory | No |
 | [CC-MEM-002](./generated/cc-mem-002.md) | Circular Import | HIGH | Claude Memory | No |
 | [CC-MEM-003](./generated/cc-mem-003.md) | Import Depth Exceeds 5 | HIGH | Claude Memory | No |
@@ -142,6 +143,8 @@ This section contains all `432` validation rules generated from `knowledge-base/
 | [CC-SET-011](./generated/cc-set-011.md) | Non-boolean respondToBashCommands Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-012](./generated/cc-set-012.md) | Invalid sandbox.credentials Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-013](./generated/cc-set-013.md) | Non-boolean autoMode.classifyAllShell Setting | MEDIUM | Claude Settings | No |
+| [CC-SET-014](./generated/cc-set-014.md) | autoMode Setting Ignored in settings.local.json | MEDIUM | Claude Settings | No |
+| [CC-SET-015](./generated/cc-set-015.md) | Dead pluginConfigs in Project-Level Settings | MEDIUM | Claude Settings | No |
 | [CDX-000](./generated/cdx-000.md) | TOML Parse Error | HIGH | Codex CLI | No |
 | [CDX-001](./generated/cdx-001.md) | Invalid Approval Mode | HIGH | Codex CLI | Yes (unsafe) |
 | [CDX-002](./generated/cdx-002.md) | Invalid Full Auto Error Mode | HIGH | Codex CLI | Yes (unsafe) |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 432,
+  "totalRules": 435,
   "categoryCount": 40,
   "autofixCount": 127,
   "uniqueTools": [


### PR DESCRIPTION
Closes #1203. Implements the three rule candidates from the [Claude Code v2.1.207](https://github.com/anthropics/claude-code/releases/tag/v2.1.207) release triage (#1198). Rule count 432 → 435.

## New rules

### CC-SET-014 [MEDIUM] autoMode Setting Ignored in settings.local.json
v2.1.207 stopped reading `autoMode` from repo-resident `.claude/settings.local.json` — the key is silently ignored there and only read from `~/.claude/settings.json`. Warns on any non-null `autoMode` in `settings.local.json` only (not `settings.json`, not `managed-settings.json`). Fires on presence, not shape — CC-SET-013 (classifyAllShell type check) co-fires independently.

### CC-SET-015 [MEDIUM] Dead pluginConfigs in Project-Level Settings
v2.1.207 restricted plugin option values to user settings, `--settings` files, and managed settings. Warns on non-null `pluginConfigs` in `.claude/settings.json` and `.claude/settings.local.json` (both project-level, both excluded from the honored list); `managed-settings.json` is exempt since the managed tier is still honored.

### CC-HK-028 [HIGH] Rejected user_config Interpolation in Shell-Form Command
v2.1.207 rejects `${user_config.*}` inside a command hook's shell-form `command` string at load time (shell-injection fix). Errors on any command-type hook whose command contains the pattern; suggestion directs to `$CLAUDE_PLUGIN_OPTION_<KEY>` or environment-passing. Carries security metadata (CWE-78, OWASP A03:2021, command-injection).

## Detection extension

Plugin hooks files (`<plugin-root>/hooks/hooks.json`) previously fell through to `FileType::Unknown` and got no validation, which would have made CC-HK-028 dead on its primary target. Added a path-only detection arm routing any `hooks/hooks.json` (excluding the Copilot `.github/hooks/` and Cursor `.cursor/` layouts) to `FileType::Hooks`, following the documented-trade-off precedent from CodexRequirements. Safety-gated: a dedicated test proves the hooks validator emits zero diagnostics for JSON without a `hooks` key, so unrelated `hooks/hooks.json` files aren't sprayed with errors.

## Coverage

- 25 new unit tests (9 + 9 + 7) plus detection tests; full workspace suite green.
- All bookkeeping synced: rules.json + mirror, 12 locale files (es/zh-CN translations for the CC-SET rules; `cc_hk_028` en-only per CC-HK-013..027 precedent), VALIDATION-RULES.md, INDEX.md/SPEC.md/CONTRIBUTING.md count tables, website generated docs, CHANGELOG.
- Gates: `sync-rule-bookkeeping.js --check`, `check-rule-counts.py`, `check-locale-sync.sh`, `cargo test --workspace`, fmt, clippy `-D warnings`, `agnix eval` (62/62), self-lint — all pass.