### PR TITLE
fix(ci): repair Spec Drift Sentinel output writes [skip changelog]

### DIFF
--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -249,14 +249,27 @@ jobs:
           echo ""
           echo "drift_detected=$DRIFT_DETECTED" >> "$GITHUB_OUTPUT"
 
-          # Use multiline output syntax for drift report
+          # Use multiline output syntax for the drift report. The delimiter is
+          # randomized because DRIFT_REPORT embeds upstream-controlled text
+          # (filenames from fetch_github_diff): a literal `EOF` line in that
+          # content would otherwise close the block early and let the rest of
+          # the report inject arbitrary step outputs.
+          report_delim="DRIFT_REPORT_EOF_$(openssl rand -hex 16)"
           {
-            echo "drift_report<<EOF"
+            echo "drift_report<<${report_delim}"
             echo -e "$DRIFT_REPORT"
-            echo "EOF"
+            echo "${report_delim}"
           } >> "$GITHUB_OUTPUT"
 
-          # Output drift sources JSON for downstream jobs
+          # Output drift sources JSON for downstream jobs.
+          #
+          # `jq` pretty-prints by default and the `key=value` form of
+          # GITHUB_OUTPUT takes single-line values only, so a drifted run wrote
+          # a multi-line value and failed the whole step with
+          # `Invalid format '  {'`. That aborted the step before the
+          # issue-filing step could run, so the sentinel reported nothing from
+          # 2026-03-29 onward. `-c` keeps the JSON on one line.
+          DRIFT_SOURCES_JSON=$(printf '%s' "$DRIFT_SOURCES_JSON" | jq -c '.')
           echo "drift_sources=$DRIFT_SOURCES_JSON" >> "$GITHUB_OUTPUT"
 
           # Output new hashes if update requested


### PR DESCRIPTION
The Spec Drift Sentinel has reported nothing since **2026-03-29**. It was not merely failing loudly - it was failing *after* detecting drift and *before* filing an issue, so the whole point of the workflow was silently lost for four months across 15 tracked upstream sources.

Found while releasing v0.43.0: the workflow showed red on the release commit, and checking whether it was a release blocker turned up the actual defect.

## Root cause

`DRIFT_SOURCES_JSON` is accumulated with `jq`, which pretty-prints by default. The `key=value` form of `GITHUB_OUTPUT` accepts single-line values only, so the step wrote a multi-line value and died with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '  {'
```

`  {` is literally line 2 of the pretty-printed array.

Because `set -euo pipefail` is in effect and the write is the failing command, the step aborted there. Consequence chain:

- `Create or update drift issue` - `skipped` (gated on the step's output)
- `Request Claude analysis` job - `skipped` (gated on the same output)

So drift was detected on every run, reported nowhere. Confirmed against the latest run's step outcomes.

Fix: pipe through `jq -c` so the value stays on one line.

## Why it passed before

The bug landed 2026-02-04 (`9231db85`), yet the workflow succeeded as recently as 2026-03-28 - the run that filed #695.

A run only writes a non-empty array when drift is found; a clean run writes `[]`, which is single-line and parses fine. 2026-03-29 was the first drifted run after the regression, and every run since has failed. Run history shows exactly one `success` followed by an unbroken wall of `failure`.

## Second fix: heredoc delimiter injection

`drift_report` is written with a multi-line block using a literal `EOF` delimiter, and the report interpolates **upstream-controlled text** - `fetch_github_diff` pulls filenames from arbitrary tracked repos via `gh api`. A file named `EOF` closes the block early and lets the remaining report lines inject arbitrary step outputs:

```
drift_report<<EOF

- file: EOF
malicious=1     <-- parsed as its own step output
EOF
```

Reproduced locally, then fixed by randomizing the delimiter per run (`openssl rand -hex 16`, GitHub's documented pattern for this).

## Verification

Extracted the real step body from the YAML (by line range - `${{ }}` expressions defeat a plain YAML parse) and ran it against the live upstream URLs:

- Step completes instead of aborting; detects **15** drifted sources
- `drift_sources` is one line and valid JSON (`jq -e 'type=="array"'` returns true)
- Emulated the Actions output-file parser: **zero** format errors, all three outputs (`drift_detected`, `drift_report`, `drift_sources`) read back correctly
- Adversarial test with a literal `EOF` line in the report: injected `malicious=` no longer escapes the block
- Both downstream consumers verified against the real output - `ALL_RULES` in the issue step, `SOURCES_LIST`/`RULES_LIST` in the Claude step
- `bash -n` clean on the modified step and on the consuming step; YAML parses

## Note on scope

I also thought the issue body carried 10 spaces of indentation per line and started rewriting both bodies as heredocs. Testing under bash showed my own heredoc was broken (an indented terminator never matches), and parsing the real YAML proved the original was correct - block scalars strip the common indent. Reverted entirely. This diff is the two real fixes only, +17/-4.

## After merge

The next scheduled run will file one issue listing all 15 drifted sources. That is four months of accumulated upstream change surfacing at once, not new breakage - the S-tier sources (agent-skills-spec, claude-code-hooks/memory/plugins/skills/subagents, codex-cli-agents-md, mcp-spec) are the ones worth reviewing first.

`[skip changelog]`: CI-internal plumbing, no user-facing behavior change.
