### PR TITLE
fix: apply [[overrides]] to skill rules; accept server-only MCP form (#1277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`[[overrides]]` had no effect on any skill rule**. Reported as Windows-specific path matching, but the platform was incidental: `SkillValidator`'s internal `ValidationContext` stored the `&LintConfig` that `PerFileLintConfig` derefs to, so the per-file override layer was discarded before any `is_rule_enabled` call. Every AS-* and CC-SK-* rule ignored `[[overrides]]` on all platforms, with no way to suppress one for a single file. The context now holds the per-file view, and an end-to-end regression test covers the case (closes #1277).
+- **CC-SK-008/CC-AG-009/CC-AG-010 rejected the documented server-only MCP form**. `mcp__playwright` errored while the doc-equivalent `mcp__playwright__*` passed, even though the permissions reference lists both as valid ways to name every tool from one server. Both forms are now accepted. A glob in the server segment (`mcp__supabase-*`, `mcp__*`) is still rejected, since a rule must name a specific configured server, and the tool segment may still glob (`mcp__github__get_*`).
+- **Unknown-tool false positives on current built-in tools**. `Workflow`, `Artifact`, `ReportFindings`, `SendUserFile`, and `EndConversation` are in the built-in tools reference but were missing from CC-SK-008's known-tools list. CC-AG-009/010's list was further behind - 26 documented tools absent, including the `Cron*`/`Task*` families, `PowerShell`, `LSP`, `ToolSearch`, and the worktree and MCP-resource tools - so a subagent declaring any of them failed. Tools that subagents never receive stay listed: Claude Code filters those from the resolved pool rather than rejecting the name.
+
 ## [0.42.0] - 2026-07-31
 
 ### Added

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -70,9 +70,10 @@ rules:
     suggestion: Use scoped Bash like 'Bash(git:*)' or 'Bash(npm:*)' instead of plain 'Bash'
     fix: Replace unrestricted Bash with scoped Bash(git:*)
   cc_sk_008:
-    message: 'Unknown tool ''%{tool}''. Known tools: %{known}. MCP tools must use lowercase mcp__<server>__<tool> format'
-    suggestion: 'Use one of the known Claude Code tools: %{known}, or a valid MCP tool (mcp__<server>__<tool>, case-sensitive
-      lowercase prefix)'
+    message: 'Unknown tool ''%{tool}''. Known tools: %{known}. MCP tools must use lowercase mcp__<server> or mcp__<server>__<tool>
+      format'
+    suggestion: 'Use one of the known Claude Code tools: %{known}, or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>,
+      case-sensitive lowercase prefix, no glob in the server segment)'
   cc_sk_009:
     message: Too many dynamic injections (%{count}). Limit to %{max} for better performance
     suggestion: Consider moving complex logic to a scripts/ directory or reducing injections
@@ -284,12 +285,14 @@ rules:
     suggestion: 'Use one of: user, project, local'
     fix: Change memory scope to '%{fixed}'
   cc_ag_009:
-    message: 'Unknown tool ''%{tool}'' in tools list. Known tools: %{known}. MCP tools must use lowercase mcp__<server>__<tool>
-      format'
-    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server>__<tool>, case-sensitive lowercase prefix)
+    message: 'Unknown tool ''%{tool}'' in tools list. Known tools: %{known}. MCP tools must use lowercase mcp__<server> or
+      mcp__<server>__<tool> format'
+    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>, case-sensitive
+      lowercase prefix, no glob in the server segment)
   cc_ag_010:
     message: 'Unknown tool ''%{tool}'' in disallowedTools list. Known tools: %{known}'
-    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server>__<tool>, case-sensitive lowercase prefix)
+    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>, case-sensitive
+      lowercase prefix, no glob in the server segment)
   cc_ag_011:
     message: 'Invalid hooks configuration in agent frontmatter: %{error}'
     suggestion: Ensure hooks follow the same schema as settings.json hooks

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -70,9 +70,10 @@ rules:
     suggestion: Use scoped Bash like 'Bash(git:*)' or 'Bash(npm:*)' instead of plain 'Bash'
     fix: Replace unrestricted Bash with scoped Bash(git:*)
   cc_sk_008:
-    message: 'Unknown tool ''%{tool}''. Known tools: %{known}. MCP tools must use lowercase mcp__<server>__<tool> format'
-    suggestion: 'Use one of the known Claude Code tools: %{known}, or a valid MCP tool (mcp__<server>__<tool>, case-sensitive
-      lowercase prefix)'
+    message: 'Unknown tool ''%{tool}''. Known tools: %{known}. MCP tools must use lowercase mcp__<server> or mcp__<server>__<tool>
+      format'
+    suggestion: 'Use one of the known Claude Code tools: %{known}, or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>,
+      case-sensitive lowercase prefix, no glob in the server segment)'
   cc_sk_009:
     message: Too many dynamic injections (%{count}). Limit to %{max} for better performance
     suggestion: Consider moving complex logic to a scripts/ directory or reducing injections
