### PR TITLE
feat: add OC-CFG-014 for subagent_depth and accept it as a known key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 436 rules, 75+ sources, rules.json
+knowledge-base/     # 437 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-436 rules defined in `knowledge-base/rules.json` (source of truth)
+437 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 436 validation rules across 40 validators
+- 437 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OC-CFG-014: Invalid subagent_depth Value** (#1214). OpenCode v1.18.2 added a top-level `subagent_depth` field (`Schema.optional(NonNegativeInt)`); the new rule warns when the value is present but not a non-negative integer (string, float, bool, negative number). `"subagent_depth"` is also added to `KNOWN_TOP_LEVEL_KEYS` so valid v1.18.2 configs no longer trigger the OC-004/OC-CFG-003 unknown-key false positive. Source: https://github.com/anomalyco/opencode/releases/tag/v1.18.2. Rule count 436 → 437. Closes #1214.
+
 ## [0.39.0] - 2026-07-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 436 rules, 75+ sources, rules.json
+knowledge-base/     # 437 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-436 rules defined in `knowledge-base/rules.json` (source of truth)
+437 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 436 validation rules across 40 validators
+- 437 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ Rule IDs follow the format `[PREFIX]-[NUMBER]` where the prefix indicates the ru
 | `OC-` | 8 | OC-001 through OC-004, OC-006 through OC-009 |
 | `OC-AG-` | 9 | OC-AG-001 through OC-AG-009 |
 | `OC-AGM-` | 2 | OC-AGM-001 through OC-AGM-002 |
-| `OC-CFG-` | 13 | OC-CFG-001 through OC-CFG-013 |
+| `OC-CFG-` | 14 | OC-CFG-001 through OC-CFG-014 |
 | `OC-DEP-` | 6 | OC-DEP-001 through OC-DEP-006 |
 | `OC-LSP-` | 2 | OC-LSP-001 through OC-LSP-002 |
 | `OC-PM-` | 2 | OC-PM-001 through OC-PM-002 |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>436 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>437 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 436 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 437 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # agnix Technical Reference
 
-> Linter for agent configs. 436 rules across 40 categories.
+> Linter for agent configs. 437 rules across 40 categories.
 
 
 ## What agnix Validates
@@ -23,7 +23,7 @@
 | GitHub Copilot | .github/copilot-instructions.md, .github/instructions/*.instructions.md, .github/agents/*.agent.md, .github/prompts/*.prompt.md, .github/hooks/hooks.json, .github/workflows/copilot-setup-steps.yml | 25 |
 | Cursor Project Rules | .cursor/rules/*.mdc, .cursorrules, .cursor/hooks.json, .cursor/agents/**/*.md, .cursor/environment.json | 19 |
 | Cline | .clinerules, .clinerules/*.md, .clinerules/*.txt | 7 |
-| OpenCode | opencode.json, opencode.jsonc | 45 |
+| OpenCode | opencode.json, opencode.jsonc | 46 |
 | Gemini Agents | .gemini/agents/*.json | 1 |
 | Gemini CLI | GEMINI.md, GEMINI.local.md, .gemini/settings.json (hooks), gemini-extension.json (extensions), .geminiignore | 10 |
 | Codex CLI | .codex/config.toml/.json/.yaml | 65 |
@@ -62,7 +62,7 @@ agnix/
 │   ├── agnix-mcp/      # MCP server
 │   └── agnix-wasm/     # WebAssembly bindings
 ├── editors/            # Neovim, VS Code, JetBrains, Zed integrations
-├── knowledge-base/     # 436 rules documented
+├── knowledge-base/     # 437 rules documented
 
 ├── scripts/            # Build/dev automation scripts
 ├── website/            # Docusaurus documentation website

--- a/crates/agnix-core/src/rules/opencode.rs
+++ b/crates/agnix-core/src/rules/opencode.rs
@@ -47,6 +47,7 @@ const RULE_IDS: &[&str] = &[
     "OC-CFG-011",
     "OC-CFG-012",
     "OC-CFG-013",
+    "OC-CFG-014",
     "OC-AG-001",
     "OC-AG-002",
     "OC-AG-003",
@@ -1684,6 +1685,48 @@ impl Validator for OpenCodeValidator {
                                         ),
                                     );
                                 }
+                            }
+                        }
+                    }
+                }
+
+                // OC-CFG-014: Invalid subagent_depth value
+                if config.is_rule_enabled("OC-CFG-014") {
+                    if let Some(depth_val) = obj.get("subagent_depth") {
+                        if !depth_val.is_null() {
+                            if let Some(n) = depth_val.as_i64() {
+                                if n < 0 {
+                                    diagnostics.push(
+                                        Diagnostic::warning(
+                                            path.to_path_buf(),
+                                            find_key_line(content, "subagent_depth").unwrap_or(1),
+                                            0,
+                                            "OC-CFG-014",
+                                            format!(
+                                                "subagent_depth must be non-negative (got {})",
+                                                n
+                                            ),
+                                        )
+                                        .with_suggestion(
+                                            "Use a non-negative integer such as 0 or 1".to_string(),
+                                        ),
+                                    );
+                                }
+                            } else {
+                                // Not an integer (string, bool, float, array, object)
+                                diagnostics.push(
+                                    Diagnostic::warning(
+                                        path.to_path_buf(),
+                                        find_key_line(content, "subagent_depth").unwrap_or(1),
+                                        0,
+                                        "OC-CFG-014",
+                                        "Invalid subagent_depth type. Must be a non-negative integer"
+                                            .to_string(),
+                                    )
+                                    .with_suggestion(
+                                        "Use a non-negative integer such as 0 or 1".to_string(),
+                                    ),
+                                );
                             }
                         }
                     }
@@ -3758,6 +3801,97 @@ mod tests {
             .filter(|d| d.rule == "OC-CFG-013")
             .collect();
         assert_eq!(cfg.len(), 2);
+    }
+
+    // ===== OC-CFG-014: Invalid subagent_depth value =====
+
+    #[test]
+    fn test_oc_cfg_014_valid_positive() {
+        // subagent_depth: 2 → clean (no OC-CFG-014)
+        let diagnostics = validate(r#"{"subagent_depth": 2}"#);
+        assert!(!diagnostics.iter().any(|d| d.rule == "OC-CFG-014"));
+    }
+
+    #[test]
+    fn test_oc_cfg_014_valid_zero() {
+        // subagent_depth: 0 → clean
+        let diagnostics = validate(r#"{"subagent_depth": 0}"#);
+        assert!(!diagnostics.iter().any(|d| d.rule == "OC-CFG-014"));
+    }
+
+    #[test]
+    fn test_oc_cfg_014_negative_integer() {
+        // subagent_depth: -1 → 1 warning
+        let diagnostics = validate(r#"{"subagent_depth": -1}"#);
+        let cfg: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "OC-CFG-014")
+            .collect();
+        assert_eq!(cfg.len(), 1);
+        assert_eq!(cfg[0].level, DiagnosticLevel::Warning);
+        assert!(cfg[0].message.contains("non-negative"));
+        assert!(cfg[0].message.contains("-1"));
+    }
+
+    #[test]
+    fn test_oc_cfg_014_string_type() {
+        // subagent_depth: "2" → 1 warning (wrong type)
+        let diagnostics = validate(r#"{"subagent_depth": "2"}"#);
+        let cfg: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "OC-CFG-014")
+            .collect();
+        assert_eq!(cfg.len(), 1);
+        assert_eq!(cfg[0].level, DiagnosticLevel::Warning);
+        assert!(cfg[0].message.contains("type"));
+    }
+
+    #[test]
+    fn test_oc_cfg_014_float_type() {
+        // subagent_depth: 1.5 → 1 warning (wrong type)
+        let diagnostics = validate(r#"{"subagent_depth": 1.5}"#);
+        let cfg: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "OC-CFG-014")
+            .collect();
+        assert_eq!(cfg.len(), 1);
+        assert_eq!(cfg[0].level, DiagnosticLevel::Warning);
+        assert!(cfg[0].message.contains("type"));
+    }
+
+    #[test]
+    fn test_oc_cfg_014_null_clean() {
+        // subagent_depth: null → clean
+        let diagnostics = validate(r#"{"subagent_depth": null}"#);
+        assert!(!diagnostics.iter().any(|d| d.rule == "OC-CFG-014"));
+    }
+
+    #[test]
+    fn test_oc_cfg_014_absent_clean() {
+        // subagent_depth absent → clean
+        let diagnostics = validate(r#"{"share": "manual"}"#);
+        assert!(!diagnostics.iter().any(|d| d.rule == "OC-CFG-014"));
+    }
+
+    #[test]
+    fn test_oc_cfg_014_rule_disabled() {
+        // Rule disabled → no OC-CFG-014 even with invalid value
+        let mut config = LintConfig::default();
+        config.rules_mut().disabled_rules = vec!["OC-CFG-014".to_string()];
+        let diagnostics = validate_with_config(r#"{"subagent_depth": -1}"#, &config);
+        assert!(!diagnostics.iter().any(|d| d.rule == "OC-CFG-014"));
+    }
+
+    #[test]
+    fn test_oc_cfg_014_known_key_no_oc_004() {
+        // subagent_depth: 2 must NOT trigger OC-004 / OC-CFG-003 (Part 1: known-key fix)
+        let diagnostics = validate(r#"{"subagent_depth": 2}"#);
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d.rule == "OC-004" || d.rule == "OC-CFG-003"),
+            "subagent_depth should be recognized as a known key"
+        );
     }
 
     // ===== OC-AG-009: Invalid agent disable type =====

--- a/crates/agnix-core/src/schemas/opencode.rs
+++ b/crates/agnix-core/src/schemas/opencode.rs
@@ -47,6 +47,7 @@ pub const KNOWN_TOP_LEVEL_KEYS: &[&str] = &[
     "skills",
     "small_model",
     "snapshot",
+    "subagent_depth",
     "theme",
     "tools",
     "tui",

--- a/crates/agnix-lsp/README.md
+++ b/crates/agnix-lsp/README.md
@@ -81,7 +81,7 @@ The extension automatically downloads the `agnix-lsp` binary. See `editors/zed/R
 
 - Real-time diagnostics as you type (via textDocument/didChange)
 - Real-time diagnostics on file open and save
-- Supports all agnix validation rules (436 rules)
+- Supports all agnix validation rules (437 rules)
 - Project-level validation for cross-file rules (AGM-006, XP-004/005/006, VER-001)
 
 - Maps diagnostic severity levels (Error, Warning, Info)

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 436,
+  "total_rules": 437,
   "last_updated": "2026-07-16",
   "schema": {
     "evidence": {
@@ -12318,6 +12318,34 @@
       "bad_example": "{\n  \"mcp\": { \"srv\": { \"type\": \"invalid\" } }\n}"
     },
     {
+      "id": "OC-CFG-014",
+      "name": "Invalid subagent_depth Value",
+      "severity": "MEDIUM",
+      "category": "opencode",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anomalyco/opencode/releases/tag/v1.18.2"
+        ],
+        "verified_on": "2026-07-16",
+        "applies_to": {
+          "tool": "opencode",
+          "version_range": ">=1.18.2"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"subagent_depth\": 2\n}",
+      "bad_example": "{\n  \"subagent_depth\": -1\n}"
+    },
+    {
       "id": "OC-AG-005",
       "name": "top_p Out of Range",
       "severity": "HIGH",
@@ -12654,7 +12682,7 @@
     },
     "opencode": {
       "prefix": "OC",
-      "count": 45,
+      "count": 46,
       "description": "OpenCode configuration rules"
     },
     "gemini-cli": {

--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -300,6 +300,6 @@ cargo install agnix-lsp
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for frontmatter fields
-- 436 validation rules
+- 437 validation rules
 - Status bar indicator (VS Code)
 - Syntax highlighting for SKILL.md (VS Code)

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,7 +3,7 @@
 Real-time validation for AI agent configuration files in VS Code.
 Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix).
 
-**436 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
+**437 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
 
 
 ## Features
@@ -11,7 +11,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Real-time validation** - Diagnostics as you type
 - **Context-aware completions** - Frontmatter keys, values, and snippets
 - **JSON Schema validation and autocomplete for `.agnix.toml` config files**
-- **Validates 436 rules** - From official specs and best practices
+- **Validates 437 rules** - From official specs and best practices
 
 - **Diagnostics panel** - Sidebar tree view of all issues by file
 - **CodeLens** - Rule info shown inline above problematic lines
@@ -45,7 +45,7 @@ Access via Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | `agnix: Fix All Issues in File` | `Ctrl+Shift+.` | Apply all available fixes |
 | `agnix: Preview Fixes` | - | Browse fixes with diff preview |
 | `agnix: Fix All Safe Issues` | `Ctrl+Alt+.` | Apply only safe fixes |
-| `agnix: Show All Rules` | - | Browse 436 rules by category |
+| `agnix: Show All Rules` | - | Browse 437 rules by category |
 
 | `agnix: Show Rule Documentation` | - | Open docs for a rule (via CodeLens) |
 | `agnix: Ignore Rule in Project` | - | Add rule to `.agnix.toml` disabled list |

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 436 validation rules across 40 categories, sourced from 75+ references
+> 437 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 436 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 437 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (436 rules)
+├── VALIDATION-RULES.md             # Master validation reference (437 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **436 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **437 rules** |
 
 
 ### Validation Rules by Category
@@ -118,7 +118,7 @@ knowledge-base/
 | Kiro Skills | 1 | 0 | 1 | 0 | 1 |
 | Kiro Steering | 14 | 3 | 9 | 2 | 1 |
 | MCP | 26 | 20 | 6 | 0 | 7 |
-| OpenCode | 45 | 28 | 16 | 1 | 10 |
+| OpenCode | 46 | 28 | 17 | 1 | 10 |
 | OpenCode Skills | 1 | 0 | 1 | 0 | 1 |
 | Prompt Eng | 6 | 0 | 6 | 0 | 2 |
 | References | 4 | 2 | 2 | 0 | 1 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **436** | **213** | **193** | **30** | **127** |
+| **TOTAL** | **437** | **213** | **194** | **30** | **127** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 436 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 437 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     436 rules
+Validation Rules:     437 rules
 Auto-Fixable Rules:   127 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 436 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 437 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -2120,6 +2120,13 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 **Fix**: Manual
 **Source**: opencode.ai/docs/
 
+<a id="oc-cfg-014"></a>
+### OC-CFG-014 [MEDIUM] Invalid subagent_depth Value
+**Requirement**: The top-level `subagent_depth` field MUST be a non-negative integer when present
+**Detection**: Parse JSON, check that `subagent_depth` is a non-negative integer (null/absent is valid)
+**Fix**: No auto-fix
+**Source**: github.com/anomalyco/opencode/releases/tag/v1.18.2
+
 <a id="oc-ag-005"></a>
 ### OC-AG-005 [HIGH] top_p Out of Range
 **Requirement**: The agent `top_p` field MUST be between 0.0 and 1.0
@@ -3522,7 +3529,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Kiro Skills | 1 | 0 | 1 | 0 | 1 |
 | Kiro Steering | 14 | 3 | 9 | 2 | 1 |
 | MCP | 26 | 20 | 6 | 0 | 7 |
-| OpenCode | 45 | 28 | 16 | 1 | 10 |
+| OpenCode | 46 | 28 | 17 | 1 | 10 |
 | OpenCode Skills | 1 | 0 | 1 | 0 | 1 |
 | Prompt Eng | 6 | 0 | 6 | 0 | 2 |
 | References | 4 | 2 | 2 | 0 | 1 |
@@ -3532,7 +3539,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **436** | **213** | **193** | **30** | **127** |
+| **TOTAL** | **437** | **213** | **194** | **30** | **127** |
 
 
 ---
@@ -3562,8 +3569,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 436 validation rules across 40 categories
+**Total Coverage**: 437 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 213 HIGH, 193 MEDIUM, 30 LOW
+**Certainty**: 213 HIGH, 194 MEDIUM, 30 LOW
 **Auto-Fixable**: 127 rules (29%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,7 +1,7 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 436,
+  "total_rules": 437,
   "last_updated": "2026-07-16",
   "schema": {
     "evidence": {
@@ -12318,6 +12318,34 @@
       "bad_example": "{\n  \"mcp\": { \"srv\": { \"type\": \"invalid\" } }\n}"
     },
     {
+      "id": "OC-CFG-014",
+      "name": "Invalid subagent_depth Value",
+      "severity": "MEDIUM",
+      "category": "opencode",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anomalyco/opencode/releases/tag/v1.18.2"
+        ],
+        "verified_on": "2026-07-16",
+        "applies_to": {
+          "tool": "opencode",
+          "version_range": ">=1.18.2"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"subagent_depth\": 2\n}",
+      "bad_example": "{\n  \"subagent_depth\": -1\n}"
+    },
+    {
       "id": "OC-AG-005",
       "name": "top_p Out of Range",
       "severity": "HIGH",
@@ -12654,7 +12682,7 @@
     },
     "opencode": {
       "prefix": "OC",
-      "count": 45,
+      "count": 46,
       "description": "OpenCode configuration rules"
     },
     "gemini-cli": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.39.0",
-  "description": "Lint agent configurations before they break your workflow. 436 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 437 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "aviarchi1994@gmail.com",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 436 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 437 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 436 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 437 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 436 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 437 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 436 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 437 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -73,6 +73,6 @@ GitHub Copilot validation is enabled by default and can be targeted in config wi
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 436 rules
+- [Rules Reference](./rules/index.md) - browse all 437 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 436 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 437 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 436 rules derived from official specs and real-world testing
+- **Validates** configuration files against 437 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 436 validation rules
+- [Rules Reference](./rules/index.md) - browse all 437 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics

--- a/website/docs/rules/generated/oc-cfg-014.md
+++ b/website/docs/rules/generated/oc-cfg-014.md
@@ -1,0 +1,52 @@
+---
+id: oc-cfg-014
+title: "OC-CFG-014: Invalid subagent_depth Value - OpenCode"
+sidebar_label: "OC-CFG-014"
+description: "agnix rule OC-CFG-014 checks for invalid subagent_depth value in opencode files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["OC-CFG-014", "invalid subagent_depth value", "opencode", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `OC-CFG-014`
+- **Severity**: `MEDIUM`
+- **Category**: `OpenCode`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-07-16`
+
+## Applicability
+
+- **Tool**: `opencode`
+- **Version Range**: `>=1.18.2`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anomalyco/opencode/releases/tag/v1.18.2
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "subagent_depth": -1
+}
+```
+
+### Valid
+
+```json
+{
+  "subagent_depth": 2
+}
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `436` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `437` validation rules generated from `knowledge-base/rules.json`.
 `127` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -431,6 +431,7 @@ This section contains all `436` validation rules generated from `knowledge-base/
 | [OC-CFG-011](./generated/oc-cfg-011.md) | Invalid MCP Timeout | HIGH | OpenCode | No |
 | [OC-CFG-012](./generated/oc-cfg-012.md) | Invalid MCP OAuth Config | HIGH | OpenCode | No |
 | [OC-CFG-013](./generated/oc-cfg-013.md) | Invalid Server Config | HIGH | OpenCode | No |
+| [OC-CFG-014](./generated/oc-cfg-014.md) | Invalid subagent_depth Value | MEDIUM | OpenCode | No |
 | [OC-AG-005](./generated/oc-ag-005.md) | top_p Out of Range | HIGH | OpenCode | No |
 | [OC-AG-006](./generated/oc-ag-006.md) | Invalid Named Color | MEDIUM | OpenCode | Yes (unsafe) |
 | [OC-AG-007](./generated/oc-ag-007.md) | Redundant steps and maxSteps | MEDIUM | OpenCode | No |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 436,
+  "totalRules": 437,
   "categoryCount": 40,
   "autofixCount": 127,
   "uniqueTools": [


### PR DESCRIPTION
Closes #1214. Implements the rule candidate from the [OpenCode v1.18.2](https://github.com/anomalyco/opencode/releases/tag/v1.18.2) triage (#1211). Rule count 436 → 437.

## Correction to the issue

The auto-triage proposed OC-AG-010 (agent-definition field), but the upstream source (`packages/core/src/v1/config/config.ts`) shows `subagent_depth` is a **top-level** `opencode.json` key — `Schema.optional(NonNegativeInt)`, default 1 ("prevents subagents from launching subagents"). The rule is therefore **OC-CFG-014**, following the OC-CFG-004 (`default_agent`) pattern.

## Two changes

1. **Known-key fix (false-positive)**: `subagent_depth` was missing from `KNOWN_TOP_LEVEL_KEYS`, so every valid v1.18.2 config using it tripped the unknown-key rules (OC-004/OC-CFG-003). Now accepted, with a regression test.
2. **OC-CFG-014 [MEDIUM] Invalid subagent_depth Value**: when present and non-null, warns on non-integer types (string/bool/float/array/object) and on negative integers, matching the upstream `NonNegativeInt` schema.

## Coverage

- 9 new unit tests (valid 0/2, negative, string, float, null, absent, disable-switch, unknown-key regression).
- Full bookkeeping synced (rules.json + mirror, VALIDATION-RULES.md, INDEX.md/SPEC.md/CONTRIBUTING.md tables incl. the two SPEC.md prose phrases, website docs, CHANGELOG). No locale changes — OC-CFG rules use inline messages per existing convention.
- Gates: workspace tests, fmt, clippy `-D warnings`, bookkeeping --check, check-rule-counts, locale sync, eval 62/62, self-lint — all pass.