### PR TITLE
fix: address release and dependency queue

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-07-16",
+  "last_updated": "2026-07-20",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.210",
+      "last_known_version": "v2.1.215",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -60,7 +60,7 @@
         "agents_md"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.144.4",
+      "last_known_version": "rust-v0.144.6",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -96,7 +96,7 @@
         "agents_md"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.18.2",
+      "last_known_version": "v1.18.3",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -136,7 +136,7 @@
       "html_url": "https://kiro.dev/changelog/cli/",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
       "notes_extractor": "glm",
-      "last_known_version": "2.12.0",
+      "last_known_version": "2.13.0",
       "tracked": true,
       "notes": "Proprietary CLI; no GH releases. Tracked via HTML scrape of kiro.dev/changelog/cli/ - the first NN.NN.NN version on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). The CLI itself exposes `kiro-cli version --changelog`. IDE has a separate changelog at https://kiro.dev/changelog/ide/ (not tracked here; could be added as a separate kiro-ide entry if needed).",
       "changes_of_interest": {
@@ -203,7 +203,7 @@
         "cline"
       ],
       "github_repo": "cline/cline",
-      "last_known_version": "cli-v3.0.40",
+      "last_known_version": "v4.0.10",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -237,7 +237,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.11.25",
+      "last_known_version": "3.12.17",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {
@@ -305,7 +305,7 @@
       "html_url": "https://ampcode.com/news.rss",
       "version_regex": "https://ampcode\\.com/news/[a-zA-Z0-9._-]+",
       "notes_extractor": "rss_cdata",
-      "last_known_version": "the-dial",
+      "last_known_version": "subscriptions",
       "tracked": true,
       "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed).",
       "changes_of_interest": {
@@ -337,7 +337,7 @@
         "gemini_ignore"
       ],
       "github_repo": "google-gemini/gemini-cli",
-      "last_known_version": "v0.50.0",
+      "last_known_version": "v0.51.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,7 +28,7 @@ cache poisoning from pull requests.
 
 ## SHA Pin Reference
 
-When updating actions, use these SHA commits (last verified: 2026-02):
+When updating actions, use these SHA commits (last verified: 2026-07):
 
 ```yaml
 # GitHub Official Actions
@@ -45,16 +45,18 @@ rhysd/actionlint@v1.7.1:       62dc61a45fc95efe8c800af7a557ab0b9165d63b
 # Rust Tooling
 dtolnay/rust-toolchain@stable: 4be9e76fd7c4901c61fb841f559994984270fce7
 Swatinem/rust-cache@v2:        779680da715d629ac1d338a641029a2f4372abb5
-taiki-e/install-action@v2.67.30:     288875dd3d64326724fa6d9593062d9f8ba0b131
+taiki-e/install-action@v2.83.4:  07b4745e0c39a41822af610387492e3e53aa222b
 taiki-e/install-action@nextest: cd05dcd6eb73067dda063b97a15b7060049dacd9
 
 # Security
-github/codeql-action@v3:       2588666de8825e1e9dc4e2329a4c985457d55b32
+github/codeql-action@v4.37.1:   7188fc363630916deb702c7fdcf4e481b751f97a
+EmbarkStudios/cargo-deny-action@v2.1.1: 3c6349835b2b7b196a839186cb8b78e02f7b5f25
 
 # Coverage
 codecov/codecov-action@v5.5.2:  671740ac38dd9b0130fbe1cec585b89eea48d3de
 
 # Release
+actions/setup-java@v5.6.0:      03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
 softprops/action-gh-release@v2: a06a81a03ee405af7f2048a818ed3f03bbf83c7b
 
 # Zed Extension

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,7 +51,7 @@ jobs:
           toolchain: nightly-2026-05-03
 
       - name: Install cargo-fuzz
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
         with:
           tool: cargo-fuzz@0.13.1
           fallback: cargo-install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Install cross
         if: matrix.cross
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
         with:
           tool: cross@0.2.5
 
@@ -442,7 +442,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: rust
           queries: security-extended
@@ -34,7 +34,7 @@ jobs:
         run: cargo build --release --workspace
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:rust"
 
@@ -48,7 +48,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install cargo-audit
-        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
+        uses: taiki-e/install-action@07b4745e0c39a41822af610387492e3e53aa222b # v2.83.4
         with:
           tool: cargo-audit@0.22.1
       - name: Run security audit
@@ -63,6 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check all

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload SARIF to GitHub
         if: steps.agnix.outputs.sarif-file != ''
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v3
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           sarif_file: ${{ steps.agnix.outputs.sarif-file }}
           category: agnix-linting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Tool release baselines (2026-07-20 sweep)**. Advanced Claude Code to `v2.1.215`, Codex CLI to `rust-v0.144.6`, OpenCode to `v1.18.3`, Kiro CLI to `2.13.0`, Cline to `v4.0.10`, Cursor to `3.12.17`, Gemini CLI to `v0.51.0`, and amp to `subscriptions` after reviewing the current release notes (closes #1217, #1218, #1219, #1220, #1221, #1222, #1223, and #1234).
+- **Dependency and CI action refresh**. Updated `toml` to `1.1.3`, `clap` to `4.6.2`, `rust-i18n` to `4.2.1`, `regex` to `1.13.1`, and `ignore` to `0.4.30`; refreshed the pinned cargo-deny, CodeQL, setup-java, and taiki-e action revisions. The `rust-i18n` update removes the deprecated transitive `serde_yaml` package.
+
+### Fixed
+- **Cline UTF-8 BOM compatibility**. Parse BOM-prefixed Cline rules, workflows, and skill frontmatter so validation matches Cline's current parser behavior instead of silently skipping scoped rules.
+- **CodeQL action version consistency**. Pin CodeQL initialization, analysis, and SARIF upload to the same `v4.37.1` revision, preventing mixed-version configuration failures.
+
 ## [0.40.0] - 2026-07-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
  "similar",
  "sys-locale",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -56,7 +56,7 @@ dependencies = [
  "serde_norway",
  "tempfile",
  "thiserror 2.0.18",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
  "tracking-allocator",
 ]
 
@@ -124,7 +124,20 @@ dependencies = [
  "agnix-rules",
  "serde_json",
  "tempfile",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.3+spec-1.1.0",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -159,6 +172,17 @@ name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
 
 [[package]]
 name = "anstream"
@@ -224,6 +248,12 @@ checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "assert_cmd"
@@ -453,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -463,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -512,7 +542,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -784,6 +814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,7 +835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1012,6 +1051,16 @@ dependencies = [
  "bitflags 1.3.2",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03f81ad4732830d85cfd417a9f62cde6dadda4354d37d078a6084a19560aa2d"
+dependencies = [
+ "arraydeque",
+ "smallvec",
 ]
 
 [[package]]
@@ -1348,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.28"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
+checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -1677,6 +1726,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "normalize-line-endings"
@@ -2062,7 +2117,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2186,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2198,9 +2253,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2306,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55691a65892c33ee2de49c15ea5600c6f4a70e8eeb8e6c3cd96d2a231d230c40"
+checksum = "f10cee36dd3b1f7929ea12b759de9eea9eff83bfccbc71f387ef4d41a57c64a4"
 dependencies = [
  "globwalk",
  "regex",
@@ -2319,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "rust-i18n-macro"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30de488acadcf767d97cd48518a8da8ea9777b1c9a5beca4eab78bbf77d07309"
+checksum = "f0bb1ed4e04fe26c2a2652cad1c6595efaf7196f4445c0d6e13c67154347fb7e"
 dependencies = [
  "glob",
  "proc-macro2",
@@ -2329,15 +2384,14 @@ dependencies = [
  "rust-i18n-support",
  "serde",
  "serde_json",
- "serde_yaml",
  "syn",
 ]
 
 [[package]]
 name = "rust-i18n-support"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea0fef8a93c06326b66392c95a115120e609674cb2132d37d276a6b05b545b4"
+checksum = "ba1c083408a2733180ae0acf2897612f8ceec7b0c0dcd065a0a87103bfb3b1d9"
 dependencies = [
  "arc-swap",
  "base62",
@@ -2345,8 +2399,8 @@ dependencies = [
  "itertools 0.11.0",
  "normpath",
  "serde",
+ "serde-saphyr",
  "serde_json",
- "serde_yaml",
  "siphasher",
  "toml 0.8.23",
  "triomphe",
@@ -2377,7 +2431,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2434,7 +2488,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2569,6 +2623,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-saphyr"
+version = "0.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd22781911de0ca6debda95f073c8f18bec65d1a94f1fa9573f3102e514cea4"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde_core",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
 name = "serde-wasm-bindgen"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,19 +2736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2829,7 +2889,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2987,9 +3047,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -3049,9 +3109,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3247,16 +3307,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsafe-libyaml-norway"
@@ -3311,6 +3371,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -3543,7 +3609,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/agnix-core/src/parsers/frontmatter.rs
+++ b/crates/agnix-core/src/parsers/frontmatter.rs
@@ -334,8 +334,12 @@ pub struct FrontmatterParts {
 
 /// Split frontmatter and body from content.
 pub fn split_frontmatter(content: &str) -> FrontmatterParts {
+    let (content, bom_offset) = match content.strip_prefix('\u{FEFF}') {
+        Some(content) => (content, '\u{FEFF}'.len_utf8()),
+        None => (content, 0),
+    };
     let trimmed = content.trim_start();
-    let trim_offset = content.len() - trimmed.len();
+    let trim_offset = bom_offset + content.len() - trimmed.len();
 
     // Check for opening ---
     if !trimmed.starts_with("---") {
@@ -493,6 +497,17 @@ description: second-description
         assert_eq!(parts.body, "\nbody");
         // frontmatter_start points past "---\n" (4 bytes)
         assert_eq!(parts.frontmatter_start, 4);
+        assert_eq!(&content[parts.body_start..], parts.body);
+    }
+
+    #[test]
+    fn test_split_frontmatter_accepts_utf8_bom() {
+        let content = "\u{FEFF}---\nname: test\n---\nbody";
+        let parts = split_frontmatter(content);
+        assert!(parts.has_frontmatter);
+        assert!(parts.has_closing);
+        assert_eq!(parts.frontmatter, "name: test");
+        assert_eq!(parts.frontmatter_start, 7);
         assert_eq!(&content[parts.body_start..], parts.body);
     }
 

--- a/crates/agnix-core/src/rules/cline.rs
+++ b/crates/agnix-core/src/rules/cline.rs
@@ -626,6 +626,13 @@ mod tests {
     }
 
     #[test]
+    fn test_cln_002_validates_bom_prefixed_frontmatter() {
+        let content = "\u{FEFF}---\npaths:\n  - \"[unclosed\"\n---\n# Instructions\n";
+        let diagnostics = validate_folder(content);
+        assert!(diagnostics.iter().any(|d| d.rule == "CLN-002"));
+    }
+
+    #[test]
     fn test_cln_002_valid_glob_patterns() {
         let patterns = vec!["**/*.ts", "*.rs", "src/**/*.js", "tests/**/*.test.ts"];
 
@@ -1051,6 +1058,13 @@ unknownKey: value
     }
 
     #[test]
+    fn test_cln_006_detects_bom_prefixed_frontmatter() {
+        let content = "\u{FEFF}---\ntitle: Deploy\n---\n# Deploy steps\n";
+        let diagnostics = validate_workflow(content);
+        assert!(diagnostics.iter().any(|d| d.rule == "CLN-006"));
+    }
+
+    #[test]
     fn test_cln_006_disabled() {
         let mut config = LintConfig::default();
         config.rules_mut().disabled_rules = vec!["CLN-006".to_string()];
@@ -1148,6 +1162,17 @@ unknownKey: value
             .filter(|d| d.rule == "CL-SK-002")
             .collect();
         assert!(cl_sk_002.is_empty());
+    }
+
+    #[test]
+    fn test_cl_sk_accepts_bom_prefixed_frontmatter() {
+        let content = "\u{FEFF}---\nname: my-skill\ndescription: A test skill\n---\n# Skill body\n";
+        let diagnostics = validate_cline_skill(".cline/skills/my-skill/SKILL.md", content);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| d.rule != "CL-SK-002" && d.rule != "CL-SK-003")
+        );
     }
 
     #[test]

--- a/crates/agnix-core/src/schemas/cline.rs
+++ b/crates/agnix-core/src/schemas/cline.rs
@@ -97,6 +97,7 @@ pub struct GlobValidation {
 ///
 /// Returns parsed frontmatter if present, or None if no frontmatter exists.
 pub fn parse_frontmatter(content: &str) -> Option<ParsedClineFrontmatter> {
+    let content = content.strip_prefix('\u{FEFF}').unwrap_or(content);
     let lines: Vec<&str> = content.lines().collect();
     if lines.is_empty() {
         return None;
@@ -222,7 +223,11 @@ pub fn is_body_empty(body: &str) -> bool {
 
 /// Check if content is empty
 pub fn is_content_empty(content: &str) -> bool {
-    content.trim().is_empty()
+    content
+        .strip_prefix('\u{FEFF}')
+        .unwrap_or(content)
+        .trim()
+        .is_empty()
 }
 
 #[cfg(test)]
@@ -248,6 +253,19 @@ Use strict mode.
         assert_eq!(paths.patterns(), vec!["**/*.ts"]);
         assert!(result.parse_error.is_none());
         assert!(result.body.contains("TypeScript Rules"));
+    }
+
+    #[test]
+    fn test_parse_frontmatter_accepts_utf8_bom() {
+        let content = "\u{FEFF}---\npaths:\n  - \"**/*.ts\"\n---\n# TypeScript Rules\n";
+        let result = parse_frontmatter(content).expect("BOM-prefixed frontmatter should parse");
+        let paths = result
+            .schema
+            .as_ref()
+            .and_then(|schema| schema.paths.as_ref())
+            .expect("paths should be preserved");
+        assert_eq!(paths.patterns(), vec!["**/*.ts"]);
+        assert!(result.parse_error.is_none());
     }
 
     #[test]
@@ -395,6 +413,7 @@ paths: "**/*.rs"
         assert!(is_content_empty(""));
         assert!(is_content_empty("   \n\t  "));
         assert!(!is_content_empty("# Instructions"));
+        assert!(is_content_empty("\u{FEFF}"));
     }
 
     #[test]

--- a/docs/RUSTSEC-ADVISORIES.md
+++ b/docs/RUSTSEC-ADVISORIES.md
@@ -89,34 +89,6 @@ cargo tree -i proc-macro-error2 -e dev    # Check if iai-callgrind still depends
 # 5. Close or update the related tracking issue
 ```
 
-## Tracked Non-RUSTSEC Supply-Chain Items
-
-### `serde_yaml` 0.9.34+deprecated - via `rust-i18n`
-
-**Status**: Runtime transitive dependency with no current RUSTSEC advisory ID
-
-**Details**:
-- agnix's direct YAML/frontmatter parser dependency is the maintained `serde_norway` package through the stable internal `serde_yaml` crate alias.
-- `rust-i18n 4.1.0` still pulls the upstream-deprecated `serde_yaml 0.9.34+deprecated` through `rust-i18n-support`.
-- The dependency is linked into release binaries, but agnix uses it for trusted, repository-owned locale data rather than untrusted user input.
-
-**Risk Level**: Low
-- Hygiene and binary-footprint concern, not a known exploitable advisory.
-- Untrusted frontmatter parsing uses agnix's direct `serde_norway` dependency plus local size and depth guards.
-
-**Action Items**:
-- Monitor `rust-i18n` for a release that removes the deprecated `serde_yaml` dependency.
-- Re-check with `cargo tree -e normal -p rust-i18n | grep serde_yaml` before each release.
-- Remove this section once `serde_yaml 0.9.34+deprecated` is absent from `Cargo.lock`.
-
-**References**:
-- rust-i18n: https://crates.io/crates/rust-i18n
-- serde_yaml: https://crates.io/crates/serde_yaml
-
-```bash
-cargo tree -e normal -p rust-i18n | grep serde_yaml
-```
-
 ## Adding New Advisory Ignores
 
 If a new advisory needs to be temporarily ignored:

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-07-02
+**Last Updated**: 2026-07-20
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -16,31 +16,31 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-16 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
-| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-15 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
-| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-16 | AGM, XP, OC |
-| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-07-11 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-20 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
+| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-20 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
+| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-20 | AGM, XP, OC |
+| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/*.json`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-07-20 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 
 ### A Tier (test on major changes)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-04-22 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-07-15 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-07-16 | CUR |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-07-20 | CLN, CL-SK |
+| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-07-20 | CUR |
 
 ### B Tier (test on significant changes if time permits)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Roo Code | `.roomodes`, `.rooignore`, `.roorules`, `.roo/rules/*.md`, `.roo/rules-{slug}/*.md`, `.roo/mcp.json` | https://github.com/RooCodeInc/Roo-Code | Automated (tool-release-watch.yml) | Quarterly | 2026-06-02 | ROO |
-| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-07-11 | AMP, AMP-SK |
+| amp | `.amp/settings.json`, `.agents/checks/*.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-07-20 | AMP, AMP-SK |
 
 ### C Tier (community reports fixes only)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-07-11 | GM |
+| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-07-20 | GM |
 
 ### D Tier (no support, nice to have)
 


### PR DESCRIPTION
## Summary

- advance all eight open tool-release baselines after reviewing the current upstream releases
- match Cline's UTF-8 BOM behavior for rules, workflows, and skill frontmatter
- roll up the ten open dependency/action updates, including a consistent CodeQL v4.37.1 pin across init, analyze, and SARIF upload
- remove the resolved deprecated transitive serde_yaml tracking item

Closes #1217
Closes #1218
Closes #1219
Closes #1220
Closes #1221
Closes #1222
Closes #1223
Closes #1234

Supersedes #1224, #1225, #1226, #1227, #1228, #1229, #1230, #1231, #1232, and #1233.

## Root causes

Cline now accepts BOM-prefixed frontmatter, while agnix's Cline-specific and shared frontmatter parsers treated the BOM as content and silently missed the opening delimiter. The standalone CodeQL analyze bump also mixed v4.37.1 with a v4.37.0 init step, which GitHub rejects at runtime.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo run -p agnix-cli --bin agnix -- eval tests/eval.yaml
- cargo test -p agnix-cli --test kiro_ci_gate -- --include-ignored
- cargo test -p agnix-cli --test docs_website_parity
- cargo test --test security_hygiene
- node scripts/sync-rule-bookkeeping.js --check --skip-docs
- python3 scripts/check-rule-counts.py
- cargo audit --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2026-0173
- cargo deny check all