@@ -284,12 +285,14 @@ rules:
     suggestion: 'Use one of: user, project, local'
     fix: Change memory scope to '%{fixed}'
   cc_ag_009:
-    message: 'Unknown tool ''%{tool}'' in tools list. Known tools: %{known}. MCP tools must use lowercase mcp__<server>__<tool>
-      format'
-    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server>__<tool>, case-sensitive lowercase prefix)
+    message: 'Unknown tool ''%{tool}'' in tools list. Known tools: %{known}. MCP tools must use lowercase mcp__<server> or
+      mcp__<server>__<tool> format'
+    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>, case-sensitive
+      lowercase prefix, no glob in the server segment)
   cc_ag_010:
     message: 'Unknown tool ''%{tool}'' in disallowedTools list. Known tools: %{known}'
-    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server>__<tool>, case-sensitive lowercase prefix)
+    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>, case-sensitive
+      lowercase prefix, no glob in the server segment)
   cc_ag_011:
     message: 'Invalid hooks configuration in agent frontmatter: %{error}'
     suggestion: Ensure hooks follow the same schema as settings.json hooks

--- a/crates/agnix-core/src/rules/agent.rs
+++ b/crates/agnix-core/src/rules/agent.rs
@@ -103,29 +103,64 @@ const KNOWN_AGENT_FIELDS: &[&str] = &[
     "color",
 ];
 
