### PR TITLE
fix: fourth pass on spec drift - clears the #1281 tail (#1281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`args` on command hooks**. The exec-form field - "When present, `command` is resolved as an executable and spawned directly with `args` as the argument vector, with no shell involved" - was absent from the schema, so it was silently ignored and two rules could not tell exec form from shell form.
+
+### Fixed
+- **CC-SK-009 miscounted dynamic injections in both directions**. It counted raw `` !` `` occurrences, so inert `` KEY=!`cmd` `` forms inflated the count (the doc: a `!` following another character "is left as literal text and the command does not run"), while ` ```! ` fenced blocks - where every line is a command - counted as zero. Counting now honors both documented forms and ignores plain fences.
+- **CC-SK-012/CC-SK-016 recognized only `$ARGUMENTS`**. The substitution table documents four forms; a body using the `$N` shorthand or a `$name` declared in `arguments` was reported as ignoring its own arguments, and `$0` escaped CC-SK-016 entirely. The `arguments` frontmatter field is now parsed so named placeholders can be resolved. The shorthand is matched as a single digit, matching the documented examples, so `${CLAUDE_SKILL_DIR}`, `x$3y`, and prose amounts like `$500` are not mistaken for positional arguments.
+- **CC-HK-028 flagged the exec form the doc recommends**. `${user_config.*}` is rejected only in shell form: "Plugin hooks additionally substitute `${user_config.*}` values, **in exec form only**". The rule fired regardless of `args`, so `{"command": "${user_config.formatter}", "args": ["--fix"]}` errored.
+- **CC-HK-008 skipped scripts named in `args`**. In exec form the script sits in `args` while `command` names an interpreter, so exec-form hooks - the form the doc recommends for path placeholders - got no script-existence checking at all.
+- **AS-013 only inspected `references/` paths**. The spec scopes skill resources to "`scripts/`, `references/`, or `assets/`" and uses `scripts/extract.py` in its own example, so deep `scripts/` and `assets/` paths were invisible. Git ref paths stay excluded.
+- **AS-017 rejected Claude Code display labels**. Claude Code decouples `name` from the directory ("`name` sets only the display label... the command still comes from the directory or file name"), and a plugin skill's `name` deliberately replaces the last command segment - the reference's own `name: fancy` in `skills/review/` example errored. Scoped out for Claude Code skills, following the AS-008 precedent; the agentskills.io baseline still requires the match.
+- **CC-PL-002 checked four of eight directories**. The doc names `commands/`, `agents/`, `skills/`, `workflows/`, `output-styles/`, `themes/`, `monitors/`, and `hooks/` as forbidden inside `.claude-plugin/`.
+- **CC-PL-007/CC-PL-008 checked four of ten path fields**. `workflows`, `mcpServers`, `outputStyles`, `lspServers`, `experimental.themes`, and `experimental.monitors` accepted absolute paths, `..` traversal, and `.claude-plugin/` targets unchecked. Dotted `experimental.*` keys are now traversed, which a plain field lookup could not do.
+- **XP-007 ignored `AGENTS.override.md`**. Codex reads it first in each directory, so it draws on the same `project_doc_max_bytes` budget; the code comment claiming Codex "reads this file, not local/override variants" was contradicted by the current guide. The cap is cumulative across the root-to-cwd chain while this check remains per-file - noted in the rule docs as a known gap.
+- **AGM-006's suggestion contradicted upstream**. It advised consolidating files, while Codex documents root-down concatenation with nearest-file-wins precedence and recommends splitting across nested directories to stay under the byte cap.
+
 ### Removed
 - **CC-SK-003 (Context Without Agent)**. The rule errored when `context: fork` had no `agent` field and shipped an unsafe autofix inserting `agent: general-purpose`. The skills reference states "The `agent` field specifies which subagent configuration to use... **If omitted, uses `general-purpose`**", so the rule demanded that users restate a default the tool already applies. Rule count 443 -> 442.
 

--- a/crates/agnix-core/src/rules/cross_platform.rs
+++ b/crates/agnix-core/src/rules/cross_platform.rs
@@ -113,8 +113,21 @@ impl Validator for CrossPlatformValidator {
         }
 
         // XP-007: AGENTS.md exceeds Codex byte limit (WARNING)
