### PR TITLE
ci(deps): bump codeql-action to v4.37.3 and setup-python to v7.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -559,7 +559,7 @@ jobs:
         with:
           node-version: '20'
 
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@c54b30b7df092240050e69945842bc67aee0f0f4 # v4.37.3
         with:
           languages: rust
           queries: security-extended
@@ -34,7 +34,7 @@ jobs:
         run: cargo build --release --workspace
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@c54b30b7df092240050e69945842bc67aee0f0f4 # v4.37.3
         with:
           category: "/language:rust"
 

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload SARIF to GitHub
         if: steps.agnix.outputs.sarif-file != ''
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/upload-sarif@c54b30b7df092240050e69945842bc67aee0f0f4 # v4.37.3
         with:
           sarif_file: ${{ steps.agnix.outputs.sarif-file }}
           category: agnix-linting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Dependency refresh**. Updated `serde_json` to `1.0.151` and `thiserror` to `2.0.19`. `thiserror-impl` 2.0.19 moved to `syn` 3.x, so `syn` joins the `[bans.skip]` duplicate allowlist in `deny.toml` alongside the other proc-macro crates that span two majors.
+- **CI action refresh**. Advanced all four `github/codeql-action` pins to `v4.37.3` and `actions/setup-python` to `v7.0.0`. The CodeQL pins must move together: `init` and `analyze` reject a split, failing with `Loaded a configuration file for version '4.37.1', but running version '4.37.3'`, so `upload-sarif` in `test-action.yml` is bumped alongside them.
 
 ### Security
 - **Cleared all open high-severity npm advisories in both lockfiles.** `website/`: `fast-uri` to `3.1.4` (GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6), `brace-expansion` to `5.0.8` (GHSA-3jxr-9vmj-r5cp), `js-yaml` to `4.3.0` (GHSA-52cp-r559-cp3m), `shell-quote` to `1.10.0` (GHSA-395f-4hp3-45gv), and `svgo` to `3.3.4` (GHSA-2p49-hgcm-8545). `editors/vscode/`: `fast-uri` to `3.1.4`, `brace-expansion` to `5.0.8`, `js-yaml` to `4.3.0`, and `linkify-it` to `5.0.2` (GHSA-v245-v573-v5vm). Lockfile-only; no manifest ranges changed and no major upgrades pulled in.


### PR DESCRIPTION
Replaces #1252, #1253, and #1256.

## Why the dependabot PRs could not merge

Dependabot split `github/codeql-action/init` (#1253) and `github/codeql-action/analyze` (#1252) into separate PRs. Neither can pass alone — each branch ends up running one action at 4.37.3 against a config written by the other at 4.37.1, and the analyze post-action fails:

```
##[error]Loaded a configuration file for version '4.37.1', but running version '4.37.3'
##[error]analyze post-action step failed: Loaded a configuration file for version '4.37.1', but running version '4.37.3'
```

The pins have to move together, so all of them are bumped here in one commit.

## Changes

- `github/codeql-action/init` → `v4.37.3` (`c54b30b`) in `security.yml`
- `github/codeql-action/analyze` → `v4.37.3` in `security.yml`
- `github/codeql-action/upload-sarif` → `v4.37.3` in `test-action.yml` — **neither dependabot PR touched this one**; leaving it at 4.37.1 would keep a mismatched pin in the tree
- `actions/setup-python` → `v7.0.0` (`5fda3b9`) in `release.yml`

All pins stay SHA-pinned with the version in a trailing comment, matching the existing convention.

## Verification

- SHAs resolved from the upstream tags via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, not copied from the PR titles
- All three workflow files re-parsed with `yaml.safe_load` after editing
- `setup-python` v7.0.0's only removal is the `pip-install` input, which `release.yml` does not use (it passes only `python-version: '3.x'`); the rest of the release is ESM migration and bug fixes