-/// Known Claude Code tools for CC-AG-009 and CC-AG-010
+/// Known Claude Code tools for CC-AG-009 and CC-AG-010.
+///
+/// Mirrors the built-in tools reference (code.claude.com/docs/en/tools,
+/// verified 2026-07-31) plus legacy/internal names kept for version
+/// tolerance. Alphabetized.
+///
+/// Tools that subagents never receive (`AskUserQuestion`, `Workflow`,
+/// `ScheduleWakeup`, …) stay listed here: per the sub-agents reference those
+/// are silently filtered from the resolved pool rather than rejected as
+/// unknown names, so flagging them under CC-AG-009/010 would be wrong.
 const KNOWN_AGENT_TOOLS: &[&str] = &[
     "Agent",
-    "Bash",
-    "Read",
-    "Write",
-    "Edit",
-    "Grep",
-    "Glob",
-    "Task",
-    "WebFetch",
-    "WebSearch",
+    "Artifact",
     "AskUserQuestion",
-    "TodoRead",
-    "TodoWrite",
+    "Bash",
+    "CronCreate",
+    "CronDelete",
+    "CronList",
+    "Edit",
+    "EndConversation",
+    "EnterPlanMode",
+    "EnterWorktree",
+    "ExitPlanMode",
+    "ExitWorktree",
+    "Glob",
+    "Grep",
+    "LSP",
+    "ListMcpResourcesTool",
+    "Monitor",
     "MultiTool",
     "NotebookEdit",
-    "EnterPlanMode",
-    "ExitPlanMode",
+    "PowerShell",
+    "PushNotification",
+    "Read",
+    "ReadMcpResourceTool",
+    "RemoteTrigger",
+    "ReportFindings",
+    "ScheduleWakeup",
+    "SendMessage",
+    "SendUserFile",
+    "ShareOnboardingGuide",
     "Skill",
     "StatusBarMessageTool",
+    "Task",
+    "TaskCreate",
+    "TaskGet",
+    "TaskList",
     "TaskOutput",
-    "Monitor",
+    "TaskStop",
+    "TaskUpdate",
+    "TodoRead",
+    "TodoWrite",
+    "ToolSearch",
+    "WaitForMcpServers",
+    "WebFetch",
+    "WebSearch",
+    "Workflow",
+    "Write",
 ];
 
 const RULE_IDS: &[&str] = &[
@@ -2894,15 +2929,17 @@ Agent instructions"#;
 
     #[test]
     fn test_cc_ag_009_mcp_tool_invalid_formats() {
-        // Test various invalid MCP formats
+        // Test various invalid MCP formats. `mcp__server` is NOT here: the
+        // sub-agents reference documents the server-only form as valid, so it
+        // is covered by test_cc_ag_009_mcp_server_only_form_accepted below.
         let content = r#"---
 name: my-agent
 description: A test agent
 tools:
   - Read
   - mcp__
-  - mcp__server
   - mcp__bad name
+  - mcp__supabase-*
   - MCP__server__tool
 ---
 Agent instructions"#;
@@ -2912,8 +2949,72 @@ Agent instructions"#;
             .iter()
             .filter(|d| d.rule == "CC-AG-009")
             .collect();
-        // Should flag: mcp__, mcp__server, mcp__bad name, MCP__server__tool (uppercase)
+        // Should flag: mcp__, mcp__bad name, mcp__supabase-* (glob in the
+        // server segment), MCP__server__tool (uppercase prefix)
         assert_eq!(cc_ag_009.len(), 4, "Invalid MCP formats should be rejected");
+    }
+
+    /// The sub-agents reference documents `mcp__<server>` and
+    /// `mcp__<server>__*` as equivalent server-level patterns for both
+    /// `tools` and `disallowedTools`, so neither may be flagged. Regression
+    /// for the CC-AG-009/010 half of upstream issue #1277.
+    #[test]
+    fn test_cc_ag_009_mcp_server_only_form_accepted() {
+        let content = r#"---
+name: my-agent
+description: A test agent
+tools:
+  - Read
+  - mcp__supabase-ssh
+  - mcp__playwright__*
+disallowedTools:
+  - mcp__github
+---
+Agent instructions"#;
+
+        let diagnostics = validate(content);
+        let tool_name_hits: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-AG-009" || d.rule == "CC-AG-010")
+            .collect();
+        assert!(
+            tool_name_hits.is_empty(),
+            "server-only MCP form must be accepted in tools and disallowedTools, got: {tool_name_hits:?}"
+        );
+    }
+
+    /// `Workflow` and the other tools added to the built-in tools reference
+    /// must not be flagged as unknown. Subagents never receive `Workflow`,
+    /// but Claude Code filters it from the resolved pool rather than
+    /// rejecting the name, so CC-AG-009 must stay silent.
+    #[test]
+    fn test_cc_ag_009_recent_builtin_tools_accepted() {
+        let content = r#"---
+name: my-agent
+description: A test agent
+tools:
+  - Workflow
+  - ToolSearch
+  - Artifact
+  - ReportFindings
+  - SendUserFile
+  - EndConversation
+  - PowerShell
+  - LSP
+  - TaskCreate
+  - EnterWorktree
+---
+Agent instructions"#;
+
+        let diagnostics = validate(content);
+        let cc_ag_009: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.rule == "CC-AG-009")
+            .collect();
+        assert!(
+            cc_ag_009.is_empty(),
+            "documented built-in tools must be accepted, got: {cc_ag_009:?}"
+        );
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -1,7 +1,7 @@
 //! Skill file validation
 
 use crate::{
-    config::{LintConfig, PerFileLintConfig},
+    config::PerFileLintConfig,
     diagnostics::{Diagnostic, Fix},
     parsers::frontmatter::{FrontmatterParts, split_frontmatter},
     regex_util::static_regex,
@@ -226,17 +226,19 @@ const VALID_MODELS_DESC: &str = "sonnet, opus, haiku, inherit, or claude-*";
 const BUILTIN_AGENTS: &[&str] = &["Explore", "Plan", "general-purpose"];
 
 /// Known Claude Code tool names for CC-SK-008. Union of the current built-in
-/// tools reference (code.claude.com/docs/en/tools, verified 2026-05-24 - adds
-/// PowerShell, the Cron*/Team*/Worktree/MCP-resource tools, ScheduleWakeup,
-/// etc.) plus legacy/internal names kept for version tolerance. Alphabetized.
+/// tools reference (code.claude.com/docs/en/tools, verified 2026-07-31 - adds
+/// Artifact, EndConversation, ReportFindings, SendUserFile, and Workflow)
+/// plus legacy/internal names kept for version tolerance. Alphabetized.
 const KNOWN_TOOLS: &[&str] = &[
     "Agent",
+    "Artifact",
     "AskUserQuestion",
     "Bash",
     "CronCreate",
     "CronDelete",
     "CronList",
     "Edit",
+    "EndConversation",
     "EnterPlanMode",
     "EnterWorktree",
     "ExitPlanMode",
@@ -253,9 +255,11 @@ const KNOWN_TOOLS: &[&str] = &[
     "Read",
     "ReadMcpResourceTool",
     "RemoteTrigger",
+    "ReportFindings",
     "ScheduleWakeup",
     "SendMessage",
     "SendMessageTool",
+    "SendUserFile",
     "ShareOnboardingGuide",
     "Skill",
     "StatusBarMessageTool",
@@ -274,6 +278,7 @@ const KNOWN_TOOLS: &[&str] = &[
     "WaitForMcpServers",
     "WebFetch",
     "WebSearch",
+    "Workflow",
     "Write",
 ];
 
@@ -398,8 +403,13 @@ struct ValidationContext<'a> {
     path: &'a Path,
     /// Raw file content
     content: &'a str,
-    /// Lint configuration (rule enablement, filesystem access)
-    config: &'a LintConfig,
+    /// Per-file lint configuration view (rule enablement, filesystem access).
+    ///
+    /// This MUST stay a [`PerFileLintConfig`] rather than the `&LintConfig` it
+    /// derefs to: `is_rule_enabled` differs between the two, and storing the
+    /// bare config here silently dropped every `[[overrides]]` block for the
+    /// whole AS-*/CC-SK-* family (upstream issue #1277).
+    config: &'a PerFileLintConfig<'a>,
     /// Parsed frontmatter sections (header, body, byte positions)
     parts: FrontmatterParts,
     /// Byte offsets of line starts for position tracking
@@ -418,7 +428,7 @@ struct ValidationContext<'a> {
 }
 
 impl<'a> ValidationContext<'a> {
-    fn new(path: &'a Path, content: &'a str, config: &'a LintConfig) -> Self {
+    fn new(path: &'a Path, content: &'a str, config: &'a PerFileLintConfig<'a>) -> Self {
         let parts = split_frontmatter(content);
         let line_starts = compute_line_starts(content);
         let client = resolve_skill_client(path, config);

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -1692,6 +1692,96 @@ Body"#;
     );
 }
 
+/// The Claude Code permissions reference documents `mcp__<server>` and
+/// `mcp__<server>__*` as equivalent server-level MCP rules, so CC-SK-008 must
+/// accept both. Regression for the CC-SK-008 half of upstream issue #1277.
+#[test]
+fn test_cc_sk_008_mcp_server_only_form_valid() {
+    let content = r#"---
+name: test-skill
+description: Use when testing
+allowed-tools: Read, mcp__supabase-ssh, mcp__playwright, mcp__github__*
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let cc_sk_008: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-008")
+        .collect();
+
+    assert!(
+        cc_sk_008.is_empty(),
+        "server-only MCP form `mcp__<server>` must be accepted, got: {cc_sk_008:?}"
+    );
+}
+
+/// The server segment names one configured server, so a glob there is still
+/// rejected even though the server-only form is now accepted.
+#[test]
+fn test_cc_sk_008_mcp_glob_in_server_segment_rejected() {
+    let content = r#"---
+name: test-skill
+description: Use when testing
+allowed-tools: Read, mcp__supabase-*, mcp__*
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let cc_sk_008: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-008")
+        .collect();
+
+    assert_eq!(
+        cc_sk_008.len(),
+        2,
+        "a glob in the server segment must still be rejected, got: {cc_sk_008:?}"
+    );
+}
+
+/// `Workflow` and the other tools added to the built-in tools reference must
+/// not be flagged as unknown. Regression for the `Workflow` false positive
+/// reported in upstream issue #1277.
+#[test]
+fn test_cc_sk_008_recent_builtin_tools_accepted() {
+    let content = r#"---
+name: test-skill
+description: Use when testing
+allowed-tools: Workflow, Artifact, ReportFindings, SendUserFile, EndConversation
+---
+Body"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let cc_sk_008: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-008")
+        .collect();
+
+    assert!(
+        cc_sk_008.is_empty(),
+        "documented built-in tools must be accepted, got: {cc_sk_008:?}"
+    );
+}
+
 #[test]
 fn test_cc_sk_008_mcp_case_sensitive() {
     let content = r#"---

--- a/crates/agnix-core/src/validation/mod.rs
+++ b/crates/agnix-core/src/validation/mod.rs
@@ -1,16 +1,29 @@
 //! Shared validation utilities
 
 /// Check if a tool name is valid (either known or properly formatted MCP tool).
-/// MCP tools must follow the format: mcp__<server>__<tool> (case-sensitive, lowercase prefix).
+///
+/// Two MCP forms are accepted, both documented as equivalent by Claude Code:
+/// the server-only `mcp__<server>` (matches every tool from that server) and
+/// the fully qualified `mcp__<server>__<tool>` (see
+/// <https://code.claude.com/docs/en/permissions> "MCP" and
+/// <https://code.claude.com/docs/en/sub-agents> "Available tools"). The
+/// `mcp__` prefix is case-sensitive and must be lowercase.
+///
+/// The server segment must be glob-free - the same docs require an allow rule
+/// to name a specific configured server - so `mcp__supabase-*` is rejected
+/// while the tool segment may glob (`mcp__github__get_*`).
 ///
 /// # Examples
 /// ```
 /// use agnix_core::validation::is_valid_mcp_tool_format;
 ///
 /// assert!(is_valid_mcp_tool_format("mcp__filesystem__read_file", &["Read", "Write"]));
+/// assert!(is_valid_mcp_tool_format("mcp__playwright", &["Read"])); // Server-only form
+/// assert!(is_valid_mcp_tool_format("mcp__github__get_*", &["Read"])); // Tool-segment glob
 /// assert!(is_valid_mcp_tool_format("Read", &["Read", "Write"]));
 /// assert!(!is_valid_mcp_tool_format("mcp__", &["Read"])); // Empty
-/// assert!(!is_valid_mcp_tool_format("mcp__server", &["Read"])); // No tool part
+/// assert!(!is_valid_mcp_tool_format("mcp__supabase-*", &["Read"])); // Glob in server segment
+/// assert!(!is_valid_mcp_tool_format("mcp__bad name", &["Read"])); // Whitespace in server segment
 /// assert!(!is_valid_mcp_tool_format("MCP__server__tool", &["Read"])); // Uppercase
 /// ```
 pub fn is_valid_mcp_tool_format(tool: &str, known_tools: &[&str]) -> bool {
@@ -23,15 +36,20 @@ pub fn is_valid_mcp_tool_format(tool: &str, known_tools: &[&str]) -> bool {
         return true;
     }
 
-    // Check if it's a valid MCP tool: mcp__<server>__<tool>
+    // Check if it's a valid MCP tool: mcp__<server> or mcp__<server>__<tool>
     if let Some(rest) = base_name.strip_prefix("mcp__") {
-        // Must have at least one more double-underscore separator for server__tool
-        // and both server and tool parts must be non-empty
-        if let Some(tool_start) = rest.find("__") {
-            let server = &rest[..tool_start];
-            let tool_name = &rest[tool_start + 2..];
-            return !server.is_empty() && !tool_name.is_empty();
-        }
+        let (server, tool_name) = match rest.find("__") {
+            Some(tool_start) => (&rest[..tool_start], Some(&rest[tool_start + 2..])),
+            // Server-only form: `mcp__<server>` matches any tool from that server.
+            None => (rest, None),
+        };
+        // The server segment names one configured server, so it can't be
+        // empty, contain a glob, or contain whitespace. The tool segment, when
+        // present, must be non-empty but may glob (`mcp__github__get_*`).
+        return !server.is_empty()
+            && !server.contains('*')
+            && !server.chars().any(char::is_whitespace)
+            && tool_name.is_none_or(|name| !name.is_empty());
     }
 
     false

--- a/crates/agnix-core/tests/overrides_integration.rs
+++ b/crates/agnix-core/tests/overrides_integration.rs
@@ -333,6 +333,59 @@ fn overrides_partial_agm006_no_cross_mention() {
     );
 }
 
+/// Regression for upstream issue #1277: `[[overrides]]` had no effect on any
+/// rule emitted by the skill validator (the whole AS-*/CC-SK-* family),
+/// because its internal `ValidationContext` stored the `&LintConfig` that
+/// `PerFileLintConfig` derefs to, dropping the per-file override layer before
+/// any `is_rule_enabled` call. Reported as Windows-specific but platform
+/// independent.
+#[test]
+fn overrides_suppress_skill_validator_rules() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let skill_dir = temp.path().join("skills").join("picky");
+    fs::create_dir_all(&skill_dir).unwrap();
+    // `FooBarTool` is not a Claude Code tool, so CC-SK-008 fires.
+    fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\nname: picky\ndescription: Use when testing per-file overrides on skills\nallowed-tools: Read, FooBarTool\n---\n\nBody\n",
+    )
+    .unwrap();
+
+    // Baseline: CC-SK-008 fires without an override.
+    let baseline =
+        validate_project(temp.path(), &LintConfig::default()).expect("validate_project (baseline)");
+    let baseline_hits: Vec<_> = baseline
+        .diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-008")
+        .collect();
+    assert_eq!(
+        baseline_hits.len(),
+        1,
+        "baseline: expected CC-SK-008 for the unknown tool, got: {baseline_hits:?}"
+    );
+
+    let config = LintConfig::builder()
+        .overrides(vec![OverrideConfig {
+            paths: vec!["skills/picky/SKILL.md".to_string()],
+            disabled_rules: vec!["CC-SK-008".to_string()],
+        }])
+        .build()
+        .expect("valid config");
+
+    let result = validate_project(temp.path(), &config).expect("validate_project");
+
+    let hits: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-008")
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "override on `skills/picky/SKILL.md` must suppress CC-SK-008, got: {hits:?}"
+    );
+}
+
 /// Regression for project-level rule VER-001: per-file `[[overrides]]`
 /// must suppress VER-001 when the override targets the diagnostic's
 /// report path (`.agnix.toml` when present, project root otherwise).

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -70,9 +70,10 @@ rules:
     suggestion: Use scoped Bash like 'Bash(git:*)' or 'Bash(npm:*)' instead of plain 'Bash'
     fix: Replace unrestricted Bash with scoped Bash(git:*)
   cc_sk_008:
-    message: 'Unknown tool ''%{tool}''. Known tools: %{known}. MCP tools must use lowercase mcp__<server>__<tool> format'
-    suggestion: 'Use one of the known Claude Code tools: %{known}, or a valid MCP tool (mcp__<server>__<tool>, case-sensitive
-      lowercase prefix)'
+    message: 'Unknown tool ''%{tool}''. Known tools: %{known}. MCP tools must use lowercase mcp__<server> or mcp__<server>__<tool>
+      format'
+    suggestion: 'Use one of the known Claude Code tools: %{known}, or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>,
+      case-sensitive lowercase prefix, no glob in the server segment)'
   cc_sk_009:
     message: Too many dynamic injections (%{count}). Limit to %{max} for better performance
     suggestion: Consider moving complex logic to a scripts/ directory or reducing injections
