### PR TITLE
fix(jetbrains): highlight SKILL.md as Markdown

### DIFF
--- a/editors/jetbrains/CHANGELOG.md
+++ b/editors/jetbrains/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Render `SKILL.md` files with Markdown syntax highlighting instead of
+  registering them as plain text. (#1265)
 - Surface an actionable notification when the OS or a security policy blocks execution of `agnix-lsp` (e.g. AppLocker/WDAC, EDR, or antivirus on locked-down Windows producing `CreateProcess error=5, Access is denied`). Previously this only appeared as a raw `CannotStartProcessException` stack trace. The notification explains the cause and offers "Set Binary Path" and "Troubleshooting" actions, since upgrading the IDE does not resolve an OS-level execution block. Access-denied detection is locale-independent (matches the Win32 `error=5` / POSIX `errno=13`/`EACCES` codes, not localized text).
 - Reject relative values in **LSP binary path** (for example `agnix-lsp.exe`) and tell users to provide the full absolute executable path, preventing the plugin from silently falling back to the blocked downloaded copy.
 

--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
 
         // LSP4IJ - JetBrains LSP Support
         plugin("com.redhat.devtools.lsp4ij:0.14.0")
+        bundledPlugin("org.intellij.plugins.markdown")
 
         pluginVerifier()
         zipSigner()

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/filetype/AgnixFileTypes.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/filetype/AgnixFileTypes.kt
@@ -1,8 +1,8 @@
 package io.agnix.jetbrains.filetype
 
 import com.intellij.openapi.fileTypes.LanguageFileType
-import com.intellij.openapi.fileTypes.PlainTextLanguage
 import io.agnix.jetbrains.AgnixIcons
+import org.intellij.plugins.markdown.lang.MarkdownLanguage
 import javax.swing.Icon
 
 /**
@@ -10,7 +10,7 @@ import javax.swing.Icon
  *
  * Extends Markdown language with custom icon for better identification.
  */
-class SkillFileType private constructor() : LanguageFileType(PlainTextLanguage.INSTANCE) {
+class SkillFileType private constructor() : LanguageFileType(MarkdownLanguage.INSTANCE) {
 
     override fun getName(): String = "SKILL.md"
 

--- a/editors/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/editors/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,7 @@
 
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.json</depends>
+    <depends>org.intellij.plugins.markdown</depends>
     <depends>com.redhat.devtools.lsp4ij</depends>
 
     <extensions defaultExtensionNs="com.intellij">
@@ -53,7 +54,7 @@
             name="SKILL.md"
             implementationClass="io.agnix.jetbrains.filetype.SkillFileType"
             fieldName="INSTANCE"
-            language="TEXT"
+            language="Markdown"
             fileNames="SKILL.md"/>
 
         <!-- Notifications -->

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/filetype/AgnixFileTypesTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/filetype/AgnixFileTypesTest.kt
@@ -1,13 +1,20 @@
 package io.agnix.jetbrains.filetype
 
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.intellij.plugins.markdown.lang.MarkdownLanguage
 
 /**
  * Tests for path-aware agnix file detection.
  */
 class AgnixFileTypesTest {
+
+    @Test
+    fun `skill file type uses markdown syntax highlighting`() {
+        assertSame(MarkdownLanguage.INSTANCE, SkillFileType.INSTANCE.language)
+    }
 
     @Test
     fun `matches top-level markdown memory files`() {


### PR DESCRIPTION
## Summary

- register the custom `SKILL.md` file type with JetBrains Markdown instead of plain text
- declare the bundled Markdown plugin as a build and runtime dependency
- add regression coverage and a changelog entry

## Verification

- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test --no-daemon --max-workers=2 --rerun-tasks --no-build-cache -Pkotlin.compiler.execution.strategy=in-process`
- `git diff --check`

Closes #1265