### PR TITLE
fix(hooks): honor shell quoting when extracting CC-HK-008 script paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CC-HK-008 false positive on script paths containing spaces**. The script-path patterns matched `[^\s"']+`, so a hook command pointing at `/Applications/My App.app/Contents/hook.js` matched only the tail after the space and was reported missing as `App.app/Contents/hook.js`. Quoting did not help — double quotes, single quotes, and backslash escapes all failed identically. `command` strings are now split into shell words that honor all three forms before script paths are matched, so a quoted or escaped path is taken whole. An unquoted space stays split, since it is genuinely ambiguous without a shell. Nested fragments such as `bash -c "python script.py"` still have the path picked out of them, and the URL, glob, and regex exclusions are unchanged (closes #1259).
+
 ### Changed
 - **Dependency refresh**. Updated `serde_json` to `1.0.151` and `thiserror` to `2.0.19`. `thiserror-impl` 2.0.19 moved to `syn` 3.x, so `syn` joins the `[bans.skip]` duplicate allowlist in `deny.toml` alongside the other proc-macro crates that span two majors.
 - **CI action refresh**. Advanced all four `github/codeql-action` pins to `v4.37.3` and `actions/setup-python` to `v7.0.0`. The CodeQL pins must move together: `init` and `analyze` reject a split, failing with `Loaded a configuration file for version '4.37.1', but running version '4.37.3'`, so `upload-sarif` in `test-action.yml` is bumped alongside them.

--- a/crates/agnix-core/src/rules/hooks/helpers.rs
+++ b/crates/agnix-core/src/rules/hooks/helpers.rs
@@ -593,7 +593,8 @@ pub(super) fn extract_script_paths(command: &str) -> Vec<String> {
         // contain a path (e.g. `bash -c "python script.py"`) fall through to
         // the regex scan below, which picks the path out of the fragment.
         let whole_word_is_path = has_script_extension(text)
-            && (!text.chars().any(char::is_whitespace) || (word.protected && looks_like_path(text)));
+            && (!text.chars().any(char::is_whitespace)
+                || (word.protected && looks_like_path(text)));
 
         if whole_word_is_path {
             if is_script_path_candidate(text) {

--- a/crates/agnix-core/src/rules/hooks/helpers.rs
+++ b/crates/agnix-core/src/rules/hooks/helpers.rs
@@ -456,26 +456,160 @@ pub(super) fn check_dangerous_patterns(command: &str) -> Option<(&'static str, &
     None
 }
 
+/// A single shell word from a `command` string, with the quoting metadata
+/// needed to tell a spaced-but-quoted path from a nested shell fragment.
+struct ShellWord {
+    /// Text with quotes removed and backslash escapes applied.
+    text: String,
+    /// Whether any part of the word was inside quotes or backslash-escaped.
+    /// A word only reaches us intact across a space if it was protected, so
+    /// this is what distinguishes `"/My App/x.js"` from an accidental split.
+    protected: bool,
+}
+
+/// Split a command string into shell words, honoring double quotes, single
+/// quotes, and backslash escapes.
+///
+/// This is deliberately not a full POSIX shell parser - it resolves exactly
+/// the quoting forms that determine where a script path begins and ends.
+/// Operators (`&&`, `|`, `;`) are left as their own words, which is enough
+/// for the per-word script matching in `extract_script_paths`.
+fn shell_words(command: &str) -> Vec<ShellWord> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut protected = false;
+    let mut started = false;
+    let mut chars = command.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => {
+                // Outside quotes a backslash escapes whitespace and quote
+                // characters. It is kept literal before anything else so that
+                // Windows paths (`C:\tools\hook.py`) survive intact.
+                match chars.peek() {
+                    Some(&next) if next.is_whitespace() || next == '"' || next == '\'' => {
+                        chars.next();
+                        current.push(next);
+                        protected = true;
+                    }
+                    _ => current.push('\\'),
+                }
+                started = true;
+            }
+            '"' | '\'' => {
+                let quote = c;
+                started = true;
+                protected = true;
+                // Inside single quotes a backslash is always literal. Inside
+                // double quotes POSIX only lets it escape `$`, backtick, `"`
+                // and itself - every other backslash stays literal, which is
+                // what keeps `"C:\Program Files\hook.py"` intact.
+                while let Some(q) = chars.next() {
+                    if q == quote {
+                        break;
+                    }
+                    if q == '\\' && quote == '"' {
+                        match chars.peek() {
+                            Some(&next @ ('$' | '`' | '"' | '\\')) => {
+                                chars.next();
+                                current.push(next);
+                            }
+                            _ => current.push('\\'),
+                        }
+                    } else {
+                        current.push(q);
+                    }
+                }
+            }
+            c if c.is_whitespace() => {
+                if started {
+                    words.push(ShellWord {
+                        text: std::mem::take(&mut current),
+                        protected,
+                    });
+                    protected = false;
+                    started = false;
+                }
+            }
+            c => {
+                current.push(c);
+                started = true;
+            }
+        }
+    }
+    if started {
+        words.push(ShellWord {
+            text: current,
+            protected,
+        });
+    }
+    words
+}
+
+/// Whether a word looks like a filesystem path rather than a shell fragment
+/// that happens to contain one. Used only to decide whether a word holding
+/// whitespace should be treated as a single path.
+fn looks_like_path(word: &str) -> bool {
+    word.starts_with('/')
+        || word.starts_with("./")
+        || word.starts_with("../")
+        || word.starts_with('~')
+        || word.starts_with('$')
+        // Windows drive-qualified path, e.g. `C:\tools\hook.ps1`.
+        || {
+            let mut c = word.chars();
+            matches!((c.next(), c.next(), c.next()), (Some(a), Some(':'), Some('\\' | '/')) if a.is_ascii_alphabetic())
+        }
+}
+
+/// Whether a word ends in one of the script extensions CC-HK-008 checks.
+fn has_script_extension(word: &str) -> bool {
+    let lower = word.to_ascii_lowercase();
+    [".sh", ".bash", ".py", ".js", ".ts"]
+        .iter()
+        .any(|ext| lower.ends_with(ext))
+}
+
+/// Reject regex and glob fragments that happen to end in a script extension
+/// (e.g. `\.py$`, `*.js`, `[^/]*.sh`), plus URLs.
+fn is_script_path_candidate(path: &str) -> bool {
+    if path.contains("://") || path.starts_with("http") {
+        return false;
+    }
+    !(path.starts_with('\\')
+        || path.starts_with('[')
+        || path.starts_with('*')
+        || path.starts_with('(')
+        || path.contains("]*"))
+}
+
 pub(super) fn extract_script_paths(command: &str) -> Vec<String> {
     let mut paths = Vec::new();
-    for re in script_patterns() {
-        for caps in re.captures_iter(command) {
-            if let Some(m) = caps.get(1) {
-                let path = m.as_str().trim_matches(|c| c == '"' || c == '\'');
-                if path.contains("://") || path.starts_with("http") {
-                    continue;
+    for word in shell_words(command) {
+        let text = word.text.as_str();
+        // A quoted or escaped word that reads as a path is taken whole, so a
+        // space inside it no longer truncates the path. Words that merely
+        // contain a path (e.g. `bash -c "python script.py"`) fall through to
+        // the regex scan below, which picks the path out of the fragment.
+        let whole_word_is_path = has_script_extension(text)
+            && (!text.chars().any(char::is_whitespace) || (word.protected && looks_like_path(text)));
+
+        if whole_word_is_path {
+            if is_script_path_candidate(text) {
+                paths.push(text.to_string());
+            }
+            continue;
+        }
+
+        for re in script_patterns() {
+            for caps in re.captures_iter(text) {
+                if let Some(m) = caps.get(1) {
+                    let path = m.as_str().trim_matches(|c| c == '"' || c == '\'');
+                    if is_script_path_candidate(path) {
+                        paths.push(path.to_string());
+                    }
                 }
-                // Skip regex patterns and glob patterns that happen to end in
-                // script extensions (e.g., `\.py$`, `*.js`, `[^/]*.sh`)
-                if path.starts_with('\\')
-                    || path.starts_with('[')
-                    || path.starts_with('*')
-                    || path.starts_with('(')
-                    || path.contains("]*")
-                {
-                    continue;
-                }
-                paths.push(path.to_string());
             }
         }
     }
@@ -1661,6 +1795,94 @@ mod tests {
         // Should filter out bracket patterns
         let paths = extract_script_paths("match [^/]*.sh pattern");
         assert!(paths.is_empty(), "Should filter bracket patterns");
+    }
+
+    // Regression tests for #1259: a space inside a quoted or escaped script
+    // path must not truncate the path. Before the fix the `[^\s"']+` script
+    // patterns matched only the tail after the space, so
+    // `/tmp/My App.app/Contents/hook.js` was reported as
+    // `App.app/Contents/hook.js` and always looked missing.
+
+    #[test]
+    fn test_extract_script_paths_double_quoted_space() {
+        let paths = extract_script_paths(r#""/tmp/My App.app/Contents/hook.js""#);
+        assert_eq!(paths, vec!["/tmp/My App.app/Contents/hook.js"]);
+    }
+
+    #[test]
+    fn test_extract_script_paths_single_quoted_space() {
+        let paths = extract_script_paths("'/tmp/My App.app/Contents/hook.js'");
+        assert_eq!(paths, vec!["/tmp/My App.app/Contents/hook.js"]);
+    }
+
+    #[test]
+    fn test_extract_script_paths_backslash_escaped_space() {
+        let paths = extract_script_paths(r"/tmp/My\ App.app/Contents/hook.js");
+        assert_eq!(paths, vec!["/tmp/My App.app/Contents/hook.js"]);
+    }
+
+    #[test]
+    fn test_extract_script_paths_interpreter_and_quoted_spaced_script() {
+        // The interpreter has no script extension, so only the script is
+        // returned - and the trailing `Stop` argument is not mistaken for one.
+        let paths = extract_script_paths(
+            r#""/opt/homebrew/bin/node" "/tmp/My App.app/Contents/hook.js" Stop"#,
+        );
+        assert_eq!(paths, vec!["/tmp/My App.app/Contents/hook.js"]);
+    }
+
+    #[test]
+    fn test_extract_script_paths_unquoted_space_stays_split() {
+        // An unquoted space is genuinely ambiguous without a shell, so the
+        // pre-existing behaviour is kept deliberately.
+        let paths = extract_script_paths("/tmp/My App.app/Contents/hook.js");
+        assert_eq!(paths, vec!["App.app/Contents/hook.js"]);
+    }
+
+    #[test]
+    fn test_extract_script_paths_quoted_no_space_unchanged() {
+        let paths = extract_script_paths(r#""/tmp/NoSpace/hook.js""#);
+        assert_eq!(paths, vec!["/tmp/NoSpace/hook.js"]);
+    }
+
+    #[test]
+    fn test_extract_script_paths_nested_shell_fragment() {
+        // A quoted word that *contains* a command rather than being a path
+        // still has the path picked out of it by the regex scan.
+        let paths = extract_script_paths(r#"bash -c "python /tmp/absent.py""#);
+        assert_eq!(paths, vec!["/tmp/absent.py"]);
+    }
+
+    #[test]
+    fn test_extract_script_paths_quoted_url_still_skipped() {
+        let paths = extract_script_paths(r#"curl "https://example.com/thing.sh""#);
+        assert!(paths.is_empty(), "URLs should still be skipped when quoted");
+    }
+
+    #[test]
+    fn test_extract_script_paths_windows_quoted_space() {
+        let paths = extract_script_paths(r#""C:\Program Files\tools\hook.py""#);
+        assert_eq!(paths, vec![r"C:\Program Files\tools\hook.py"]);
+    }
+
+    #[test]
+    fn test_shell_words_tracks_protection() {
+        let words = shell_words(r#"node "/a b/c.js" plain"#);
+        assert_eq!(words.len(), 3);
+        assert_eq!(words[0].text, "node");
+        assert!(!words[0].protected);
+        assert_eq!(words[1].text, "/a b/c.js");
+        assert!(words[1].protected);
+        assert_eq!(words[2].text, "plain");
+        assert!(!words[2].protected);
+    }
+
+    #[test]
+    fn test_shell_words_unterminated_quote() {
+        // An unterminated quote must not loop or drop the remainder.
+        let words = shell_words(r#""/tmp/a b/c.js"#);
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].text, "/tmp/a b/c.js");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1259.

## Root cause

The reporter diagnosed this as a whitespace split; the mechanism is slightly different but the effect is the same. `extract_script_paths` applies these patterns directly to the raw `command` string:

```rust
r#"["']?([^\s"']+\.js)["']?\b"#
```

`[^\s"']+` excludes whitespace **and** quote characters, so on `"/tmp/My App.app/Contents/hook.js"` the match cannot start at `/tmp` — it begins after the space and captures `App.app/Contents/hook.js`. Because there was no tokenization step, quoting could not help: the quotes were merely stripped by `trim_matches` *after* the regex had already chosen the boundaries. That is why cases A, B, and C in the report all failed identically.

## Fix

`command` is split into shell words honoring double quotes, single quotes, and backslash escapes before any pattern is applied. A word that is quoted-or-escaped, reads as a path, and ends in a script extension is taken whole. Everything else falls through to the existing per-word regex scan, so nested fragments like `bash -c "python script.py"` still have the path picked out of them.

I did not take the suggested `shlex` dependency. It appears in `Cargo.lock` only transitively, and the decision here needs per-token "was this quoted" metadata to tell a protected spaced path from an accidental split — which `shlex` does not expose. The tokenizer is ~50 lines and resolves exactly the three quoting forms that matter.

Inside double quotes a backslash only escapes `$`, backtick, `"`, and itself, per POSIX. My first attempt consumed every backslash and mangled `"C:\Program Files\tools\hook.py"` into `Filestoolshook.py`; a test now covers that.

## Verification

All seven cases from the report, reproduced against `main` first and re-run after the fix:

| # | Form | Before | After |
|---|---|---|---|
| A | double-quoted | `App.app/Contents/hook.js` | no error |
| B | single-quoted | `App.app/Contents/hook.js` | no error |
| C | backslash-escaped | `App.app/Contents/hook.js` | no error |
| D | unquoted | `App.app/Contents/hook.js` | **still flagged** (intended) |
| E | quoted, no space | no error | no error |
| G | interpreter + quoted script + arg | `App.app/Contents/hook.js` | no error |
| H | interpreter + unspaced script | no error | no error |

Case D is left as-is, per the reporter: an unquoted space is genuinely ambiguous without a shell.

The rule keeps its teeth — verified that these still emit CC-HK-008 exactly once each: a missing bare path, a missing quoted path, a missing **spaced quoted** path, and a missing path inside `bash -c "..."`. URL, glob, and regex exclusions still suppress correctly.

- `cargo test --workspace` → 5,004 passed, 0 failed (up from 4,993; 11 new tests)
- `cargo clippy --workspace --all-targets -- -D warnings` → clean

## Note on the issue text

One small correction for the record: the report says the `resolved to` value comes back identical to the reported path, implying no resolution happens. It does resolve against the config directory — the values looked identical because the repro was run from inside that directory. Doesn't affect the bug or the fix.

This is the third false-positive class in this check, after the two in #894.