@@ -284,12 +285,14 @@ rules:
     suggestion: 'Use one of: user, project, local'
     fix: Change memory scope to '%{fixed}'
   cc_ag_009:
-    message: 'Unknown tool ''%{tool}'' in tools list. Known tools: %{known}. MCP tools must use lowercase mcp__<server>__<tool>
-      format'
-    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server>__<tool>, case-sensitive lowercase prefix)
+    message: 'Unknown tool ''%{tool}'' in tools list. Known tools: %{known}. MCP tools must use lowercase mcp__<server> or
+      mcp__<server>__<tool> format'
+    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>, case-sensitive
+      lowercase prefix, no glob in the server segment)
   cc_ag_010:
     message: 'Unknown tool ''%{tool}'' in disallowedTools list. Known tools: %{known}'
-    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server>__<tool>, case-sensitive lowercase prefix)
+    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>, case-sensitive
+      lowercase prefix, no glob in the server segment)
   cc_ag_011:
     message: 'Invalid hooks configuration in agent frontmatter: %{error}'
     suggestion: Ensure hooks follow the same schema as settings.json hooks

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -997,9 +997,10 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://code.claude.com/docs/en/sub-agents"
+          "https://code.claude.com/docs/en/sub-agents",
+          "https://code.claude.com/docs/en/tools"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -1024,9 +1025,10 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://code.claude.com/docs/en/sub-agents"
+          "https://code.claude.com/docs/en/sub-agents",
+          "https://code.claude.com/docs/en/tools"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3296,9 +3298,11 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://code.claude.com/docs/en/settings"
+          "https://code.claude.com/docs/en/settings",
+          "https://code.claude.com/docs/en/tools",
+          "https://code.claude.com/docs/en/permissions"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -267,8 +267,8 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 <a id="cc-sk-008"></a>
 ### CC-SK-008 [HIGH] Unknown Tool Name
 **Requirement**: Tool names MUST match Claude Code tools. **Claude Code skills only** - other clients (Codex/OpenCode/…) have their own tool vocabularies, so this is scoped to the owning client.
