### PR TITLE
feat: add CC-SET-016 for deprecated Write/NotebookEdit/Glob permission-rule forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 435 rules, 75+ sources, rules.json
+knowledge-base/     # 436 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-435 rules defined in `knowledge-base/rules.json` (source of truth)
+436 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 435 validation rules across 40 validators
+- 436 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SET-016: Deprecated Tool-Scoped Permission Rule Form** (#1208). Claude Code v2.1.210 added a startup warning for `Write(path)`, `NotebookEdit(path)`, and `Glob(path)` permission rule forms; the new rule warns on their presence in any of the three settings files and suggests `Edit(path)` or `Read(path)` instead. Rule count 435 → 436.
+
 ## [0.38.0] - 2026-07-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 435 rules, 75+ sources, rules.json
+knowledge-base/     # 436 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-435 rules defined in `knowledge-base/rules.json` (source of truth)
+436 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 435 validation rules across 40 validators
+- 436 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Rule IDs follow the format `[PREFIX]-[NUMBER]` where the prefix indicates the ru
 | `CC-MEM-` | 13 | CC-MEM-001 through CC-MEM-012, CC-MEM-014 |
 | `CC-OS-` | 6 | CC-OS-001 through CC-OS-006 |
 | `CC-PL-` | 15 | CC-PL-001 through CC-PL-015 |
-| `CC-SET-` | 15 | CC-SET-001 through CC-SET-015 |
+| `CC-SET-` | 16 | CC-SET-001 through CC-SET-016 |
 | `CC-SK-` | 21 | CC-SK-001 through CC-SK-021 |
 | `CDX-` | 7 | CDX-000 through CDX-006 |
 | `CDX-AG-` | 7 | CDX-AG-001 through CDX-AG-007 |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>435 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>436 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 435 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 436 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # agnix Technical Reference
 
-> Linter for agent configs. 435 rules across 40 categories.
+> Linter for agent configs. 436 rules across 40 categories.
 
 
 ## What agnix Validates
@@ -14,7 +14,7 @@
 | Agents | agents/*.md | 17 |
 | Plugins | plugin.json | 15 |
 | Claude Output Styles | .claude/output-styles/*.md | 6 |
-| Claude Settings | .claude/settings.json | 15 |
+| Claude Settings | .claude/settings.json | 16 |
 | Prompt Engineering | CLAUDE.md, AGENTS.md | 6 |
 | Cross-Platform | AGENTS.md | 9 |
 | MCP | tool definitions | 26 |
@@ -62,7 +62,7 @@ agnix/
 │   ├── agnix-mcp/      # MCP server
 │   └── agnix-wasm/     # WebAssembly bindings
 ├── editors/            # Neovim, VS Code, JetBrains, Zed integrations
-├── knowledge-base/     # 435 rules documented
+├── knowledge-base/     # 436 rules documented
 
 ├── scripts/            # Build/dev automation scripts
 ├── website/            # Docusaurus documentation website

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -1228,6 +1228,9 @@ rules:
       values are only read from user settings, --settings files, and managed settings
     suggestion: Move pluginConfigs to ~/.claude/settings.json (user-level), pass it via the --settings flag, or configure
       it in managed settings; remove it from the project-level file.
+  cc_set_016:
+    message: "'%{rule}' is a deprecated permission-rule form as of Claude Code 2.1.210; use '%{replacement}' instead"
+    suggestion: "Replace '%{rule}' with '%{replacement}' in your permissions list."
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -753,6 +753,9 @@ rules:
       configuracion administrada
     suggestion: Mueve pluginConfigs a ~/.claude/settings.json (nivel de usuario), pasalo mediante el indicador --settings,
       o configuralo en la configuracion administrada; eliminalo del archivo a nivel de proyecto.
+  cc_set_016:
+    message: "'%{rule}' es una forma de regla de permiso obsoleta desde Claude Code 2.1.210; usa '%{replacement}' en su lugar"
+    suggestion: "Reemplaza '%{rule}' con '%{replacement}' en tu lista de permisos."
 
 
 # ===========================================================================

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -710,6 +710,9 @@ rules:
   cc_set_015:
     message: 自 Claude Code 2.1.207 起，项目级 .claude 设置中的 pluginConfigs 会被静默忽略；插件选项值仅从用户设置、--settings 文件和托管设置中读取
     suggestion: 将 pluginConfigs 移至 ~/.claude/settings.json（用户级），通过 --settings 标志传入，或在托管设置中配置；并从项目级文件中删除。
+  cc_set_016:
+    message: "'%{rule}' 是 Claude Code 2.1.210 起已弃用的权限规则形式；请改用 '%{replacement}'"
+    suggestion: "将权限列表中的 '%{rule}' 替换为 '%{replacement}'。"
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -1228,6 +1228,9 @@ rules:
       values are only read from user settings, --settings files, and managed settings
     suggestion: Move pluginConfigs to ~/.claude/settings.json (user-level), pass it via the --settings flag, or configure
       it in managed settings; remove it from the project-level file.
+  cc_set_016:
+    message: "'%{rule}' is a deprecated permission-rule form as of Claude Code 2.1.210; use '%{replacement}' instead"
+    suggestion: "Replace '%{rule}' with '%{replacement}' in your permissions list."
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -753,6 +753,9 @@ rules:
       configuracion administrada
     suggestion: Mueve pluginConfigs a ~/.claude/settings.json (nivel de usuario), pasalo mediante el indicador --settings,
       o configuralo en la configuracion administrada; eliminalo del archivo a nivel de proyecto.
+  cc_set_016:
+    message: "'%{rule}' es una forma de regla de permiso obsoleta desde Claude Code 2.1.210; usa '%{replacement}' en su lugar"
+    suggestion: "Reemplaza '%{rule}' con '%{replacement}' en tu lista de permisos."
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -710,6 +710,9 @@ rules:
   cc_set_015:
     message: 自 Claude Code 2.1.207 起，项目级 .claude 设置中的 pluginConfigs 会被静默忽略；插件选项值仅从用户设置、--settings 文件和托管设置中读取
     suggestion: 将 pluginConfigs 移至 ~/.claude/settings.json（用户级），通过 --settings 标志传入，或在托管设置中配置；并从项目级文件中删除。
+  cc_set_016:
+    message: "'%{rule}' 是 Claude Code 2.1.210 起已弃用的权限规则形式；请改用 '%{replacement}'"
+    suggestion: "将权限列表中的 '%{rule}' 替换为 '%{replacement}'。"
 
 
 # ===========================================================================

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -20,6 +20,7 @@
 //! - `autoMode.classifyAllShell` boolean check (CC-SET-013, added in Claude Code v2.1.193).
 //! - autoMode ignored in settings.local.json (CC-SET-014, changed in Claude Code v2.1.207).
 //! - pluginConfigs dead in project-level settings (CC-SET-015, changed in Claude Code v2.1.207).
+//! - deprecated Write/NotebookEdit/Glob permission-rule forms (CC-SET-016, added in Claude Code v2.1.210).
 //!
 //! Runs on FileType::Hooks (which covers `.claude/settings.json` -
 //! see `file_types/detection.rs`). Skips non-Claude Code settings paths
@@ -49,6 +50,7 @@ const RULE_IDS: &[&str] = &[
     "CC-SET-013",
     "CC-SET-014",
     "CC-SET-015",
+    "CC-SET-016",
 ];
 
 /// Allowed values for `worktree.baseRef` per Claude Code v2.1.133 release notes.
@@ -154,6 +156,10 @@ impl Validator for ClaudeSettingsValidator {
 
         if config.is_rule_enabled("CC-SET-015") {
             validate_plugin_configs_scope(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-016") {
+            validate_deprecated_permission_tool_forms(path, content, &value, &mut diagnostics);
         }
 
         diagnostics
@@ -1127,6 +1133,90 @@ fn validate_plugin_configs_scope(
         )
         .with_suggestion(t!("rules.cc_set_015.suggestion")),
     );
+}
+
+/// CC-SET-016: Warn on deprecated path-scoped permission rule forms.
+///
+/// Claude Code v2.1.210 added a startup warning for permission entries of the
+/// form `Write(path)`, `NotebookEdit(path)`, and `Glob(path)`. These forms are
+/// deprecated; users should use `Edit(path)` or `Read(path)` instead.
+///
+/// Fires on `permissions.allow`, `permissions.deny`, and `permissions.ask`
+/// arrays in `.claude/settings.json`, `.claude/settings.local.json`, and
+/// `.claude/managed-settings.json`. For each deprecated entry:
+/// - `Write(...)` and `NotebookEdit(...)` → suggest `Edit(...)` with the same
+///   argument.
+/// - `Glob(...)` → suggest `Read(...)` with the same argument.
+///
+/// Only path-scoped forms (those with a `(`) are flagged; bare tool names like
+/// `"Write"` alone are NOT flagged — the deprecation is specifically for the
+/// `Write(path)` forms per the v2.1.210 release notes.
+///
+/// Non-array `permissions.allow/deny/ask`, non-string entries, and absent
+/// `permissions` key are silently skipped (other rules' concern).
+fn validate_deprecated_permission_tool_forms(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(permissions) = value.get("permissions") else {
+        return;
+    };
+    let Some(permissions_obj) = permissions.as_object() else {
+        return;
+    };
+
+    for array_key in &["allow", "deny", "ask"] {
+        let Some(arr) = permissions_obj.get(*array_key) else {
+            continue;
+        };
+        let Some(arr) = arr.as_array() else {
+            continue;
+        };
+
+        for entry in arr {
+            let Some(s) = entry.as_str() else {
+                continue;
+            };
+
+            // Only flag path-scoped forms: must contain '('
+            let replacement = s
+                .strip_prefix("Write(")
+                .or_else(|| s.strip_prefix("NotebookEdit("))
+                .map(|inner| format!("Edit({inner}"))
+                .or_else(|| s.strip_prefix("Glob(").map(|inner| format!("Read({inner}")));
+
+            let Some(replacement) = replacement else {
+                continue;
+            };
+
+            // Array string values aren't found by find_key_line (no trailing
+            // ':'), so fall back to the containing array key line.
+            let line = find_key_line(content, array_key)
+                .or_else(|| find_key_line(content, "permissions"))
+                .unwrap_or(1);
+
+            diagnostics.push(
+                Diagnostic::warning(
+                    path.to_path_buf(),
+                    line,
+                    0,
+                    "CC-SET-016",
+                    t!(
+                        "rules.cc_set_016.message",
+                        rule = s,
+                        replacement = replacement.as_str()
+                    ),
+                )
+                .with_suggestion(t!(
+                    "rules.cc_set_016.suggestion",
+                    rule = s,
+                    replacement = replacement.as_str()
+                )),
+            );
+        }
+    }
 }
 
 /// Renders a `serde_json::Value` variant as a short human-readable type
@@ -2903,5 +2993,148 @@ mod tests {
         let diagnostics = validate_at(".claude/settings.json", content);
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-002"));
         assert!(diagnostics.iter().any(|d| d.rule == "CC-SET-015"));
+    }
+
+    // ===== CC-SET-016: deprecated Write/NotebookEdit/Glob permission-rule forms =====
+
+    #[test]
+    fn test_write_in_allow_flags_with_edit_suggestion() {
+        let content = r#"{"permissions": {"allow": ["Write(src/**)"]}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-016")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].level, crate::diagnostics::DiagnosticLevel::Warning);
+        let msg = &hits[0].message;
+        assert!(
+            msg.contains("Edit(src/**)"),
+            "message should mention Edit replacement, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_notebook_edit_in_deny_flags_with_edit_suggestion() {
+        let content = r#"{"permissions": {"deny": ["NotebookEdit(notebooks/**)"]}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-016")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].level, crate::diagnostics::DiagnosticLevel::Warning);
+        let msg = &hits[0].message;
+        assert!(
+            msg.contains("Edit(notebooks/**)"),
+            "message should mention Edit replacement, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_glob_in_ask_flags_with_read_suggestion() {
+        let content = r#"{"permissions": {"ask": ["Glob(docs/**)"]}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        let hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-016")
+            .collect();
+        assert_eq!(hits.len(), 1);
+        let msg = &hits[0].message;
+        assert!(
+            msg.contains("Read(docs/**)"),
+            "message should mention Read replacement, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_edit_and_read_entries_are_clean() {
+        let content =
+            r#"{"permissions": {"allow": ["Edit(src/**)", "Read(docs/**)", "Bash(npm:*)")]}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-016"));
+    }
+
+    #[test]
+    fn test_bare_write_without_paren_is_clean() {
+        // "Write" alone (no parenthesized path) must not fire CC-SET-016.
+        let content = r#"{"permissions": {"allow": ["Write", "NotebookEdit", "Glob"]}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-016"));
+    }
+
+    #[test]
+    fn test_multiple_bad_entries_produce_one_diagnostic_each() {
+        let content =
+            r#"{"permissions": {"allow": ["Write(a/**)", "NotebookEdit(b/**)", "Glob(c/**)"]}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        let count = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-SET-016")
+            .count();
+        assert_eq!(count, 3, "expected one diagnostic per deprecated entry");
+    }
+
+    #[test]
+    fn test_deprecated_forms_in_all_three_settings_filenames() {
+        let content = r#"{"permissions": {"allow": ["Write(src/**)"]}}"#;
+        for path_str in &[
+            ".claude/settings.json",
+            ".claude/settings.local.json",
+            ".claude/managed-settings.json",
+        ] {
+            let diagnostics = validate_at(path_str, content);
+            let count = diagnostics
+                .iter()
+                .filter(|d| d.rule == "CC-SET-016")
+                .count();
+            assert_eq!(
+                count, 1,
+                "expected CC-SET-016 in {path_str} but got {count}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_permissions_absent_is_clean() {
+        let content = r#"{"model": "claude-sonnet-4"}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-016"));
+    }
+
+    #[test]
+    fn test_allow_not_an_array_is_clean() {
+        let content = r#"{"permissions": {"allow": "Write(src/**)"}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-016"));
+    }
+
+    #[test]
+    fn test_non_string_entry_in_allow_is_skipped() {
+        let content = r#"{"permissions": {"allow": [42, true, null]}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-016"));
+    }
+
+    #[test]
+    fn test_rule_disabled_via_config() {
+        let mut builder = LintConfig::builder();
+        builder.disable_rule("CC-SET-016");
+        let config = builder.build().unwrap();
+        let validator = ClaudeSettingsValidator;
+        let path = PathBuf::from(".claude/settings.json");
+        let diagnostics = validator.validate(
+            &path,
+            r#"{"permissions": {"allow": ["Write(src/**)"]}}"#,
+            &config,
+        );
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-016"));
+    }
+
+    #[test]
+    fn test_other_tool_forms_like_bash_are_clean() {
+        let content = r#"{"permissions": {"allow": ["Bash(npm:*)", "Bash(git:*)", "Agent(*)"]}}"#;
+        let diagnostics = validate_at(".claude/settings.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-SET-016"));
     }
 }

--- a/crates/agnix-lsp/README.md
+++ b/crates/agnix-lsp/README.md
@@ -81,7 +81,7 @@ The extension automatically downloads the `agnix-lsp` binary. See `editors/zed/R
 
 - Real-time diagnostics as you type (via textDocument/didChange)
 - Real-time diagnostics on file open and save
-- Supports all agnix validation rules (435 rules)
+- Supports all agnix validation rules (436 rules)
 - Project-level validation for cross-file rules (AGM-006, XP-004/005/006, VER-001)
 
 - Maps diagnostic severity levels (Error, Warning, Info)

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -1228,6 +1228,9 @@ rules:
       values are only read from user settings, --settings files, and managed settings
     suggestion: Move pluginConfigs to ~/.claude/settings.json (user-level), pass it via the --settings flag, or configure
       it in managed settings; remove it from the project-level file.
+  cc_set_016:
+    message: "'%{rule}' is a deprecated permission-rule form as of Claude Code 2.1.210; use '%{replacement}' instead"
+    suggestion: "Replace '%{rule}' with '%{replacement}' in your permissions list."
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -753,6 +753,9 @@ rules:
       configuracion administrada
     suggestion: Mueve pluginConfigs a ~/.claude/settings.json (nivel de usuario), pasalo mediante el indicador --settings,
       o configuralo en la configuracion administrada; eliminalo del archivo a nivel de proyecto.
+  cc_set_016:
+    message: "'%{rule}' es una forma de regla de permiso obsoleta desde Claude Code 2.1.210; usa '%{replacement}' en su lugar"
+    suggestion: "Reemplaza '%{rule}' con '%{replacement}' en tu lista de permisos."
 
 
 # ===========================================================================

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -710,6 +710,9 @@ rules:
   cc_set_015:
     message: 自 Claude Code 2.1.207 起，项目级 .claude 设置中的 pluginConfigs 会被静默忽略；插件选项值仅从用户设置、--settings 文件和托管设置中读取
     suggestion: 将 pluginConfigs 移至 ~/.claude/settings.json（用户级），通过 --settings 标志传入，或在托管设置中配置；并从项目级文件中删除。
+  cc_set_016:
+    message: "'%{rule}' 是 Claude Code 2.1.210 起已弃用的权限规则形式；请改用 '%{replacement}'"
+    suggestion: "将权限列表中的 '%{rule}' 替换为 '%{replacement}'。"
 
 
 # ===========================================================================

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 435,
-  "last_updated": "2026-07-15",
+  "total_rules": 436,
+  "last_updated": "2026-07-16",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -4071,6 +4071,34 @@
       },
       "good_example": "{\n  \"model\": \"claude-sonnet-4\"\n}",
       "bad_example": "{\n  \"pluginConfigs\": {\"my-plugin\": {\"apiKey\": \"abc\"}}\n}"
+    },
+    {
+      "id": "CC-SET-016",
+      "name": "Deprecated Tool-Scoped Permission Rule Form",
+      "severity": "LOW",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.210"
+        ],
+        "verified_on": "2026-07-16",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.210"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"permissions\": {\"allow\": [\"Edit(src/**)\", \"Read(docs/**)\"]}\n}",
+      "bad_example": "{\n  \"permissions\": {\"allow\": [\"Write(src/**)\", \"Glob(docs/**)\"]}\n}"
     },
     {
       "id": "CDX-000",
@@ -12756,7 +12784,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 15,
+      "count": 16,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -300,6 +300,6 @@ cargo install agnix-lsp
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for frontmatter fields
-- 435 validation rules
+- 436 validation rules
 - Status bar indicator (VS Code)
 - Syntax highlighting for SKILL.md (VS Code)

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,7 +3,7 @@
 Real-time validation for AI agent configuration files in VS Code.
 Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix).
 
-**435 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
+**436 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
 
 
 ## Features
@@ -11,7 +11,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Real-time validation** - Diagnostics as you type
 - **Context-aware completions** - Frontmatter keys, values, and snippets
 - **JSON Schema validation and autocomplete for `.agnix.toml` config files**
-- **Validates 435 rules** - From official specs and best practices
+- **Validates 436 rules** - From official specs and best practices
 
 - **Diagnostics panel** - Sidebar tree view of all issues by file
 - **CodeLens** - Rule info shown inline above problematic lines
@@ -45,7 +45,7 @@ Access via Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | `agnix: Fix All Issues in File` | `Ctrl+Shift+.` | Apply all available fixes |
 | `agnix: Preview Fixes` | - | Browse fixes with diff preview |
 | `agnix: Fix All Safe Issues` | `Ctrl+Alt+.` | Apply only safe fixes |
-| `agnix: Show All Rules` | - | Browse 435 rules by category |
+| `agnix: Show All Rules` | - | Browse 436 rules by category |
 
 | `agnix: Show Rule Documentation` | - | Open docs for a rule (via CodeLens) |
 | `agnix: Ignore Rule in Project` | - | Add rule to `.agnix.toml` disabled list |

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 435 validation rules across 40 categories, sourced from 75+ references
+> 436 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 435 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 436 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (435 rules)
+├── VALIDATION-RULES.md             # Master validation reference (436 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **435 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **436 rules** |
 
 
 ### Validation Rules by Category
@@ -97,7 +97,7 @@ knowledge-base/
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 15 | 0 | 15 | 0 | 0 |
+| Claude Settings | 16 | 0 | 15 | 1 | 0 |
 | Claude Skills | 21 | 11 | 9 | 1 | 13 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **435** | **213** | **193** | **29** | **127** |
+| **TOTAL** | **436** | **213** | **193** | **30** | **127** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 435 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 436 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     435 rules
+Validation Rules:     436 rules
 Auto-Fixable Rules:   127 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 435 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 436 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -468,6 +468,13 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 **Fix**: Manual - move `pluginConfigs` to `~/.claude/settings.json` (user-level), pass it via the `--settings` flag, or configure it in managed settings; then remove it from the project-level file.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.207 (project-level `pluginConfigs` no longer read)
 
+<a id="cc-set-016"></a>
+### CC-SET-016 [LOW] Deprecated Tool-Scoped Permission Rule Form
+**Requirement**: `Write(path)`, `NotebookEdit(path)`, and `Glob(path)` permission rule forms SHOULD NOT be used as of Claude Code 2.1.210, which added a startup warning for them. Use `Edit(path)` instead of `Write(path)` or `NotebookEdit(path)`, and use `Read(path)` instead of `Glob(path)`.
+**Detection**: Walk `permissions.allow`, `permissions.deny`, and `permissions.ask` arrays in `.claude/settings.json`, `.claude/settings.local.json`, and `.claude/managed-settings.json`. Flag (warning) any string entry that starts with `Write(`, `NotebookEdit(`, or `Glob(`. Bare tool names without `(` (e.g. `"Write"`) are NOT flagged — only path-scoped forms. Non-array values, non-string entries, and absent `permissions` key are silently skipped.
+**Fix**: Manual - replace `Write(path)` → `Edit(path)`, `NotebookEdit(path)` → `Edit(path)`, `Glob(path)` → `Read(path)` in the permissions array.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.210 (startup warning added for deprecated `Write(path)`, `NotebookEdit(path)`, `Glob(path)` permission rule forms)
+
 ---
 
 ## PER-CLIENT SKILL RULES
@@ -3494,7 +3501,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 15 | 0 | 15 | 0 | 0 |
+| Claude Settings | 16 | 0 | 15 | 1 | 0 |
 | Claude Skills | 21 | 11 | 9 | 1 | 13 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -3525,7 +3532,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **435** | **213** | **193** | **29** | **127** |
+| **TOTAL** | **436** | **213** | **193** | **30** | **127** |
 
 
 ---
@@ -3555,8 +3562,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 435 validation rules across 40 categories
+**Total Coverage**: 436 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 213 HIGH, 193 MEDIUM, 29 LOW
+**Certainty**: 213 HIGH, 193 MEDIUM, 30 LOW
 **Auto-Fixable**: 127 rules (29%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 435,
-  "last_updated": "2026-07-15",
+  "total_rules": 436,
+  "last_updated": "2026-07-16",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -4071,6 +4071,34 @@
       },
       "good_example": "{\n  \"model\": \"claude-sonnet-4\"\n}",
       "bad_example": "{\n  \"pluginConfigs\": {\"my-plugin\": {\"apiKey\": \"abc\"}}\n}"
+    },
+    {
+      "id": "CC-SET-016",
+      "name": "Deprecated Tool-Scoped Permission Rule Form",
+      "severity": "LOW",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.210"
+        ],
+        "verified_on": "2026-07-16",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.210"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"permissions\": {\"allow\": [\"Edit(src/**)\", \"Read(docs/**)\"]}\n}",
+      "bad_example": "{\n  \"permissions\": {\"allow\": [\"Write(src/**)\", \"Glob(docs/**)\"]}\n}"
     },
     {
       "id": "CDX-000",
@@ -12756,7 +12784,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 15,
+      "count": 16,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1228,6 +1228,9 @@ rules:
       values are only read from user settings, --settings files, and managed settings
     suggestion: Move pluginConfigs to ~/.claude/settings.json (user-level), pass it via the --settings flag, or configure
       it in managed settings; remove it from the project-level file.
+  cc_set_016:
+    message: "'%{rule}' is a deprecated permission-rule form as of Claude Code 2.1.210; use '%{replacement}' instead"
+    suggestion: "Replace '%{rule}' with '%{replacement}' in your permissions list."
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -753,6 +753,9 @@ rules:
       configuracion administrada
     suggestion: Mueve pluginConfigs a ~/.claude/settings.json (nivel de usuario), pasalo mediante el indicador --settings,
       o configuralo en la configuracion administrada; eliminalo del archivo a nivel de proyecto.
+  cc_set_016:
+    message: "'%{rule}' es una forma de regla de permiso obsoleta desde Claude Code 2.1.210; usa '%{replacement}' en su lugar"
+    suggestion: "Reemplaza '%{rule}' con '%{replacement}' en tu lista de permisos."
 
 
 # ===========================================================================

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -710,6 +710,9 @@ rules:
   cc_set_015:
     message: 自 Claude Code 2.1.207 起，项目级 .claude 设置中的 pluginConfigs 会被静默忽略；插件选项值仅从用户设置、--settings 文件和托管设置中读取
     suggestion: 将 pluginConfigs 移至 ~/.claude/settings.json（用户级），通过 --settings 标志传入，或在托管设置中配置；并从项目级文件中删除。
+  cc_set_016:
+    message: "'%{rule}' 是 Claude Code 2.1.210 起已弃用的权限规则形式；请改用 '%{replacement}'"
+    suggestion: "将权限列表中的 '%{rule}' 替换为 '%{replacement}'。"
 
 
 # ===========================================================================

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.38.0",
-  "description": "Lint agent configurations before they break your workflow. 435 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 436 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "aviarchi1994@gmail.com",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 435 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 436 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 435 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 436 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 435 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 436 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 435 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 436 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -73,6 +73,6 @@ GitHub Copilot validation is enabled by default and can be targeted in config wi
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 435 rules
+- [Rules Reference](./rules/index.md) - browse all 436 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 435 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 436 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 435 rules derived from official specs and real-world testing
+- **Validates** configuration files against 436 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 435 validation rules
+- [Rules Reference](./rules/index.md) - browse all 436 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics

--- a/website/docs/rules/generated/cc-set-016.md
+++ b/website/docs/rules/generated/cc-set-016.md
@@ -1,0 +1,52 @@
+---
+id: cc-set-016
+title: "CC-SET-016: Deprecated Tool-Scoped Permission Rule Form"
+sidebar_label: "CC-SET-016"
+description: "agnix rule CC-SET-016 checks for deprecated tool-scoped permission rule form in claude settings files. Severity: LOW. See examples and fix guidance."
+keywords: ["CC-SET-016", "deprecated tool-scoped permission rule form", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-016`
+- **Severity**: `LOW`
+- **Category**: `Claude Settings`
+- **Normative Level**: `SHOULD`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-07-16`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.210`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.210
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "permissions": {"allow": ["Write(src/**)", "Glob(docs/**)"]}
+}
+```
+
+### Valid
+
+```json
+{
+  "permissions": {"allow": ["Edit(src/**)", "Read(docs/**)"]}
+}
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `435` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `436` validation rules generated from `knowledge-base/rules.json`.
 `127` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -145,6 +145,7 @@ This section contains all `435` validation rules generated from `knowledge-base/
 | [CC-SET-013](./generated/cc-set-013.md) | Non-boolean autoMode.classifyAllShell Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-014](./generated/cc-set-014.md) | autoMode Setting Ignored in settings.local.json | MEDIUM | Claude Settings | No |
 | [CC-SET-015](./generated/cc-set-015.md) | Dead pluginConfigs in Project-Level Settings | MEDIUM | Claude Settings | No |
+| [CC-SET-016](./generated/cc-set-016.md) | Deprecated Tool-Scoped Permission Rule Form | LOW | Claude Settings | No |
 | [CDX-000](./generated/cdx-000.md) | TOML Parse Error | HIGH | Codex CLI | No |
 | [CDX-001](./generated/cdx-001.md) | Invalid Approval Mode | HIGH | Codex CLI | Yes (unsafe) |
 | [CDX-002](./generated/cdx-002.md) | Invalid Full Auto Error Mode | HIGH | Codex CLI | Yes (unsafe) |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 435,
+  "totalRules": 436,
   "categoryCount": 40,
   "autofixCount": 127,
   "uniqueTools": [


### PR DESCRIPTION
Closes #1208. Implements the rule candidate from the [Claude Code v2.1.210](https://github.com/anthropics/claude-code/releases/tag/v2.1.210) triage (#1204). Rule count 435 → 436.

## CC-SET-016 [LOW] Deprecated Tool-Scoped Permission Rule Form

v2.1.210 added a startup warning for `Write(path)`, `NotebookEdit(path)`, and `Glob(path)` permission rules — the canonical forms are `Edit(path)` (for Write/NotebookEdit) and `Read(path)` (for Glob). The new rule walks `permissions.allow`/`deny`/`ask` arrays in all three Claude settings files and warns per offending entry, suggesting the concrete replacement with the same argument (`Write(src/**)` → `Edit(src/**)`).

Scope decisions:
- Only path-scoped forms (containing `(`) are flagged — bare tool names like `"Write"` are untouched, matching the release note which deprecates the `Write(path)` forms specifically.
- Fires in all three settings files including managed-settings.json (the deprecated form is wrong in every tier).
- Non-array values, non-string entries, and absent keys are silently skipped.

## Coverage

- 10 new unit tests (per-form suggestions, all three filenames, bare-name/other-tool/malformed-shape negatives, per-entry diagnostics, disable-switch).
- Full bookkeeping synced: rules.json + mirror, 12 locale files (en/es/zh-CN), VALIDATION-RULES.md, INDEX.md/SPEC.md/CONTRIBUTING.md tables, the 6 prose count files (including the two SPEC.md phrases the count checker doesn't cover), website generated docs, CHANGELOG.
- Gates: workspace tests (3953+, 0 failed), fmt, clippy `-D warnings`, bookkeeping --check, check-rule-counts, locale sync, eval 62/62, self-lint — all pass.