-        // Only check AGENTS.md itself (Codex CLI reads this file, not local/override variants)
-        if config.is_rule_enabled("XP-007") && filename == "AGENTS.md" {
+        //
+        // `AGENTS.override.md` is included: Codex reads it *first* in each
+        // directory ("AGENTS.override.md, then AGENTS.md, then
+        // project_doc_fallback_filenames"), so it counts against the same
+        // `project_doc_max_bytes` budget. The previous comment here claimed
+        // Codex "reads this file, not local/override variants", which the
+        // current guide contradicts.
+        //
+        // Note this remains a per-file check while the documented cap is
+        // cumulative across the root-to-cwd chain, so a project split into
+        // several mid-size files can still be truncated without a diagnostic.
+        // Catching that needs project-level accounting; tracked separately.
+        if config.is_rule_enabled("XP-007")
+            && matches!(filename, "AGENTS.md" | "AGENTS.override.md")
+        {
             if let Some(exceeded) = check_byte_limit(content, CODEX_BYTE_LIMIT) {
                 diagnostics.push(
                     Diagnostic::warning(

--- a/crates/agnix-core/src/rules/hooks/mod.rs
+++ b/crates/agnix-core/src/rules/hooks/mod.rs
@@ -73,13 +73,22 @@ fn validate_cc_hk_006_command_field(
 /// CC-HK-008: Script file not found
 fn validate_cc_hk_008_script_exists(
     command: &str,
+    args: Option<&Vec<String>>,
     project_dir: &Path,
     config: &PerFileLintConfig<'_>,
     path: &Path,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     let fs = config.fs();
-    for script_path in extract_script_paths(command) {
+    // In exec form the script often sits in `args` rather than `command` (e.g.
+    // `command: "node"`, `args: [".claude/hooks/check.js"]`), so scanning only
+    // `command` left exec-form hooks - the form the doc recommends for path
+    // placeholders - with no script-existence checking at all.
+    let arg_paths: Vec<String> = args
+        .map(|list| list.iter().flat_map(|a| extract_script_paths(a)).collect())
+        .unwrap_or_default();
+
+    for script_path in extract_script_paths(command).into_iter().chain(arg_paths) {
         if !has_unresolved_env_vars(&script_path) {
             let resolved = resolve_script_path(&script_path, project_dir);
             if !fs.exists(&resolved) {
@@ -131,10 +140,19 @@ fn validate_cc_hk_009_dangerous_patterns(
 /// environment.
 fn validate_cc_hk_028_user_config_interpolation(
     command: &str,
+    is_exec_form: bool,
     hook_location: &str,
     path: &Path,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    // Exec form is explicitly permitted: "Plugin hooks additionally substitute
+    // `${user_config.*}` values, in exec form only", and only "A shell-form
+    // plugin hook whose `command` references `${user_config.*}` fails with an
+    // error". Presence of `args` is what selects exec form, so firing without
+    // checking it flagged the pattern the doc recommends.
+    if is_exec_form {
+        return;
+    }
     if command.contains("${user_config.") {
         diagnostics.push(
             Diagnostic::error(
@@ -610,6 +628,7 @@ impl Validator for HooksValidator {
                     match hook {
                         Hook::Command {
                             command,
+                            args,
                             timeout,
                             model,
                             ..
@@ -650,6 +669,7 @@ impl Validator for HooksValidator {
                                 if config.is_rule_enabled("CC-HK-008") {
                                     validate_cc_hk_008_script_exists(
                                         cmd,
+                                        args.as_ref(),
                                         project_dir,
                                         config,
                                         path,
@@ -670,6 +690,7 @@ impl Validator for HooksValidator {
                                 if config.is_rule_enabled("CC-HK-028") {
                                     validate_cc_hk_028_user_config_interpolation(
                                         cmd,
+                                        args.is_some(),
                                         &hook_location,
                                         path,
                                         &mut diagnostics,

--- a/crates/agnix-core/src/rules/hooks/tests.rs
+++ b/crates/agnix-core/src/rules/hooks/tests.rs
@@ -5040,3 +5040,93 @@ fn test_cc_hk_028_can_be_disabled() {
     let diagnostics = validate_with_config(content, &config);
     assert!(diagnostics.iter().all(|d| d.rule != "CC-HK-028"));
 }
+
+/// `${user_config.*}` is permitted in exec form - "Plugin hooks additionally
+/// substitute `${user_config.*}` values, in exec form only" - and rejected only
+/// in shell form. CC-HK-028 fired on both, flagging the recommended pattern.
+#[test]
+fn test_cc_hk_028_allows_user_config_in_exec_form() {
+    let content = r#"{
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Edit",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "${user_config.formatter}",
+                                "args": ["--fix"],
+                                "timeout": 60
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+
+    let diagnostics = validate(content);
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-HK-028")
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "exec form (with `args`) permits ${{user_config.*}} and must not be flagged, got: {hits:?}"
+    );
+}
+
+/// Shell form (no `args`) is still rejected.
+#[test]
+fn test_cc_hk_028_still_flags_shell_form() {
+    let content = r#"{
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Edit",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "${user_config.formatter} --fix",
+                                "timeout": 60
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+
+    let diagnostics = validate(content);
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CC-HK-028"),
+        "shell-form ${{user_config.*}} fails at load time and must be flagged, got: {diagnostics:?}"
+    );
+}
+
+/// In exec form the script lives in `args`, so CC-HK-008 must scan there too -
+/// otherwise exec-form hooks got no script-existence checking at all.
+#[test]
+fn test_cc_hk_008_checks_script_paths_in_args() {
+    let content = r#"{
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Edit",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "node",
+                                "args": [".claude/hooks/definitely-missing-agnix-test.js"],
+                                "timeout": 60
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+
+    let diagnostics = validate(content);
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CC-HK-008"),
+        "a missing script named in `args` must be reported, got: {diagnostics:?}"
+    );
+}

--- a/crates/agnix-core/src/rules/plugin.rs
+++ b/crates/agnix-core/src/rules/plugin.rs
@@ -90,7 +90,20 @@ impl Validator for PluginValidator {
         if config.is_rule_enabled("CC-PL-002") && is_in_claude_plugin {
             if let Some(plugin_dir) = plugin_dir {
                 let fs = config.fs();
-                let disallowed = ["skills", "agents", "hooks", "commands"];
+                // The full documented set: "All other directories (commands/,
+                // agents/, skills/, workflows/, output-styles/, themes/,
+                // monitors/, hooks/) must be at the plugin root, not inside
+                // `.claude-plugin/`." Four were missing.
+                let disallowed = [
+                    "commands",
+                    "agents",
+                    "skills",
+                    "workflows",
+                    "output-styles",
+                    "themes",
+                    "monitors",
+                    "hooks",
+                ];
                 for entry in disallowed {
                     if fs.exists(&plugin_dir.join(entry)) {
                         diagnostics.push(
@@ -167,7 +180,22 @@ impl Validator for PluginValidator {
         let pl_007_enabled = config.is_rule_enabled("CC-PL-007");
         let pl_008_enabled = config.is_rule_enabled("CC-PL-008");
         if pl_007_enabled || pl_008_enabled {
-            let path_fields = ["commands", "agents", "skills", "hooks"];
+            // Every documented path-bearing manifest key. The component-path
+            // table lists ten; only four were checked, so six fields accepted
+            // absolute paths, `..` traversal, and `.claude-plugin/` targets
+            // without complaint.
+            let path_fields = [
+                "commands",
+                "agents",
+                "skills",
+                "workflows",
+                "hooks",
+                "mcpServers",
+                "outputStyles",
+                "lspServers",
+                "experimental.themes",
+                "experimental.monitors",
+            ];
             for field in path_fields {
                 if pl_007_enabled {
                     check_component_paths(&raw_value, field, path, content, &mut diagnostics);
@@ -715,6 +743,21 @@ fn check_default_component_shadowing(
 
 /// CC-PL-007: Validate component paths are relative without `..` traversal.
 /// Also flags relative paths missing a `./` prefix (with safe autofix).
+/// Look up a manifest field, traversing one level of dotted key.
+///
+/// `raw_value.get("experimental.themes")` never matches, because the key is
+/// nested under `experimental`. The path-bearing fields include two such keys,
+/// so both CC-PL-007 and CC-PL-008 need this.
+fn manifest_field<'a>(
+    raw_value: &'a serde_json::Value,
+    field: &str,
+) -> Option<&'a serde_json::Value> {
+    match field.split_once('.') {
+        Some((parent, child)) => raw_value.get(parent).and_then(|v| v.get(child)),
+        None => raw_value.get(field),
+    }
+}
+
 fn check_component_paths(
     raw_value: &serde_json::Value,
     field: &str,
@@ -722,7 +765,7 @@ fn check_component_paths(
     content: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    if let Some(val) = raw_value.get(field) {
+    if let Some(val) = manifest_field(raw_value, field) {
         for p in extract_paths(val) {
             if is_invalid_component_path(&p) {
                 // Absolute or traversal path: error without autofix
@@ -771,7 +814,7 @@ fn check_component_inside_claude_plugin(
     path: &Path,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    if let Some(val) = raw_value.get(field) {
+    if let Some(val) = manifest_field(raw_value, field) {
         for p in extract_paths(val) {
             if path_inside_claude_plugin(&p) {
                 diagnostics.push(

--- a/crates/agnix-core/src/rules/project_level.rs
+++ b/crates/agnix-core/src/rules/project_level.rs
@@ -93,7 +93,13 @@ pub(crate) fn run_project_level_checks(
                         description,
                     )
                     .with_suggestion(
-                        "Some tools load AGENTS.md hierarchically. Document inheritance behavior or consolidate files.".to_string(),
+                        // Codex concatenates from the root down, joins with blank
+                        // lines, takes at most one file per directory, and lets
+                        // files nearer the working directory override earlier
+                        // guidance. It also recommends splitting across nested
+                        // directories to stay under the byte cap - the opposite
+                        // of the "consolidate files" advice this used to give.
+                        "AGENTS.md files are merged from the project root down, one per directory, with files nearer the working directory taking precedence. Confirm the layered guidance is consistent, or document the intended precedence.".to_string(),
                     ),
                 );
             }

--- a/crates/agnix-core/src/rules/skill/helpers.rs
+++ b/crates/agnix-core/src/rules/skill/helpers.rs
@@ -43,10 +43,17 @@ pub(super) fn reference_path_too_deep(path: &str) -> bool {
         return false;
     };
 
-    // Check for file references (references/, reference/, refs/)
+    // Check for bundled resource references. The spec scopes skill resources to
+    // "`scripts/`, `references/`, or `assets/`" and states the depth rule over
+    // file references generally - "Keep file references one level deep from
+    // `SKILL.md`" - with `scripts/extract.py` used in its own example. Only the
+    // `references*` spellings were inspected, so deep `scripts/` and `assets/`
+    // paths were invisible to AS-013.
     if !prefix.eq_ignore_ascii_case("references")
         && !prefix.eq_ignore_ascii_case("reference")
         && !prefix.eq_ignore_ascii_case("refs")
+        && !prefix.eq_ignore_ascii_case("scripts")
+        && !prefix.eq_ignore_ascii_case("assets")
     {
         return false;
     }

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -62,6 +62,11 @@ struct SkillFrontmatter {
     allowed_tools: Option<String>,
     #[serde(rename = "argument-hint")]
     argument_hint: Option<String>,
+    // Named positional arguments for `$name` substitution. "Accepts a
+    // space-separated string or a YAML list." Needed so CC-SK-012 can tell a
+    // declared `$issue` placeholder from an unrelated `$word`.
+    #[serde(default, deserialize_with = "de_string_or_space_seq")]
+    arguments: Option<String>,
     #[serde(
         rename = "disable-model-invocation",
         default,
@@ -92,10 +97,17 @@ struct PathMatch {
 
 static_regex!(fn name_format_regex, r"^[a-z0-9]+(-[a-z0-9]+)*$");
 static_regex!(fn consecutive_hyphen_regex, r"-{2,}");
-static_regex!(fn reference_path_regex, "(?i)\\b(?:references?|refs)[/\\\\][^\\s)\\]}>\"']+");
+static_regex!(fn reference_path_regex, "(?i)\\b(?:references?|refs|scripts|assets)[/\\\\][^\\s)\\]}>\"']+");
 static_regex!(fn plain_bash_regex, r"\bBash\b");
 static_regex!(fn imperative_verb_regex, r"(?i)\b(run|execute|create|build|deploy|install|configure|update|delete|remove|add|write|read|check|test|validate|ensure|make|use|call|invoke|start|stop|send|fetch|generate|implement|fix|analyze|review|search|find|move|copy|replace|push|pull|commit|clean|format|lint|parse|process|handle|prepare|download|upload|export|import|open|save|load|connect|verify|apply|enable|disable)\b");
 static_regex!(fn indexed_arguments_regex, r"\$ARGUMENTS\[\d+\]");
+// `$N` shorthand for `$ARGUMENTS[N]`, e.g. `$0`. Restricted to a single digit,
+// matching the documented examples (`$0` for the first argument, `$1` for the
+// second): allowing `\d+` made prose dollar amounts like `$500` read as
+// positional argument 500. A skill needing a tenth argument would use the
+// explicit `$ARGUMENTS[N]` form. Requires a non-word, non-`$` char before the
+// `$` so `x$3y` and `${CLAUDE_SKILL_DIR}` are not mistaken for it.
+static_regex!(fn positional_shorthand_regex, r"(?:^|[^\w$])\$([0-9])\b");
 
 fn is_valid_name_segment(segment: &str) -> bool {
     segment.chars().count() <= 64 && name_format_regex().is_match(segment)
@@ -180,6 +192,27 @@ fn collapse_skill_name_hyphens(name: &str) -> String {
             .replace_all(parts.skill, "-")
             .to_string(),
     }
+}
+
+/// Whether a skill body references its arguments in any documented form.
+///
+/// The substitution table lists four: `$ARGUMENTS`, `$ARGUMENTS[N]`, the `$N`
+/// shorthand, and `$name` for each entry in the `arguments` frontmatter list.
+/// CC-SK-012 only looked for the literal `$ARGUMENTS`, so a body using `$0` or
+/// `$issue` was reported as ignoring its own arguments.
+fn body_references_arguments(body: &str, declared_arguments: Option<&str>) -> bool {
+    if body.contains("$ARGUMENTS") || positional_shorthand_regex().is_match(body) {
+        return true;
+    }
+
+    // Named arguments: `arguments: issue branch` makes `$issue` / `$branch` valid.
+    declared_arguments.is_some_and(|declared| {
+        declared
+            .split_whitespace()
+            .map(|name| name.trim_matches(|c: char| c == ',' || c == '[' || c == ']'))
+            .filter(|name| !name.is_empty())
+            .any(|name| body.contains(&format!("${}", name)))
+    })
 }
 
 /// Valid model description for CC-SK-001 diagnostic messages
@@ -281,6 +314,86 @@ const KNOWN_FRONTMATTER_FIELDS: &[&str] = &[
 
 /// Maximum dynamic injections for CC-SK-009
 const MAX_INJECTIONS: usize = 3;
+
+/// Count the dynamic shell injections in a skill body for CC-SK-009.
+///
+/// Two documented forms exist, and a raw `content.matches("!`")` scan got both
+/// wrong:
+///
+/// - Inline `` !`cmd` `` "is only recognized when `!` appears at the start of a
+///   line or immediately after whitespace. If `!` follows another character, as
+///   in `` KEY=!`cmd` ``, the placeholder is left as literal text and the
+///   command does not run" - so those are inert and must not be counted.
+/// - A fenced block opened with ` ```! ` runs each line as a command. These were
+///   not counted at all, so a block of ten commands read as zero.
+///
+/// Inline placeholders inside a fenced block are not double-counted: the block
+/// contributes its own command lines instead.
+fn count_dynamic_injections(content: &str) -> usize {
+    let mut count = 0usize;
+    let mut in_shell_fence = false;
+    let mut in_plain_fence = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+
+        if in_shell_fence {
+            if trimmed.starts_with("```") {
+                in_shell_fence = false;
+            } else if !trimmed.is_empty() {
+                // Each non-empty line in a `!` fence is one command.
+                count += 1;
+            }
+            continue;
+        }
+
+        if in_plain_fence {
+            if trimmed.starts_with("```") {
+                in_plain_fence = false;
+            }
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("```") {
+            // ```! opens a shell-execution block; any other fence is inert.
+            if rest.trim_start().starts_with('!') {
+                in_shell_fence = true;
+            } else {
+                in_plain_fence = true;
+            }
+            continue;
+        }
+
+        count += count_inline_injections(line);
+    }
+
+    count
+}
+
+/// Count inline `` !`cmd` `` placeholders on a single line, honoring the rule
+/// that `!` must be at line start or directly after whitespace.
+fn count_inline_injections(line: &str) -> usize {
+    let bytes = line.as_bytes();
+    let mut count = 0usize;
+    let mut idx = 0usize;
+
+    while let Some(found) = line[idx..].find("!`") {
+        let at = idx + found;
+        let recognized = match line[..at].chars().next_back() {
+            None => true,
+            Some(prev) => prev.is_whitespace(),
+        };
+        if recognized {
+            count += 1;
+        }
+        idx = at + 2;
+        if idx >= bytes.len() {
+            break;
+        }
+    }
+
+    count
+}
 
 /// Convert a name to kebab-case format.
 /// - Lowercase the name
@@ -663,6 +776,20 @@ impl<'a> ValidationContext<'a> {
     /// AS-017: Validate frontmatter name matches parent directory
     fn validate_name_directory_match(&mut self, name: &str) {
         if !self.config.is_rule_enabled("AS-017") {
+            return;
+        }
+
+        // Claude Code decouples `name` from the directory: "In a personal or
+        // project skill, `name` sets only the display label shown in skill
+        // listings, and the command still comes from the directory or file
+        // name", and in a plugin skill `name` deliberately replaces the last
+        // command segment - the reference's own example is `name: fancy` inside
+        // `my-plugin/skills/review/`, which this rule used to reject.
+        //
+        // The agentskills.io baseline still requires the match ("Must match the
+        // parent directory name"), so the rule is scoped by owning client the
+        // same way AS-008's length cap is.
+        if self.client == SkillClient::ClaudeCode {
             return;
         }
 
@@ -1148,7 +1275,7 @@ impl<'a> ValidationContext<'a> {
         // CC-SK-009: Too many injections (warning)
         // Count across full content (frontmatter + body) per VALIDATION-RULES.md
         if self.config.is_rule_enabled("CC-SK-009") {
-            let injection_count = self.content.matches("!`").count();
+            let injection_count = count_dynamic_injections(self.content);
             if injection_count > MAX_INJECTIONS {
                 self.diagnostics.push(
                     Diagnostic::warning(
@@ -1329,7 +1456,7 @@ impl<'a> ValidationContext<'a> {
                 ""
             };
 
-            if !body.contains("$ARGUMENTS") {
+            if !body_references_arguments(body, frontmatter.arguments.as_deref()) {
                 let (line, col) = self.frontmatter_key_line_col("argument-hint");
                 let mut diagnostic = Diagnostic::warning(
                     self.path.to_path_buf(),
@@ -1371,11 +1498,18 @@ impl<'a> ValidationContext<'a> {
             ""
         };
 
-        let Some(first_match) = indexed_arguments_regex().find(body) else {
+        // `$N` is documented as shorthand for `$ARGUMENTS[N]`, so a body using
+        // `$0` without an argument-hint has the same gap the rule targets.
+        let indexed_at = indexed_arguments_regex().find(body).map(|m| m.start());
+        let shorthand_at = positional_shorthand_regex().find(body).map(|m| m.start());
+        let Some(match_start) = (match (indexed_at, shorthand_at) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        }) else {
             return;
         };
 
-        let (line, col) = self.line_col_at(self.parts.body_start + first_match.start());
+        let (line, col) = self.line_col_at(self.parts.body_start + match_start);
         self.diagnostics.push(
             Diagnostic::warning(
                 self.path.to_path_buf(),

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -4683,3 +4683,377 @@ fn test_cc_sk_021_ignores_files_outside_skill_dir() {
 
     assert!(cc_sk_021_for(&dir).is_empty());
 }
+
+/// CC-SK-009 counted raw `` !` `` occurrences, which was wrong twice over:
+/// inert `` KEY=!`cmd` `` forms were counted (the doc says a `!` following
+/// another character stays literal), and ` ```! ` fenced blocks were not counted
+/// at all.
+#[test]
+fn test_cc_sk_009_ignores_inert_inline_injections() {
+    let content = r#"---
+name: test-skill
+description: Use when testing inert injection forms
+---
+Run the setup with these values.
+
+KEY1=!`date`
+KEY2=!`whoami`
+KEY3=!`pwd`
+KEY4=!`hostname`
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-009")
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "`KEY=!`cmd`` is literal text and must not count as an injection, got: {hits:?}"
+    );
+}
+
+/// A ` ```! ` fenced block runs each line as a command, so its lines count.
+#[test]
+fn test_cc_sk_009_counts_shell_fence_lines() {
+    let content = r#"---
+name: test-skill
+description: Use when testing fenced shell injection counting
+---
+Check the environment.
+
+```!
+node --version
+npm --version
+git status --short
+uname -a
+```
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-009")
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "four commands in a ```! fence exceed the limit of 3, got: {diagnostics:?}"
+    );
+}
+
+/// A plain fenced block is inert and must not contribute counts.
+#[test]
+fn test_cc_sk_009_ignores_plain_fence() {
+    let content = r#"---
+name: test-skill
+description: Use when testing that plain fences are inert
+---
+Example output:
+
+```bash
+!`one`
+!`two`
+!`three`
+!`four`
+```
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-009")
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "a plain ```bash fence does not execute and must not be counted, got: {hits:?}"
+    );
+}
+
+/// Genuine inline injections past the limit still fire.
+#[test]
+fn test_cc_sk_009_still_flags_real_inline_injections() {
+    let content = r#"---
+name: test-skill
+description: Use when testing that real inline injections are counted
+---
+Current state: !`date` and !`whoami` and !`pwd` and !`hostname`
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CC-SK-009"),
+        "four recognized inline injections must exceed the limit, got: {diagnostics:?}"
+    );
+}
+
+/// The substitution table documents four argument forms. CC-SK-012 only looked
+/// for the literal `$ARGUMENTS`, so a body using `$0` or a declared `$name` was
+/// falsely reported as ignoring its own arguments.
+#[test]
+fn test_cc_sk_012_accepts_positional_shorthand() {
+    let content = r#"---
+name: test-skill
+description: Use when testing positional shorthand recognition
+argument-hint: "[issue-number] [branch]"
+---
+Fix issue $0 on branch $1.
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-012")
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "`$0`/`$1` are documented shorthand for $ARGUMENTS[N], got: {hits:?}"
+    );
+}
+
+/// `$name` placeholders declared in the `arguments` frontmatter list also count.
+#[test]
+fn test_cc_sk_012_accepts_named_arguments() {
+    let content = r#"---
+name: test-skill
+description: Use when testing named argument recognition
+argument-hint: "[issue] [branch]"
+arguments: issue branch
+---
+Fix $issue on $branch.
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-012")
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "`$issue`/`$branch` are declared in `arguments` and must count, got: {hits:?}"
+    );
+}
+
+/// A body that references no argument at all still fires.
+#[test]
+fn test_cc_sk_012_still_flags_body_with_no_arguments() {
+    let content = r#"---
+name: test-skill
+description: Use when testing that a body ignoring arguments is flagged
+argument-hint: "[issue-number]"
+---
+Do the thing with no argument reference at all.
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CC-SK-012"),
+        "a body referencing no arguments must still be flagged, got: {diagnostics:?}"
+    );
+}
+
+/// CC-SK-016 covers the `$N` shorthand too, since it is documented as
+/// equivalent to `$ARGUMENTS[N]`.
+#[test]
+fn test_cc_sk_016_flags_positional_shorthand_without_hint() {
+    let content = r#"---
+name: test-skill
+description: Use when testing shorthand without an argument hint
+---
+Fix issue $0 for the reporter.
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CC-SK-016"),
+        "`$0` without argument-hint has the same gap as $ARGUMENTS[0], got: {diagnostics:?}"
+    );
+}
+
+/// `${CLAUDE_SKILL_DIR}`-style variables and dollar amounts must not be
+/// mistaken for positional arguments.
+#[test]
+fn test_cc_sk_016_ignores_non_positional_dollar_forms() {
+    let content = r#"---
+name: test-skill
+description: Use when testing that other dollar forms are not positional
+---
+Run ${CLAUDE_SKILL_DIR}/scripts/run.sh and report the $500 total for item x$3y.
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/test-skill/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-016")
+        .collect();
+    assert!(
+        hits.is_empty(),
+        "`${{CLAUDE_SKILL_DIR}}`, `$500`, and `x$3y` are not positional arguments, got: {hits:?}"
+    );
+}
+
+/// AS-013 only inspected `references/`-prefixed paths, so deep `scripts/` and
+/// `assets/` paths were invisible - even though the spec scopes skill resources
+/// to "`scripts/`, `references/`, or `assets/`" and uses `scripts/extract.py` in
+/// its own example.
+#[test]
+fn test_as_013_covers_scripts_and_assets() {
+    for path in [
+        "scripts/deep/nested/extract.py",
+        "assets/deep/nested/logo.png",
+    ] {
+        let content = format!(
+            r#"---
+name: test-skill
+description: Use when testing deep resource reference detection
+---
+Run the helper at {path} to continue.
+"#
+        );
+
+        let validator = SkillValidator;
+        let diagnostics = validator.validate(
+            Path::new(".claude/skills/test-skill/SKILL.md"),
+            &content,
+            &LintConfig::default(),
+        );
+
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "AS-013"),
+            "deep path '{path}' must be reported by AS-013, got: {diagnostics:?}"
+        );
+    }
+}
+
+/// One level deep stays clean for the newly covered prefixes.
+#[test]
+fn test_as_013_allows_one_level_scripts_and_assets() {
+    for path in ["scripts/extract.py", "assets/logo.png"] {
+        let content = format!(
+            r#"---
+name: test-skill
+description: Use when testing shallow resource references stay clean
+---
+Run the helper at {path} to continue.
+"#
+        );
+
+        let validator = SkillValidator;
+        let diagnostics = validator.validate(
+            Path::new(".claude/skills/test-skill/SKILL.md"),
+            &content,
+            &LintConfig::default(),
+        );
+
+        let hits: Vec<_> = diagnostics.iter().filter(|d| d.rule == "AS-013").collect();
+        assert!(
+            hits.is_empty(),
+            "'{path}' is one level deep and must not be flagged, got: {hits:?}"
+        );
+    }
+}
+
+/// For a Claude Code skill, `name` is a display label - "the command still comes
+/// from the directory or file name" - and a plugin skill's `name` deliberately
+/// replaces the last command segment. AS-017 used to reject the reference's own
+/// `name: fancy` in `skills/review/` example.
+#[test]
+fn test_as_017_scoped_out_for_claude_code_skills() {
+    let content = r#"---
+name: fancy
+description: Use when testing that a Claude Code display label is allowed
+---
+Body with instructions to run the task.
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".claude/skills/review/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let hits: Vec<_> = diagnostics.iter().filter(|d| d.rule == "AS-017").collect();
+    assert!(
+        hits.is_empty(),
+        "`name` is a display label for Claude Code skills and must not trip AS-017, got: {hits:?}"
+    );
+}
+
+/// The agentskills.io baseline still requires the match, so a skill owned by
+/// another client keeps the rule.
+#[test]
+fn test_as_017_still_enforced_for_non_claude_clients() {
+    let content = r#"---
+name: mismatched
+description: Use when testing that the baseline still requires a directory match
+---
+Body with instructions to run the task.
+"#;
+
+    let validator = SkillValidator;
+    let diagnostics = validator.validate(
+        Path::new(".opencode/skills/review/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "AS-017"),
+        "the agentskills.io baseline requires name==directory, got: {diagnostics:?}"
+    );
+}

--- a/crates/agnix-core/src/schemas/hooks.rs
+++ b/crates/agnix-core/src/schemas/hooks.rs
@@ -33,6 +33,13 @@ pub enum Hook {
     Command {
         #[serde(skip_serializing_if = "Option::is_none")]
         command: Option<String>,
+        /// Argument list. "When present, `command` is resolved as an executable
+        /// and spawned directly with `args` as the argument vector, with no
+        /// shell involved" - this is the doc's *exec form*, as opposed to the
+        /// shell form where `command` is a shell string. Several rules behave
+        /// differently between the two, so the field has to be parsed.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        args: Option<Vec<String>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         timeout: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -399,6 +406,7 @@ mod tests {
                 matcher: None,
                 hooks: vec![Hook::Command {
                     command: Some("echo hi".to_string()),
+                    args: None,
                     timeout: None,
                     model: None,
                     if_condition: None,
@@ -419,6 +427,7 @@ mod tests {
     fn test_hook_type_name() {
         let cmd = Hook::Command {
             command: Some("echo".to_string()),
+            args: None,
             timeout: None,
             model: None,
             if_condition: None,

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -631,7 +631,7 @@
         "source_urls": [
           "https://agentskills.io/specification"
         ],
-        "verified_on": "2026-05-24",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "spec_revision": "1.0"
         },
@@ -723,9 +723,10 @@
       "evidence": {
         "source_type": "spec",
         "source_urls": [
-          "https://agentskills.io/specification"
+          "https://agentskills.io/specification",
+          "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "spec_revision": "1.0"
         },
@@ -1486,7 +1487,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/hooks"
         ],
-        "verified_on": "2026-04-23",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -2069,9 +2070,9 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+          "https://code.claude.com/docs/en/hooks"
         ],
-        "verified_on": "2026-07-15",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code",
           "version_range": ">=2.1.207"
@@ -2663,7 +2664,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/plugins-reference"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -2800,7 +2801,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/plugins-reference"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -2828,7 +2829,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/plugins-reference"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3271,9 +3272,9 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://platform.claude.com/docs"
+          "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3355,7 +3356,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3466,10 +3467,9 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://code.claude.com/docs/en/skills",
-          "https://github.com/anthropics/claude-code/releases/tag/v2.1.186"
+          "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-06-24",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -185,8 +185,8 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="as-013"></a>
 ### AS-013 [MEDIUM] File Reference Too Deep
-**Requirement**: File references SHOULD be one level deep ("Keep file references one level deep from `SKILL.md`") - a SHOULD-level agentskills.io guideline, emitted as a warning.
-**Detection**: Check references like `references/guide.md` vs `refs/deep/nested/file.md`
+**Requirement**: File references SHOULD be one level deep ("Keep file references one level deep from `SKILL.md`") - a SHOULD-level agentskills.io guideline, emitted as a warning. Covers all three documented resource directories: `references/`, `scripts/`, and `assets/`.
+**Detection**: Check references like `references/guide.md` vs `refs/deep/nested/file.md`, `scripts/deep/nested/x.py`, `assets/deep/nested/y.png`. Git ref paths (`refs/heads`, `refs/remotes`, `refs/tags`) are excluded.
 **Fix**: Flatten directory structure
 **Source**: agentskills.io/specification
 
@@ -206,8 +206,8 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="as-017"></a>
 ### AS-017 [HIGH] Name Must Match Parent Directory
-**Requirement**: Skill name MUST match parent directory name
-**Detection**: name field does not match directory containing SKILL.md
+**Requirement**: Skill name MUST match parent directory name. **agentskills.io baseline only** - Claude Code decouples the two ("`name` sets only the display label shown in skill listings, and the command still comes from the directory or file name"), and a plugin skill's `name` deliberately replaces the last command segment, so the rule is scoped out for Claude Code skills the same way AS-008's length cap is.
+**Detection**: owning client is not Claude Code AND name field does not match directory containing SKILL.md
 **Fix**: Manual fix required - rename directory or update name field
 **Source**: agentskills.io/specification
 
@@ -267,8 +267,8 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="cc-sk-009"></a>
 ### CC-SK-009 [MEDIUM] Too Many Injections
-**Requirement**: Limit dynamic injections (!`cmd`) to 3
-**Detection**: `content.matches("!\`").count() > 3`
+**Requirement**: Limit dynamic injections to 3. Both documented forms count: inline `` !`cmd` `` (recognized only when `!` is at line start or directly after whitespace - `` KEY=!`cmd` `` stays literal and does not run) and each command line inside a ` ```! ` fenced block.
+**Detection**: Count recognized inline placeholders plus command lines in ` ```! ` fences; plain fences are inert
 **Fix**: Remove or move to scripts/
 **Source**: platform.claude.com/docs
 
@@ -288,8 +288,8 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="cc-sk-012"></a>
 ### CC-SK-012 [MEDIUM] Argument Hint Without $ARGUMENTS
-**Requirement**: If `argument-hint` is set, body SHOULD reference `$ARGUMENTS`
-**Detection**: `argument_hint.is_some() && !body.contains("$ARGUMENTS")`
+**Requirement**: If `argument-hint` is set, the body SHOULD reference its arguments in any documented form: `$ARGUMENTS`, `$ARGUMENTS[N]`, the `$N` shorthand, or a `$name` declared in the `arguments` frontmatter list.
+**Detection**: `argument_hint.is_some()` AND the body references none of those forms
 **Fix**: Auto-fix (unsafe) - append `$ARGUMENTS` to skill body
 **Source**: code.claude.com/docs/en/skills
 
@@ -316,8 +316,8 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="cc-sk-016"></a>
 ### CC-SK-016 [MEDIUM] Indexed $ARGUMENTS Without argument-hint
-**Requirement**: If body uses indexed $ARGUMENTS (e.g., $ARGUMENTS[0]), SHOULD have argument-hint field
-**Detection**: Body contains indexed $ARGUMENTS syntax without argument-hint field
+**Requirement**: If the body accesses arguments by position - `$ARGUMENTS[N]` or the documented `$N` shorthand - it SHOULD have an argument-hint field
+**Detection**: Body contains `$ARGUMENTS[n]` or a single-digit `$N` placeholder without an argument-hint field. `${VAR}` forms, `x$3y`, and prose amounts like `$500` are not treated as positional.
 **Fix**: Manual fix required - add argument-hint field describing expected arguments
 **Source**: code.claude.com/docs/en/skills
 
@@ -760,8 +760,8 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="cc-hk-008"></a>
 ### CC-HK-008 [HIGH] Script File Not Found
-**Requirement**: Hook command script MUST exist on filesystem
-**Detection**: Check if script path exists (resolve $CLAUDE_PROJECT_DIR)
+**Requirement**: Hook command script MUST exist on filesystem. Script paths in the exec-form `args` vector are checked too, since that is where the script sits when `command` names an interpreter.
+**Detection**: Check if script paths in `command` and in each `args` element exist (resolve $CLAUDE_PROJECT_DIR)
 **Fix**: Show error with correct path
 **Source**: code.claude.com/docs/en/hooks
 
@@ -902,8 +902,8 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="cc-hk-028"></a>
 ### CC-HK-028 [HIGH] Rejected user_config Interpolation in Shell-Form Command
-**Requirement**: A command hook's `command` string MUST NOT contain `${user_config.*}` interpolation. Claude Code v2.1.207 rejects it at load time as a shell-injection fix; values must be read inside the script via `$CLAUDE_PLUGIN_OPTION_<KEY>` (plugin hooks) or passed through the environment.
-**Detection**: Walk command-type hook entries; flag (error) when the `command` string contains the substring `${user_config.`.
+**Requirement**: A **shell-form** command hook's `command` string MUST NOT contain `${user_config.*}` interpolation. Claude Code v2.1.207 rejects it at load time as a shell-injection fix; values must be read inside the script via `$CLAUDE_PLUGIN_OPTION_<KEY>` (plugin hooks) or passed through the environment. Exec form is explicitly permitted - "Plugin hooks additionally substitute `${user_config.*}` values, in exec form only" - and exec form is what the presence of `args` selects.
+**Detection**: Walk command-type hook entries; flag (error) when `args` is absent AND the `command` string contains the substring `${user_config.`.
 **Fix**: Manual - replace `${user_config.<key>}` with `$CLAUDE_PLUGIN_OPTION_<KEY>` read inside the script, or restructure to pass the value via the environment.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.207 (shell-injection fix rejecting `${user_config.*}` in shell-form commands)
 
@@ -1242,8 +1242,8 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 
 <a id="cc-pl-002"></a>
 ### CC-PL-002 [HIGH] Components in .claude-plugin/
-**Requirement**: skills/agents/hooks MUST NOT be inside .claude-plugin/
-**Detection**: Check for `.claude-plugin/skills/`, etc.
+**Requirement**: No component directory may be inside `.claude-plugin/`. The documented set is `commands/`, `agents/`, `skills/`, `workflows/`, `output-styles/`, `themes/`, `monitors/`, and `hooks/` - "All other directories ... must be at the plugin root, not inside `.claude-plugin/`".
+**Detection**: Check for each of those eight directories under `.claude-plugin/`
 **Fix**: Move to plugin root
 **Source**: code.claude.com/docs/en/plugins-reference
 
@@ -1277,7 +1277,7 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 
 <a id="cc-pl-007"></a>
 ### CC-PL-007 [HIGH] Invalid Component Path
-**Requirement**: Paths in `commands`, `agents`, `skills`, `hooks` MUST be relative (no absolute paths or `..` traversal)
+**Requirement**: Paths in every documented path-bearing manifest field MUST be relative (no absolute paths or `..` traversal). The full set is `commands`, `agents`, `skills`, `workflows`, `hooks`, `mcpServers`, `outputStyles`, `lspServers`, `experimental.themes`, and `experimental.monitors`.
 **Detection**: Check path fields for absolute paths (`/`, `C:\`) or parent traversal (`..`)
 **Fix**: Prepend `./` to relative paths [safe autofix]
 **Source**: code.claude.com/docs/en/plugins-reference
@@ -3337,8 +3337,8 @@ agent: reviewer
 
 <a id="xp-007"></a>
 ### XP-007 [MEDIUM] AGENTS.md Exceeds Codex Byte Limit
-**Requirement**: AGENTS.md SHOULD stay under Codex CLI's 32768-byte default limit
-**Detection**: Check byte length of AGENTS.md content against the 32768-byte threshold
+**Requirement**: AGENTS.md SHOULD stay under Codex CLI's 32768-byte `project_doc_max_bytes` default. `AGENTS.override.md` is checked too, since Codex reads it first in each directory and it draws on the same budget.
+**Detection**: Check byte length of `AGENTS.md` / `AGENTS.override.md` content against the 32768-byte threshold. Note the documented cap is cumulative across the root-to-cwd chain while this check is per-file, so a project split across several mid-size files can still be truncated without a diagnostic.
 **Fix**: Reduce content or split into multiple files using @import
 **Source**: learn.chatgpt.com/docs/agent-configuration/agents-md
 

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -631,7 +631,7 @@
         "source_urls": [
           "https://agentskills.io/specification"
         ],
-        "verified_on": "2026-05-24",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "spec_revision": "1.0"
         },
@@ -723,9 +723,10 @@
       "evidence": {
         "source_type": "spec",
         "source_urls": [
-          "https://agentskills.io/specification"
+          "https://agentskills.io/specification",
+          "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "spec_revision": "1.0"
         },
@@ -1486,7 +1487,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/hooks"
         ],
-        "verified_on": "2026-04-23",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -2069,9 +2070,9 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://github.com/anthropics/claude-code/releases/tag/v2.1.207"
+          "https://code.claude.com/docs/en/hooks"
         ],
-        "verified_on": "2026-07-15",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code",
           "version_range": ">=2.1.207"
@@ -2663,7 +2664,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/plugins-reference"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -2800,7 +2801,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/plugins-reference"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -2828,7 +2829,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/plugins-reference"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3271,9 +3272,9 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://platform.claude.com/docs"
+          "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3355,7 +3356,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-02-07",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3466,10 +3467,9 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
-          "https://code.claude.com/docs/en/skills",
-          "https://github.com/anthropics/claude-code/releases/tag/v2.1.186"
+          "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-06-24",
+        "verified_on": "2026-07-31",
         "applies_to": {
           "tool": "claude-code"
         },

--- a/website/docs/rules/generated/as-013.md
+++ b/website/docs/rules/generated/as-013.md
@@ -13,7 +13,7 @@ keywords: ["AS-013", "file reference too deep", "agent skills", "validation", "a
 - **Category**: `Agent Skills`
 - **Normative Level**: `SHOULD`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-05-24`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 

--- a/website/docs/rules/generated/as-017.md
+++ b/website/docs/rules/generated/as-017.md
@@ -13,7 +13,7 @@ keywords: ["AS-017", "name must match parent directory", "agent skills", "valida
 - **Category**: `Agent Skills`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-02-14`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 
@@ -24,6 +24,7 @@ keywords: ["AS-017", "name must match parent directory", "agent skills", "valida
 ## Evidence Sources
 
 - https://agentskills.io/specification
+- https://code.claude.com/docs/en/skills
 
 ## Test Coverage Metadata
 

--- a/website/docs/rules/generated/cc-hk-008.md
+++ b/website/docs/rules/generated/cc-hk-008.md
@@ -13,7 +13,7 @@ keywords: ["CC-HK-008", "script file not found", "claude hooks", "validation", "
 - **Category**: `Claude Hooks`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-04-23`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 

--- a/website/docs/rules/generated/cc-hk-028.md
+++ b/website/docs/rules/generated/cc-hk-028.md
@@ -13,7 +13,7 @@ keywords: ["CC-HK-028", "rejected user_config interpolation in shell-form comman
 - **Category**: `Claude Hooks`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-07-15`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 
@@ -23,7 +23,7 @@ keywords: ["CC-HK-028", "rejected user_config interpolation in shell-form comman
 
 ## Evidence Sources
 
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.207
+- https://code.claude.com/docs/en/hooks
 
 ## Test Coverage Metadata
 

--- a/website/docs/rules/generated/cc-pl-002.md
+++ b/website/docs/rules/generated/cc-pl-002.md
@@ -13,7 +13,7 @@ keywords: ["CC-PL-002", "components in .claude-plugin/", "claude plugins", "vali
 - **Category**: `Claude Plugins`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-02-04`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 

--- a/website/docs/rules/generated/cc-pl-007.md
+++ b/website/docs/rules/generated/cc-pl-007.md
@@ -13,7 +13,7 @@ keywords: ["CC-PL-007", "invalid component path", "claude plugins", "validation"
 - **Category**: `Claude Plugins`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `Yes (safe)`
-- **Verified On**: `2026-02-07`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 

--- a/website/docs/rules/generated/cc-pl-008.md
+++ b/website/docs/rules/generated/cc-pl-008.md
@@ -13,7 +13,7 @@ keywords: ["CC-PL-008", "component inside .claude-plugin", "claude plugins", "va
 - **Category**: `Claude Plugins`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-02-07`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 

--- a/website/docs/rules/generated/cc-sk-009.md
+++ b/website/docs/rules/generated/cc-sk-009.md
@@ -13,7 +13,7 @@ keywords: ["CC-SK-009", "too many injections", "claude skills", "validation", "a
 - **Category**: `Claude Skills`
 - **Normative Level**: `SHOULD`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-02-04`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 
@@ -23,7 +23,7 @@ keywords: ["CC-SK-009", "too many injections", "claude skills", "validation", "a
 
 ## Evidence Sources
 
-- https://platform.claude.com/docs
+- https://code.claude.com/docs/en/skills
 
 ## Test Coverage Metadata
 

--- a/website/docs/rules/generated/cc-sk-012.md
+++ b/website/docs/rules/generated/cc-sk-012.md
@@ -13,7 +13,7 @@ keywords: ["CC-SK-012", "argument hint without $arguments", "claude skills", "va
 - **Category**: `Claude Skills`
 - **Normative Level**: `SHOULD`
 - **Auto-Fix**: `Yes (unsafe)`
-- **Verified On**: `2026-02-07`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 

--- a/website/docs/rules/generated/cc-sk-016.md
+++ b/website/docs/rules/generated/cc-sk-016.md
@@ -13,7 +13,7 @@ keywords: ["CC-SK-016", "indexed $arguments without argument-hint", "claude skil
 - **Category**: `Claude Skills`
 - **Normative Level**: `SHOULD`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-06-24`
+- **Verified On**: `2026-07-31`
 
 ## Applicability
 
@@ -24,7 +24,6 @@ keywords: ["CC-SK-016", "indexed $arguments without argument-hint", "claude skil
 ## Evidence Sources
 
 - https://code.claude.com/docs/en/skills
-- https://github.com/anthropics/claude-code/releases/tag/v2.1.186
 
 ## Test Coverage Metadata
 


### PR DESCRIPTION
Fourth and final pass on drift issue #1281, after #1283, #1284, and #1285. This clears the remaining tail — **no user-facing errors on valid config remain from that audit.**

Each finding was re-verified against the live upstream doc before I touched code.

## Skills

**CC-SK-009 miscounted injections in both directions.** It counted raw `` !` `` occurrences:

> The inline form is only recognized when `!` appears at the start of a line or immediately after whitespace. If `!` follows another character, as in `` KEY=!`cmd` ``, the placeholder is left as literal text and the command does not run.

So inert `KEY=!` forms inflated the count. Meanwhile:

> For multi-line commands, use a fenced code block opened with ` ```! `

Those blocks — where *every line* is a command — counted as **zero**. Counting now honors both forms and treats plain fences as inert.

**CC-SK-012/016 recognized only `$ARGUMENTS`.** The substitution table documents four forms (`$ARGUMENTS`, `$ARGUMENTS[N]`, `$N`, `$name`). A body using `$0` or a declared `$issue` was reported as ignoring its own arguments, and `$0` escaped CC-SK-016 entirely. The `arguments` frontmatter field is now parsed so named placeholders resolve.

One correction worth recording: my first version matched `\d+`, and a test caught `$500` in prose being read as positional argument 500. Restricted to a single digit, matching the doc's own examples (`$0`, `$1`); a tenth argument would use the explicit `$ARGUMENTS[N]` form. `${CLAUDE_SKILL_DIR}` and `x$3y` are excluded too.

**AS-013 only inspected `references/` paths** — but the spec scopes resources to "`scripts/`, `references/`, or `assets/`" and uses `scripts/extract.py` in its own example, so deep `scripts/`/`assets/` paths were invisible. Git ref paths stay excluded.

**AS-017 rejected Claude Code display labels:**

> In a personal or project skill, `name` sets only the display label shown in skill listings, and the command still comes from the directory or file name.

And a plugin skill's `name` *deliberately* replaces the last command segment — the reference's own `name: fancy` in `my-plugin/skills/review/` example errored. Scoped out for Claude Code skills following the existing AS-008 precedent; the agentskills.io baseline still requires the match, with a test pinning both sides.

## Hooks

**Added `args` to the command-hook schema.** The exec-form field was silently ignored, which blocked two fixes:

- **CC-HK-028** fired regardless of form, but `${user_config.*}` is rejected *only* in shell form — "Plugin hooks additionally substitute `${user_config.*}` values, **in exec form only**". So `{"command": "${user_config.formatter}", "args": ["--fix"]}` errored despite being the documented pattern.
- **CC-HK-008** scanned only `command`, so exec-form hooks — where the script sits in `args` and `command` names an interpreter — got **no script-existence checking at all**.

## Plugins

**CC-PL-002 covered four of eight** forbidden directories. The doc names `commands/`, `agents/`, `skills/`, `workflows/`, `output-styles/`, `themes/`, `monitors/`, `hooks/`.

**CC-PL-007/008 covered four of ten** path-bearing fields, so `workflows`, `mcpServers`, `outputStyles`, `lspServers`, `experimental.themes`, and `experimental.monitors` accepted absolute paths, `..` traversal, and `.claude-plugin/` targets unchecked. The dotted `experimental.*` keys needed traversal a plain `.get()` cannot do.

## Codex / cross-platform

**XP-007 ignored `AGENTS.override.md`.** Codex reads it *first* in each directory, so it draws on the same `project_doc_max_bytes` budget. The code comment asserting Codex "reads this file, not local/override variants" was contradicted by the current guide.

I did **not** fix the cumulative-vs-per-file gap: the documented cap applies across the whole root-to-cwd chain, while this check is per-file, so a project split across several mid-size files can still be truncated silently. That needs project-level accounting and is a design change, not a one-liner — recorded in the rule docs rather than left implicit.

**AGM-006's suggestion contradicted upstream.** It advised consolidating files; Codex documents root-down concatenation with nearest-file-wins precedence and explicitly recommends splitting across nested directories to stay under the cap.

## Verification

- **5060 tests / 37 binaries**, zero failures. Eval **61/61**. Self-lint clean.
- `cargo fmt --check`, `cargo clippy --all-targets` clean; bookkeeping, locale sync, rule counts in sync at 442; `AGENTS.md` byte-identical to `CLAUDE.md`.
- New tests assert both directions throughout: inert injection forms ignored *and* real ones still flagged; plain fences inert *and* `` ```! `` fences counted; exec form permitted *and* shell form still rejected; AS-017 relaxed for Claude Code *and* still enforced for other clients; AS-013 deep paths flagged *and* one-level paths clean.
- Every doc quote above fetched directly by me.

## #1281 status after this

All S-tier findings are now either fixed or explicitly recorded as design work. Two items remain deliberately open:

1. **Baseline hashes are still stale.** Now that the audit is worked through, they can be re-cut — but that is a separate, reviewable change, and re-cutting them silently inside a fix PR would be the wrong move.
2. **The cumulative XP-007 cap** described above.

Everything else from the original 15-source sweep is closed across the four PRs.