-**Known Tools**: the current built-in set (code.claude.com/docs/en/tools, verified 2026-05-24) incl. `PowerShell`, `Agent`, `Cron*`, `Team*`, `EnterWorktree`/`ExitWorktree`, `ScheduleWakeup`, `ListMcpResourcesTool`/`ReadMcpResourceTool`, `WaitForMcpServers`, plus legacy names kept for tolerance
-**Detection**: skill client is Claude Code AND tool not in the set; MCP tools with lowercase `mcp__<server>__<tool>` format are accepted (case-sensitive prefix)
+**Known Tools**: the current built-in set (code.claude.com/docs/en/tools, verified 2026-07-31) incl. `PowerShell`, `Agent`, `Workflow`, `Artifact`, `ReportFindings`, `SendUserFile`, `EndConversation`, `Cron*`, `Team*`, `EnterWorktree`/`ExitWorktree`, `ScheduleWakeup`, `ListMcpResourcesTool`/`ReadMcpResourceTool`, `WaitForMcpServers`, plus legacy names kept for tolerance
+**Detection**: skill client is Claude Code AND tool not in the set; MCP tools are accepted in both documented forms - server-only `mcp__<server>` and fully qualified `mcp__<server>__<tool>` (case-sensitive lowercase prefix). The tool segment may glob (`mcp__github__get_*`); the server segment may not, since a rule must name one configured server
 **Fix**: Suggest closest match
 **Source**: code.claude.com/docs/en/tools
 
@@ -986,14 +986,14 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 <a id="cc-ag-009"></a>
 ### CC-AG-009 [HIGH] Invalid Tool Name in Tools List
 **Requirement**: Tool names in `tools` MUST match known Claude Code tools
-**Detection**: Check each tool name against known tools list; MCP tools with lowercase `mcp__<server>__<tool>` format are accepted (case-sensitive prefix)
+**Detection**: Check each tool name against known tools list; MCP tools are accepted in both documented forms - server-only `mcp__<server>` and fully qualified `mcp__<server>__<tool>` (case-sensitive lowercase prefix), with globs allowed in the tool segment only
 **Fix**: Use a known Claude Code tool name
 **Source**: code.claude.com/docs/en/sub-agents
 
 <a id="cc-ag-010"></a>
 ### CC-AG-010 [HIGH] Invalid Tool Name in DisallowedTools
 **Requirement**: Tool names in `disallowedTools` MUST match known Claude Code tools
-**Detection**: Check each disallowed tool name against known tools list; MCP tools with lowercase `mcp__<server>__<tool>` format are accepted (case-sensitive prefix)
+**Detection**: Check each disallowed tool name against known tools list; MCP tools are accepted in both documented forms - server-only `mcp__<server>` and fully qualified `mcp__<server>__<tool>` (case-sensitive lowercase prefix), with globs allowed in the tool segment only
 **Fix**: Use a known Claude Code tool name
 **Source**: code.claude.com/docs/en/sub-agents
 

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -997,9 +997,10 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://code.claude.com/docs/en/sub-agents"
+          "https://code.claude.com/docs/en/sub-agents",
+          "https://code.claude.com/docs/en/tools"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -1024,9 +1025,10 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://code.claude.com/docs/en/sub-agents"
+          "https://code.claude.com/docs/en/sub-agents",
+          "https://code.claude.com/docs/en/tools"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3296,9 +3298,11 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://code.claude.com/docs/en/settings"
+          "https://code.claude.com/docs/en/settings",
+          "https://code.claude.com/docs/en/tools",
+          "https://code.claude.com/docs/en/permissions"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -70,9 +70,10 @@ rules:
     suggestion: Use scoped Bash like 'Bash(git:*)' or 'Bash(npm:*)' instead of plain 'Bash'
     fix: Replace unrestricted Bash with scoped Bash(git:*)
   cc_sk_008:
-    message: 'Unknown tool ''%{tool}''. Known tools: %{known}. MCP tools must use lowercase mcp__<server>__<tool> format'
-    suggestion: 'Use one of the known Claude Code tools: %{known}, or a valid MCP tool (mcp__<server>__<tool>, case-sensitive
-      lowercase prefix)'
+    message: 'Unknown tool ''%{tool}''. Known tools: %{known}. MCP tools must use lowercase mcp__<server> or mcp__<server>__<tool>
+      format'
+    suggestion: 'Use one of the known Claude Code tools: %{known}, or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>,
+      case-sensitive lowercase prefix, no glob in the server segment)'
   cc_sk_009:
     message: Too many dynamic injections (%{count}). Limit to %{max} for better performance
     suggestion: Consider moving complex logic to a scripts/ directory or reducing injections
@@ -284,12 +285,14 @@ rules:
     suggestion: 'Use one of: user, project, local'
     fix: Change memory scope to '%{fixed}'
   cc_ag_009:
-    message: 'Unknown tool ''%{tool}'' in tools list. Known tools: %{known}. MCP tools must use lowercase mcp__<server>__<tool>
-      format'
-    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server>__<tool>, case-sensitive lowercase prefix)
+    message: 'Unknown tool ''%{tool}'' in tools list. Known tools: %{known}. MCP tools must use lowercase mcp__<server> or
+      mcp__<server>__<tool> format'
+    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>, case-sensitive
+      lowercase prefix, no glob in the server segment)
   cc_ag_010:
     message: 'Unknown tool ''%{tool}'' in disallowedTools list. Known tools: %{known}'
-    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server>__<tool>, case-sensitive lowercase prefix)
+    suggestion: Use a known Claude Code tool name or a valid MCP tool (mcp__<server> or mcp__<server>__<tool>, case-sensitive
+      lowercase prefix, no glob in the server segment)
   cc_ag_011:
     message: 'Invalid hooks configuration in agent frontmatter: %{error}'
     suggestion: Ensure hooks follow the same schema as settings.json hooks

--- a/website/docs/rules/generated/cc-ag-009.md
+++ b/website/docs/rules/generated/cc-ag-009.md
@@ -13,7 +13,7 @@ keywords: ["CC-AG-009", "invalid tool name in tools list", "claude agents", "val
 - **Category**: `Claude Agents`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-04-22`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 
@@ -24,6 +24,7 @@ keywords: ["CC-AG-009", "invalid tool name in tools list", "claude agents", "val
 ## Evidence Sources
 
 - https://code.claude.com/docs/en/sub-agents
+- https://code.claude.com/docs/en/tools
 
 ## Test Coverage Metadata
 

--- a/website/docs/rules/generated/cc-ag-010.md
+++ b/website/docs/rules/generated/cc-ag-010.md
@@ -13,7 +13,7 @@ keywords: ["CC-AG-010", "invalid tool name in disallowedtools", "claude agents",
 - **Category**: `Claude Agents`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-04-22`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 
@@ -24,6 +24,7 @@ keywords: ["CC-AG-010", "invalid tool name in disallowedtools", "claude agents",
 ## Evidence Sources
 
 - https://code.claude.com/docs/en/sub-agents
+- https://code.claude.com/docs/en/tools
 
 ## Test Coverage Metadata
 

--- a/website/docs/rules/generated/cc-sk-008.md
+++ b/website/docs/rules/generated/cc-sk-008.md
@@ -13,7 +13,7 @@ keywords: ["CC-SK-008", "unknown tool name", "claude skills", "validation", "agn
 - **Category**: `Claude Skills`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-02-04`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 
@@ -24,6 +24,8 @@ keywords: ["CC-SK-008", "unknown tool name", "claude skills", "validation", "agn
 ## Evidence Sources
 
 - https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/tools
+- https://code.claude.com/docs/en/permissions
 
 ## Test Coverage Metadata
 


### PR DESCRIPTION
Closes #1277.

The issue reported one bug and a comment added a second. Investigating turned up three distinct defects.

## 1. `[[overrides]]` had no effect on any skill rule

Reproduced on Linux from the reporter's exact config, so the Windows path-matching theory in the issue was a red herring - the platform was incidental.

`SkillValidator::validate_per_file` receives a `PerFileLintConfig`, but its internal `ValidationContext` declared the field as `&'a LintConfig`. Deref coercion silently converted it at the construction site, dropping the per-file override layer before any `is_rule_enabled` call. Since `is_rule_enabled` is the *only* method that differs between the two types, this was invisible at the call sites.

Effect: every AS-* and CC-SK-* rule ignored `[[overrides]]` on all platforms, with no way to suppress one for a single file. Global `[rules].disabled_rules` was unaffected, which matches the reporter's observation that it kept working.

The field now holds the per-file view, with a comment on why it must not be widened back.

## 2. Server-only MCP form was rejected

Per the [permissions reference](https://code.claude.com/docs/en/permissions), `mcp__puppeteer` and `mcp__puppeteer__*` are equivalent ways to name every tool from one server. The [sub-agents reference](https://code.claude.com/docs/en/sub-agents) documents the same for `tools` and `disallowedTools`: "Both fields accept MCP server-level patterns in addition to exact tool names: `mcp__<server>` or `mcp__<server>__*`".

`is_valid_mcp_tool_format` required the second `__`, so `mcp__playwright` errored while `mcp__playwright__*` passed. Both forms are now accepted.

The reporter was right that rejecting a glob in the server segment is correct - the same doc requires a rule to name a specific configured server - so `mcp__supabase-*` and `mcp__*` still fail. Tool-segment globs (`mcp__github__get_*`) still pass.

An existing test caught a real regression here: `mcp__bad name` initially started passing as a server-only form. The server segment now also rejects whitespace.

## 3. Stale known-tools lists

`Workflow` is in the [built-in tools reference](https://code.claude.com/docs/en/tools) but was missing from CC-SK-008, along with `Artifact`, `ReportFindings`, `SendUserFile`, and `EndConversation`.

CC-AG-009/010's list was much further behind - 26 documented tools absent, including the `Cron*`/`Task*` families, `PowerShell`, `LSP`, `ToolSearch`, and the worktree and MCP-resource tools - so a subagent declaring any of them failed validation.

Both lists are reconciled against the docs table by diffing rather than reading release notes. One judgment call: tools subagents never receive (`AskUserQuestion`, `Workflow`, `ScheduleWakeup`, …) stay in the agent list, because the sub-agents doc says Claude Code filters those from the resolved pool rather than rejecting the name - flagging them as unknown would be wrong. That reasoning is recorded in a comment on the constant.

## Tests

- End-to-end `validate_project` regression for the override leak, with a baseline assertion so it can't pass vacuously
- Server-only MCP form accepted in `allowed-tools`, `tools`, and `disallowedTools`
- Glob in the server segment still rejected
- Newly recognized built-in tools accepted for both rule families
- Updated `test_cc_ag_009_mcp_tool_invalid_formats`, which asserted the now-valid `mcp__server` was invalid; `mcp__supabase-*` replaces it so the count still covers four genuinely invalid forms

Full suite: 5039 tests across 37 binaries, zero failures. `cargo fmt --check` and `cargo clippy --all-targets` clean. Rule bookkeeping, locale sync, and rule-count checks pass.

## Notes

- Diagnostic messages and the `es`/`zh-CN` locales: only `en` documents the MCP format, so only it changed. All four locale copies re-synced via `scripts/check-locale-sync.sh`.
- `verified_on` for the three rules advanced to 2026-07-31 with the tools and permissions references added as evidence URLs.
- `schemas/cross_platform.rs` has its own `KNOWN_TOOLS`, left alone: it feeds prose-mention detection for XP-005, not a validation gate.