### PR TITLE
fix(ci): make the Claude review job actually review [skip changelog]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,14 @@ jobs:
         # from knowledge-base/rules.json.
         run: python3 scripts/check-rule-counts.py
 
+      - name: Locale sync check
+        if: matrix.os == 'ubuntu-latest'
+        # The i18n!() macro loads from each crate's own locales/ directory, so a
+        # diagnostic string edited only in the root copy silently never reaches
+        # the binary. Nothing gated this: the script existed but no workflow ran
+        # it.
+        run: bash scripts/check-locale-sync.sh
+
       - name: Schema sync check
         if: matrix.os == 'ubuntu-latest'
         # Fails if the committed .agnix.toml schema differs from the current

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
+          # `shared-key` (rather than the default job-name key) lets the Claude
+          # review job restore this cache instead of cold-building the workspace.
+          shared-key: agnix-workspace
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Format check

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -103,10 +103,17 @@ jobs:
           components: clippy, rustfmt
 
       # Restore ci.yml's cache via the shared key. Without it the first
-      # `cargo test` cold-builds a 6-crate workspace, which is slow enough that
-      # the reviewer would skip running tests and fall back to reading them -
-      # putting prompt priorities 1 and 3 back where they started. Read-only:
-      # this job should consume ci.yml's cache, never publish its own.
+      # `cargo test` cold-builds the third-party dependency graph, which is slow
+      # enough that the reviewer would skip running tests and fall back to
+      # reading them - putting prompt priorities 1 and 3 back where they started.
+      #
+      # Scope: rust-cache cleans workspace-member artifacts before saving, so it
+      # caches dependencies only. A warm restore still leaves the 6 workspace
+      # crates and every test binary to compile per review - budget that against
+      # `timeout-minutes` above. The cache is also empty until this merges and
+      # one `main` run populates the new key, and adding `shared-key` abandons
+      # ci.yml's old job-name-keyed entry, so CI itself cold-builds for one merge
+      # cycle. Read-only here: this job consumes ci.yml's cache, never publishes.
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         if: steps.check-runs.outputs.should_run == 'true'
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -92,17 +92,26 @@ jobs:
           # Passing it as an input produced `Unexpected input(s) 'model'` and was
           # silently ignored, so reviews would have run on the default model.
           # The pinned value was also a stale model ID.
-          # No `--allowedTools`: an explicit list here blocked the checks the
-          # prompt below asks for. Verifying that a rule's `evidence.source_urls`
-          # actually supports its behavior needs WebFetch, and judging validator
-          # correctness on a Rust workspace needs `cargo test`; an allowlist
-          # without them reduces both to reading rather than checking. It also
-          # omitted `mcp__github_comment__update_claude_comment`, the tool the job
-          # posts through, which only worked because the action injects it anyway.
-          # The action's tag-mode defaults already grant the GitHub MCP tools plus
-          # Read/Grep/Glob.
+          # `--allowedTools` is ADDITIVE, not restrictive: per the action's
+          # configuration docs, "The base GitHub tools are always included. Use
+          # `--allowedTools` to add additional tools (including specific Bash
+          # commands)". So omitting it grants nothing extra - it only drops what
+          # the list itself would have added, and the baseline still withholds
+          # WebFetch and cargo.
+          #
+          # That matters because the prompt below asks for checks the baseline
+          # cannot perform:
+          #   - WebFetch/WebSearch: priority 2 is verifying that a rule's
+          #     `evidence.source_urls` actually says what the rule claims. Without
+          #     these, a reviewer can only confirm a URL is present.
+          #   - cargo test/clippy: priorities 1 and 3 are validator correctness
+          #     and whether tests assert both directions, which on a Rust
+          #     workspace means running them, not reading them.
+          #   - the inline-comment tool: the prompt asks for inline comments, and
+          #     the baseline provides only the top-level comment tool.
           claude_args: |
             --model claude-opus-5
+            --allowedTools "WebFetch,WebSearch,Bash(cargo test:*),Bash(cargo clippy:*),Bash(node scripts/sync-rule-bookkeeping.js:*),mcp__github_inline_comment__create_inline_comment"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,25 +36,19 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          # This job now runs `cargo test` on PR-authored code. Match ci.yml and
-          # do not leave a usable token in the checkout's git config.
+          # Kept, but it does NOT leave this job token-free. Dropping
+          # `use_commit_signing` puts the action in non-signing mode, and that
+          # branch calls `configureGitAuth` (src/modes/tag/index.ts:88), which
+          # unsets checkout's extraheader and then embeds the token in the remote
+          # URL (src/github/operations/git-config.ts:78). Verified in a live run:
+          # `.git/config` carries an `x-access-token` entry the action added after
+          # checkout. The token-free path there needs ALLOWED_NON_WRITE_USERS,
+          # which never engages behind the author_association gate above.
+          #
+          # So this only closes the window before the action runs. That is worth
+          # having and costs nothing, but the job still compiles PR-authored code
+          # alongside a readable token holding pull-requests/issues write.
           persist-credentials: false
-
-      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
-        with:
-          # Pinned like ci.yml rather than relying on the runner image, since
-          # `cargo clippy` is in the grant list below.
-          components: clippy, rustfmt
-
-      # Restore ci.yml's cache via the shared key. Without it the first
-      # `cargo test` cold-builds a 6-crate workspace, which is slow enough that
-      # the reviewer would skip running tests and fall back to reading them -
-      # putting prompt priorities 1 and 3 back where they started. Read-only:
-      # this job should consume ci.yml's cache, never publish its own.
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-        with:
-          shared-key: agnix-workspace
-          save-if: "false"
 
       - name: Check run count
         id: check-runs
@@ -98,6 +92,26 @@ jobs:
             echo "should_run=false" >> $GITHUB_OUTPUT
             echo "[SKIP] Skipping Claude review (already ran 3 times for this commit)"
           fi
+
+      # Toolchain and cache come after the run-count gate: both are pointless
+      # work when the review is going to be skipped.
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        if: steps.check-runs.outputs.should_run == 'true'
+        with:
+          # Pinned like ci.yml rather than relying on the runner image, since
+          # `cargo clippy` is in the grant list below.
+          components: clippy, rustfmt
+
+      # Restore ci.yml's cache via the shared key. Without it the first
+      # `cargo test` cold-builds a 6-crate workspace, which is slow enough that
+      # the reviewer would skip running tests and fall back to reading them -
+      # putting prompt priorities 1 and 3 back where they started. Read-only:
+      # this job should consume ci.yml's cache, never publish its own.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        if: steps.check-runs.outputs.should_run == 'true'
+        with:
+          shared-key: agnix-workspace
+          save-if: "false"
 
       - name: Run Claude Code Review
         if: steps.check-runs.outputs.should_run == 'true'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,6 +41,10 @@ jobs:
           persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          # Pinned like ci.yml rather than relying on the runner image, since
+          # `cargo clippy` is in the grant list below.
+          components: clippy, rustfmt
 
       # Restore ci.yml's cache via the shared key. Without it the first
       # `cargo test` cold-builds a 6-crate workspace, which is slow enough that
@@ -133,7 +137,7 @@ jobs:
           #     the baseline provides only the top-level comment tool.
           claude_args: |
             --model claude-opus-5
-            --allowedTools "WebFetch,WebSearch,Bash(cargo test:*),Bash(cargo clippy:*),Bash(node scripts/sync-rule-bookkeeping.js:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "WebFetch,WebSearch,Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo check:*),Bash(cargo build:*),Bash(node scripts/sync-rule-bookkeeping.js:*),Bash(python3 scripts/check-rule-counts.py:*),Bash(bash scripts/check-locale-sync.sh:*),mcp__github_inline_comment__create_inline_comment"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -133,11 +133,16 @@ jobs:
           #   - cargo test/clippy: priorities 1 and 3 are validator correctness
           #     and whether tests assert both directions, which on a Rust
           #     workspace means running them, not reading them.
+          #   - cargo run: two ci.yml gates execute this way - the eval suite
+          #     (`agnix eval tests/eval.yaml`, which catches fixture drift as
+          #     rules are rescoped, see #981) and the .agnix.toml schema sync.
+          #     `cargo fmt` is deliberately absent: the prompt says to skip
+          #     formatting, which fmt and clippy already gate.
           #   - the inline-comment tool: the prompt asks for inline comments, and
           #     the baseline provides only the top-level comment tool.
           claude_args: |
             --model claude-opus-5
-            --allowedTools "WebFetch,WebSearch,Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo check:*),Bash(cargo build:*),Bash(node scripts/sync-rule-bookkeeping.js:*),Bash(python3 scripts/check-rule-counts.py:*),Bash(bash scripts/check-locale-sync.sh:*),mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "WebFetch,WebSearch,Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo check:*),Bash(cargo build:*),Bash(cargo run:*),Bash(node scripts/sync-rule-bookkeeping.js:*),Bash(python3 scripts/check-rule-counts.py:*),Bash(bash scripts/check-locale-sync.sh:*),mcp__github_inline_comment__create_inline_comment"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+# A superseded push should not burn a full review. This was free while each run
+# was an 11-second no-op; now that runs take minutes it is not. Matches the
+# idiom already used in docs-site.yml.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     if: >-
@@ -13,7 +20,10 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write
+      # `contents: read` is enough now that this job no longer commits: dropping
+      # `use_commit_signing` removed the file-ops tooling, so write access to the
+      # branch is no longer needed to post a review.
+      contents: read
       pull-requests: write
       issues: write
       actions: read
@@ -49,14 +59,18 @@ jobs:
 
           RUN_COUNT=$((RUN_COUNT + 1))
 
-          echo "This is run #$RUN_COUNT for this PR (event: $EVENT_ACTION)"
+          # Note this counts runs for THIS commit: the API query filters on
+          # head_sha, so the cap resets on every push. It also filters
+          # status=completed, so runs still in flight are not counted. The
+          # concurrency group above is what actually prevents overlap.
+          echo "This is run #$RUN_COUNT for commit ${HEAD_SHA:0:8} (event: $EVENT_ACTION)"
 
           if [ "$RUN_COUNT" -le 3 ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
-            echo "[OK] Will run Claude review (run $RUN_COUNT of 3)"
+            echo "[OK] Will run Claude review (run $RUN_COUNT of 3 for this commit)"
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
-            echo "[SKIP] Skipping Claude review (already ran 3 times)"
+            echo "[SKIP] Skipping Claude review (already ran 3 times for this commit)"
           fi
 
       - name: Run Claude Code Review
@@ -65,7 +79,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          use_commit_signing: true
+          # No `use_commit_signing` here: it enables the file-ops MCP server, so
+          # a review-only job would carry `commit_files` and could write to the PR
+          # branch. claude.yml keeps it, since that workflow is meant to make
+          # changes when asked.
           # `track_progress` is required on a `pull_request` event: without it the
           # action finds no @claude trigger, has nothing to do, and exits in ~11
           # seconds reporting success. That is why this job posted no review on
@@ -75,9 +92,17 @@ jobs:
           # Passing it as an input produced `Unexpected input(s) 'model'` and was
           # silently ignored, so reviews would have run on the default model.
           # The pinned value was also a stale model ID.
+          # No `--allowedTools`: an explicit list here blocked the checks the
+          # prompt below asks for. Verifying that a rule's `evidence.source_urls`
+          # actually supports its behavior needs WebFetch, and judging validator
+          # correctness on a Rust workspace needs `cargo test`; an allowlist
+          # without them reduces both to reading rather than checking. It also
+          # omitted `mcp__github_comment__update_claude_comment`, the tool the job
+          # posts through, which only worked because the action injects it anyway.
+          # The action's tag-mode defaults already grant the GitHub MCP tools plus
+          # Read/Grep/Glob.
           claude_args: |
             --model claude-opus-5
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -113,4 +138,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "[INFO] Claude Code review was skipped as it has already run 3 times for this PR."
+          gh pr comment "$PR_NUMBER" --body "[INFO] Claude Code review was skipped as it has already run 3 times for this commit."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -65,8 +65,46 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-opus-4-6
           use_commit_signing: true
+          # `track_progress` is required on a `pull_request` event: without it the
+          # action finds no @claude trigger, has nothing to do, and exits in ~11
+          # seconds reporting success. That is why this job posted no review on
+          # any PR while still showing a green check.
+          track_progress: true
+          # `model` is not an action input - it goes to the CLI via claude_args.
+          # Passing it as an input produced `Unexpected input(s) 'model'` and was
+          # silently ignored, so reviews would have run on the default model.
+          claude_args: |
+            --model claude-opus-4-6
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request against the standards in CLAUDE.md.
+
+            Focus, in priority order:
+
+            1. **Correctness** - logic errors, unhandled edge cases, off-by-one
+               boundaries. For a validator change, does the rule still reject what
+               it should while accepting what the upstream doc endorses?
+            2. **Evidence** - every rule claim must trace to a cited upstream
+               source. Flag any rule behavior that no `evidence.source_urls` entry
+               supports, and any autofix that could change a config's meaning
+               rather than just its spelling.
+            3. **Test quality** - tests must assert both directions: the valid
+               input accepted AND the invalid one still rejected. A test that only
+               proves the happy path is a gap.
+            4. **Bookkeeping** - `rules.json` and `VALIDATION-RULES.md` must agree;
+               rule counts, locales, and the `AGENTS.md`/`CLAUDE.md` copies stay in
+               sync.
+
+            Skip formatting nits that do not change behavior - `cargo fmt` and
+            clippy already gate those. Report only what a maintainer would act on,
+            and say so plainly if the diff looks correct.
+
+            Use inline comments for specific lines; one top-level comment for
+            overall assessment.
 
       - name: Comment on PR (skipped)
         if: steps.check-runs.outputs.should_run == 'false'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -74,8 +74,9 @@ jobs:
           # `model` is not an action input - it goes to the CLI via claude_args.
           # Passing it as an input produced `Unexpected input(s) 'model'` and was
           # silently ignored, so reviews would have run on the default model.
+          # The pinned value was also a stale model ID.
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Grep,Glob"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,9 @@ jobs:
       github.event.pull_request.author_association)
 
     runs-on: ubuntu-latest
+    # A cargo build plus a review should never approach this; the bound is here
+    # so a hung run cannot hold the concurrency group indefinitely.
+    timeout-minutes: 30
 
     permissions:
       # `contents: read` is enough now that this job no longer commits: dropping
@@ -33,6 +36,21 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # This job now runs `cargo test` on PR-authored code. Match ci.yml and
+          # do not leave a usable token in the checkout's git config.
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+
+      # Restore ci.yml's cache via the shared key. Without it the first
+      # `cargo test` cold-builds a 6-crate workspace, which is slow enough that
+      # the reviewer would skip running tests and fall back to reading them -
+      # putting prompt priorities 1 and 3 back where they started. Read-only:
+      # this job should consume ci.yml's cache, never publish its own.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          shared-key: agnix-workspace
+          save-if: "false"
 
       - name: Check run count
         id: check-runs
@@ -49,7 +67,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${HEAD_SHA}&status=completed" \
-            --jq '[.workflow_runs[] | select(.event == "pull_request")] | length' || echo "")
+            --jq '[.workflow_runs[] | select(.event == "pull_request" and .conclusion == "success")] | length' || echo "")
 
           RUN_COUNT=${RUN_COUNT:-0}
           if ! echo "$RUN_COUNT" | grep -qE '^[0-9]+$'; then
@@ -59,10 +77,14 @@ jobs:
 
           RUN_COUNT=$((RUN_COUNT + 1))
 
-          # Note this counts runs for THIS commit: the API query filters on
-          # head_sha, so the cap resets on every push. It also filters
-          # status=completed, so runs still in flight are not counted. The
-          # concurrency group above is what actually prevents overlap.
+          # Note this counts SUCCESSFUL runs for THIS commit: the API query
+          # filters on head_sha, so the cap resets on every push. Filtering on
+          # `conclusion == "success"` matters because the concurrency group
+          # cancels superseded runs, a cancelled run reports
+          # `status=completed`, and non-push events (draft -> ready_for_review,
+          # close/reopen) fire on the same sha - so cancellations would
+          # otherwise burn budget slots without ever producing a review. In-flight
+          # runs are still uncounted; the concurrency group prevents overlap.
           echo "This is run #$RUN_COUNT for commit ${HEAD_SHA:0:8} (event: $EVENT_ACTION)"
 
           if [ "$RUN_COUNT" -le 3 ]; then

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,21 +50,28 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          # This workflow now compiles PR-authored code (build.rs and test code
-          # run under the cargo grant below), so it should not leave a usable
-          # `contents: write` token in the checkout's git config.
+          # Two separate points.
           #
-          # Scoped claim: this closes the git-config vector only. The action also
-          # passes the token into the CLI step's environment
+          # (1) Why it is here: this workflow now compiles PR-authored code
+          # (build.rs and test code run under the cargo grant below), so it
+          # should not leave a usable `contents: write` token in the checkout's
+          # git config. Scoped claim - this closes the git-config vector only.
+          # The action also passes the token into the CLI step's environment
           # (DEFAULT_WORKFLOW_TOKEN / OVERRIDE_GITHUB_TOKEN in its action.yml),
           # which cargo and therefore a PR's build.rs would inherit. What keeps
           # that acceptable is the author_association gate above: a trusted human
           # has to type @claude for any of this to run. Do not read this line as
-          # covering the whole threat model. Safe to drop:
-          # with `use_commit_signing: true` the action commits through GitHub's
-          # API rather than the git CLI - the action docs note it "cannot perform
-          # complex git operations like rebasing" for exactly that reason - so
-          # nothing here needs the persisted credential.
+          # covering the whole threat model.
+          #
+          # (2) Why it is safe: with `use_commit_signing: true` the action takes
+          # the API-signing path, so `useApiCommitSigning` is true and
+          # `configureGitAuth` is never called (src/modes/tag/index.ts:71,88) -
+          # nothing re-adds a token after checkout. Commits go through GitHub's
+          # API, which is why the action docs note that mode "cannot perform
+          # complex git operations like rebasing". Note the inversion: the review
+          # job sets the same flag but does NOT get a token-free checkout,
+          # because dropping `use_commit_signing` there puts it on the branch
+          # that does configure git auth.
           persist-credentials: false
 
       # The cargo grant below is only usable with a toolchain and a warm cache.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,7 +52,15 @@ jobs:
           fetch-depth: 0
           # This workflow now compiles PR-authored code (build.rs and test code
           # run under the cargo grant below), so it should not leave a usable
-          # `contents: write` token in the checkout's git config. Safe to drop:
+          # `contents: write` token in the checkout's git config.
+          #
+          # Scoped claim: this closes the git-config vector only. The action also
+          # passes the token into the CLI step's environment
+          # (DEFAULT_WORKFLOW_TOKEN / OVERRIDE_GITHUB_TOKEN in its action.yml),
+          # which cargo and therefore a PR's build.rs would inherit. What keeps
+          # that acceptable is the author_association gate above: a trusted human
+          # has to type @claude for any of this to run. Do not read this line as
+          # covering the whole threat model. Safe to drop:
           # with `use_commit_signing: true` the action commits through GitHub's
           # API rather than the git CLI - the action docs note it "cannot perform
           # complex git operations like rebasing" for exactly that reason - so

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -68,9 +68,17 @@ jobs:
           persist-credentials: false
 
       # The cargo grant below is only usable with a toolchain and a warm cache.
-      # Granting `cargo test` without these makes running it cost a cold 6-crate
-      # build, which the model then rationally skips - "permitted but not usable"
-      # is the same failure this grant exists to fix.
+      # Granting `cargo test` without these makes running it cost a cold build,
+      # which the model then rationally skips - "permitted but not usable" is the
+      # same failure this grant exists to fix.
+      #
+      # Deliberately ungated, unlike the two equivalent steps in
+      # claude-code-review.yml. An @claude request on a plain issue may still
+      # create a branch and commit code, and rule 7 ("not done until tests
+      # added") is why the grant exists - so predicting from `github.event_name`
+      # which requests will need cargo would fail silently in the one direction
+      # that matters. Paying toolchain setup on a prose-only question is the
+      # accepted price of the grant working everywhere.
       - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
         with:
           components: clippy, rustfmt

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,5 +61,12 @@ jobs:
           #
           # No `prompt` here on purpose: this workflow is triggered by an
           # explicit @claude mention, and the comment body is the instruction.
+          # Same additive semantics as claude-code-review.yml: the baseline
+          # withholds cargo, so without this list an `@claude fix X and add a
+          # test` request would commit code that was never compiled - against
+          # CLAUDE.md rule 7 ("Task is not done until tests added"). This
+          # workflow does commit (`use_commit_signing` + `contents: write`), so
+          # it is the one that most needs to verify its own work.
           claude_args: |
             --model claude-opus-5
+            --allowedTools "WebFetch,WebSearch,Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo fmt:*),Bash(cargo check:*),Bash(cargo build:*),Bash(cargo run:*),Bash(node scripts/sync-rule-bookkeeping.js:*),Bash(bash scripts/check-locale-sync.sh:*),Bash(python3 scripts/check-rule-counts.py:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,9 @@ jobs:
       )
 
     runs-on: ubuntu-latest
+    # Bounded now that an @claude request can trigger a cargo build; the default
+    # is 6 hours.
+    timeout-minutes: 60
 
     permissions:
       contents: write
@@ -47,6 +50,19 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+
+      # The cargo grant below is only usable with a toolchain and a warm cache.
+      # Granting `cargo test` without these makes running it cost a cold 6-crate
+      # build, which the model then rationally skips - "permitted but not usable"
+      # is the same failure this grant exists to fix.
+      - uses: dtolnay/rust-toolchain@4be9e76fd7c4901c61fb841f559994984270fce7 # stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        with:
+          shared-key: agnix-workspace
+          save-if: "false"
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@e0cf66d1d257526b5d07f141838c338921cb8455 # v1

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,5 +53,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-opus-4-6
           use_commit_signing: true
+          # `model` is not an action input - it reaches the CLI through
+          # claude_args. As an input it produced `Unexpected input(s) 'model'`
+          # and was ignored, so this ran on the default model instead.
+          #
+          # No `prompt` here on purpose: this workflow is triggered by an
+          # explicit @claude mention, and the comment body is the instruction.
+          claude_args: |
+            --model claude-opus-4-6

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,9 +56,10 @@ jobs:
           use_commit_signing: true
           # `model` is not an action input - it reaches the CLI through
           # claude_args. As an input it produced `Unexpected input(s) 'model'`
-          # and was ignored, so this ran on the default model instead.
+          # and was ignored, so this ran on the default model instead. The
+          # pinned value was also a stale model ID.
           #
           # No `prompt` here on purpose: this workflow is triggered by an
           # explicit @claude mention, and the comment body is the instruction.
           claude_args: |
-            --model claude-opus-4-6
+            --model claude-opus-5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,9 +69,10 @@ jobs:
           # nothing re-adds a token after checkout. Commits go through GitHub's
           # API, which is why the action docs note that mode "cannot perform
           # complex git operations like rebasing". Note the inversion: the review
-          # job sets the same flag but does NOT get a token-free checkout,
-          # because dropping `use_commit_signing` there puts it on the branch
-          # that does configure git auth.
+          # job carries this same `persist-credentials: false` line but does NOT
+          # end up with a token-free checkout, because dropping
+          # `use_commit_signing` there puts it on the branch that does configure
+          # git auth.
           persist-credentials: false
 
       # The cargo grant below is only usable with a toolchain and a warm cache.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,6 +50,14 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          # This workflow now compiles PR-authored code (build.rs and test code
+          # run under the cargo grant below), so it should not leave a usable
+          # `contents: write` token in the checkout's git config. Safe to drop:
+          # with `use_commit_signing: true` the action commits through GitHub's
+          # API rather than the git CLI - the action docs note it "cannot perform
+          # complex git operations like rebasing" for exactly that reason - so
+          # nothing here needs the persisted credential.
+          persist-credentials: false
 
       # The cargo grant below is only usable with a toolchain and a warm cache.
       # Granting `cargo test` without these makes running it cost a cold 6-crate

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -34,7 +34,7 @@ Each locale needs identical YAML files in three crate directories and the worksp
    `bash scripts/check-locale-sync.sh` instead of trusting this list - the gate
    discovers crates and prints the exact copy command for the current layout.
 
-   All four copies (root + 3 crates) must be identical. The CI "Locale sync check" step will fail if they drift.
+   Every copy (the root plus each crate with a `locales/` directory) must be identical. The CI "Locale sync check" step will fail if they drift.
 
 4. **Register the locale** in two places:
 

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -10,7 +10,7 @@ agnix supports multiple languages for diagnostic messages, CLI output, and LSP l
 | `es`    | Spanish               | `crates/*/locales/es.yml`      |
 | `zh-CN` | Chinese (Simplified)  | `crates/*/locales/zh-CN.yml`   |
 
-Locale files are stored per-crate (`agnix-core/locales/`, `agnix-cli/locales/`, `agnix-lsp/locales/`) so each crate embeds its required translations at compile time. A CI `locale-sync` job verifies all copies stay in sync.
+Locale files are stored per-crate (`agnix-core/locales/`, `agnix-cli/locales/`, `agnix-lsp/locales/`) so each crate embeds its required translations at compile time. The CI "Locale sync check" step (in the `ci` job) verifies all copies stay in sync.
 
 ## Adding a New Language
 
@@ -30,7 +30,7 @@ Each locale needs identical YAML files in three crate directories and the worksp
      cp "locales/<code>.yml" "crates/$crate/locales/<code>.yml"
    done
    ```
-   All four copies (root + 3 crates) must be identical. The CI `locale-sync` job will fail if they drift.
+   All four copies (root + 3 crates) must be identical. The CI "Locale sync check" step will fail if they drift.
 
 4. **Register the locale** in two places:
 

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -30,6 +30,10 @@ Each locale needs identical YAML files in three crate directories and the worksp
      cp "locales/<code>.yml" "crates/$crate/locales/<code>.yml"
    done
    ```
+   If a crate is ever added with its own `locales/` directory, run
+   `bash scripts/check-locale-sync.sh` instead of trusting this list - the gate
+   discovers crates and prints the exact copy command for the current layout.
+
    All four copies (root + 3 crates) must be identical. The CI "Locale sync check" step will fail if they drift.
 
 4. **Register the locale** in two places:

--- a/docs/TRANSLATING.md
+++ b/docs/TRANSLATING.md
@@ -10,7 +10,7 @@ agnix supports multiple languages for diagnostic messages, CLI output, and LSP l
 | `es`    | Spanish               | `crates/*/locales/es.yml`      |
 | `zh-CN` | Chinese (Simplified)  | `crates/*/locales/zh-CN.yml`   |
 
-Locale files are stored per-crate (`agnix-core/locales/`, `agnix-cli/locales/`, `agnix-lsp/locales/`) so each crate embeds its required translations at compile time. The CI "Locale sync check" step (in the `ci` job) verifies all copies stay in sync.
+Locale files are stored per-crate (`agnix-core/locales/`, `agnix-cli/locales/`, `agnix-lsp/locales/`) so each crate embeds its required translations at compile time. The CI "Locale sync check" step verifies all copies stay in sync (it runs in the `ci` job, which appears in the PR checks list as `test (ubuntu-latest)`).
 
 ## Adding a New Language
 
@@ -24,7 +24,7 @@ Each locale needs identical YAML files in three crate directories and the worksp
 
 2. **Translate all string values** in `locales/<code>.yml`. Keep YAML keys unchanged; only modify values.
 
-3. **Sync to all crates** -- copy the translated file into each crate's `locales/` directory:
+3. **Sync to all crates** - copy the translated file into each crate's `locales/` directory:
    ```bash
    for crate in agnix-core agnix-cli agnix-lsp; do
      cp "locales/<code>.yml" "crates/$crate/locales/<code>.yml"

--- a/scripts/check-locale-sync.sh
+++ b/scripts/check-locale-sync.sh
@@ -39,11 +39,18 @@ root_non_yml=0
 for glob in "${LOCALE_GLOBS[@]}"; do
   for f in "${ROOT_LOCALES}"/$glob; do
     [ -f "$f" ] || continue
-    LOCALE_FILES+=("$(basename "$f")")
     case "$f" in
       *.yml) ;;
-      *) root_non_yml=$((root_non_yml + 1)) ;;
+      *)
+        # Counted but NOT enumerated: adding it to LOCALE_FILES would make the
+        # forward loop demand a copy in every crate, i.e. instruct the
+        # contributor to propagate the very deviation these globs exist to
+        # catch. The footer's advice is to rename it.
+        root_non_yml=$((root_non_yml + 1))
+        continue
+        ;;
     esac
+    LOCALE_FILES+=("$(basename "$f")")
   done
 done
 
@@ -138,8 +145,14 @@ if [ "$errors" -gt 0 ]; then
     echo "  cp crates/<crate>/locales/<locale>.yml ${ROOT_LOCALES}/"
   fi
 
-  # Always printed: the fan-out is the final step for every class above.
-  echo "Then fan the canonical copies out to every crate:"
+  # Always printed: the fan-out is the final step for every class above. Worded
+  # as a standalone instruction when it is the only step, since plain forward
+  # drift would otherwise open on "Then ..." with nothing before it.
+  if [ $((non_yml + root_non_yml + missing_from_root)) -gt 0 ]; then
+    echo "Then fan the canonical copies out to every crate:"
+  else
+    echo "Fan the canonical copies out to every crate:"
+  fi
   echo "  for d in${crate_targets}; do cp ${ROOT_LOCALES}/*.yml \"\$d\"; done"
   exit 1
 fi

--- a/scripts/check-locale-sync.sh
+++ b/scripts/check-locale-sync.sh
@@ -55,7 +55,19 @@ for glob in "${LOCALE_GLOBS[@]}"; do
 done
 
 if [ ${#LOCALE_FILES[@]} -eq 0 ]; then
-  echo "FAIL: No locale files (${LOCALE_GLOBS[*]}) found in ${ROOT_LOCALES}/"
+  # Distinguish "nothing there" from "everything there is misnamed". The second
+  # case had already been counted into root_non_yml above, and reporting "none
+  # found" discarded that measurement and skipped the rename advice in the
+  # footer, which is 80 lines below this exit.
+  if [ "$root_non_yml" -gt 0 ]; then
+    echo "FAIL: every locale file in ${ROOT_LOCALES}/ (${root_non_yml}) uses an extension other than .yml"
+    echo ""
+    echo "Rename them, e.g."
+    echo "  mv ${ROOT_LOCALES}/<locale>.json ${ROOT_LOCALES}/<locale>.yml"
+    echo "then fan the canonical copies out to every crate."
+  else
+    echo "FAIL: No locale files (${LOCALE_GLOBS[*]}) found in ${ROOT_LOCALES}/"
+  fi
   exit 1
 fi
 

--- a/scripts/check-locale-sync.sh
+++ b/scripts/check-locale-sync.sh
@@ -31,18 +31,32 @@ done
 LOCALE_GLOBS=("*.yml" "*.yaml" "*.json" "*.toml")
 
 LOCALE_FILES=()
+# Root-side convention deviations, counted here so the rename advice is
+# reachable from this direction too. Previously only the reverse (crate-side)
+# pass counted them, so a root `zz.json` fell through to the copy hint - and
+# `cp locales/*.yml` cannot move it.
+root_non_yml=0
 for glob in "${LOCALE_GLOBS[@]}"; do
   for f in "${ROOT_LOCALES}"/$glob; do
-    [ -f "$f" ] && LOCALE_FILES+=("$(basename "$f")")
+    [ -f "$f" ] || continue
+    LOCALE_FILES+=("$(basename "$f")")
+    case "$f" in
+      *.yml) ;;
+      *) root_non_yml=$((root_non_yml + 1)) ;;
+    esac
   done
 done
 
 if [ ${#LOCALE_FILES[@]} -eq 0 ]; then
-  echo "FAIL: No .yml files found in ${ROOT_LOCALES}/"
+  echo "FAIL: No locale files (${LOCALE_GLOBS[*]}) found in ${ROOT_LOCALES}/"
   exit 1
 fi
 
 errors=0
+if [ "$root_non_yml" -gt 0 ]; then
+  echo "FAIL: ${ROOT_LOCALES}/ contains ${root_non_yml} locale file(s) not using the .yml extension"
+  errors=$((errors + root_non_yml))
+fi
 # Counted separately: a crate-only file needs the opposite copy direction.
 missing_from_root=0
 # Counted separately: a non-.yml locale needs a rename, not a copy.
@@ -95,9 +109,7 @@ done
 if [ "$errors" -gt 0 ]; then
   echo ""
   echo "${errors} locale file(s) out of sync."
-  # Direction matters: the outward copy cannot fix a crate-only file, since it
-  # never creates the root copy. Printing only that hint sent a contributor who
-  # tripped the reverse check into a no-op and identical output on re-run.
+
   # Derived from CRATES, not hardcoded: the discovery pass can add a crate, and
   # a literal list here would silently exclude it from the advice while the gate
   # still checked it.
@@ -106,22 +118,29 @@ if [ "$errors" -gt 0 ]; then
     crate_targets="${crate_targets} ${crate}/locales/"
   done
 
-  if [ "$non_yml" -gt 0 ]; then
-    # A non-.yml locale is a convention violation, not a sync problem. Telling
-    # the contributor to propagate it would spread the deviation; the fix is a
-    # rename. See docs/TRANSLATING.md.
+  # Each applicable class prints its own step rather than one exclusive branch:
+  # a tree can trip several at once, and an exclusive chain left the mixed case
+  # with no runnable command.
+  #
+  # A non-.yml locale is a convention violation, not a sync problem - telling
+  # the contributor to propagate it would spread the deviation. Counted from
+  # both directions, since a root-side `zz.json` is just as unfixable by
+  # `cp locales/*.yml` as a crate-side one. See docs/TRANSLATING.md.
+  if [ $((non_yml + root_non_yml)) -gt 0 ]; then
     echo "A locale file uses an extension other than .yml. Rename it, e.g."
-    echo "  mv crates/<crate>/locales/<locale>.json crates/<crate>/locales/<locale>.yml"
-    echo "then make sure ${ROOT_LOCALES}/ has the canonical copy and fan it out."
-  elif [ "$missing_from_root" -gt 0 ]; then
-    echo "For a file present in a crate but not in ${ROOT_LOCALES}/: copy it inward first,"
-    echo "  cp crates/<crate>/locales/<locale>.yml ${ROOT_LOCALES}/"
-    echo "then fan it back out to every crate:"
-    echo "  for d in${crate_targets}; do cp ${ROOT_LOCALES}/*.yml \"\$d\"; done"
-  else
-    echo "Run:"
-    echo "  for d in${crate_targets}; do cp ${ROOT_LOCALES}/*.yml \"\$d\"; done"
+    echo "  mv <dir>/<locale>.json <dir>/<locale>.yml"
   fi
+
+  # The outward copy cannot create a root file, so a crate-only locale needs the
+  # inward copy first.
+  if [ "$missing_from_root" -gt 0 ]; then
+    echo "For a file present in a crate but not in ${ROOT_LOCALES}/, copy it inward first:"
+    echo "  cp crates/<crate>/locales/<locale>.yml ${ROOT_LOCALES}/"
+  fi
+
+  # Always printed: the fan-out is the final step for every class above.
+  echo "Then fan the canonical copies out to every crate:"
+  echo "  for d in${crate_targets}; do cp ${ROOT_LOCALES}/*.yml \"\$d\"; done"
   exit 1
 fi
 

--- a/scripts/check-locale-sync.sh
+++ b/scripts/check-locale-sync.sh
@@ -6,12 +6,35 @@
 set -euo pipefail
 
 ROOT_LOCALES="locales"
+# Explicit floor: these three MUST have a locales/ directory, so a deleted one
+# is a failure rather than something a glob silently stops enumerating.
 CRATES=("crates/agnix-core" "crates/agnix-cli" "crates/agnix-lsp")
 
+# Discovery pass on top of the floor: a new crate that gains locales/ is checked
+# without editing this list. Union, so the floor keeps its failure mode.
+for discovered in crates/*/locales; do
+  [ -d "$discovered" ] || continue
+  crate_dir="${discovered%/locales}"
+  for known in "${CRATES[@]}"; do
+    [ "$known" = "$crate_dir" ] && continue 2
+  done
+  CRATES+=("$crate_dir")
+done
+
 # Dynamically discover locale files from root directory
+# rust-i18n loads YAML, JSON and TOML ("Use YAML (default), JSON or TOML format
+# for mapping localized text"), so restricting to *.yml would let a stray
+# fr.json in a crate be loaded by the macro while staying invisible here -
+# the same blind spot the reverse pass below exists to close.
+# docs/TRANSLATING.md mandates .yml; these extensions are checked so a
+# deviation fails loudly instead of silently.
+LOCALE_GLOBS=("*.yml" "*.yaml" "*.json" "*.toml")
+
 LOCALE_FILES=()
-for f in "${ROOT_LOCALES}"/*.yml; do
-  [ -f "$f" ] && LOCALE_FILES+=("$(basename "$f")")
+for glob in "${LOCALE_GLOBS[@]}"; do
+  for f in "${ROOT_LOCALES}"/$glob; do
+    [ -f "$f" ] && LOCALE_FILES+=("$(basename "$f")")
+  done
 done
 
 if [ ${#LOCALE_FILES[@]} -eq 0 ]; then
@@ -20,6 +43,8 @@ if [ ${#LOCALE_FILES[@]} -eq 0 ]; then
 fi
 
 errors=0
+# Counted separately: a crate-only file needs the opposite copy direction.
+missing_from_root=0
 
 for crate in "${CRATES[@]}"; do
   crate_locales="${crate}/locales"
@@ -48,20 +73,33 @@ for crate in "${CRATES[@]}"; do
   # otherwise be invisible, since the loop above only walks the root's files.
   # rust_i18n loads from the crate copy, so that file WOULD ship while the
   # canonical root copy silently lacked it.
-  for crate_file in "${crate_locales}"/*.yml; do
+  for glob in "${LOCALE_GLOBS[@]}"; do
+   for crate_file in "${crate_locales}"/$glob; do
     [ -f "$crate_file" ] || continue
     file="$(basename "$crate_file")"
     if [ ! -f "${ROOT_LOCALES}/${file}" ]; then
       echo "FAIL: ${crate_file} has no counterpart in ${ROOT_LOCALES}/ (add it there too; the root copy is canonical)"
       errors=$((errors + 1))
+      missing_from_root=$((missing_from_root + 1))
     fi
+   done
   done
 done
 
 if [ "$errors" -gt 0 ]; then
   echo ""
   echo "${errors} locale file(s) out of sync."
-  echo "Run: cp locales/*.yml crates/agnix-{core,cli,lsp}/locales/"
+  # Direction matters: the outward copy cannot fix a crate-only file, since it
+  # never creates the root copy. Printing only that hint sent a contributor who
+  # tripped the reverse check into a no-op and identical output on re-run.
+  if [ "$missing_from_root" -gt 0 ]; then
+    echo "For a file present in a crate but not in ${ROOT_LOCALES}/: copy it inward first,"
+    echo "  cp crates/<crate>/locales/<locale>.yml ${ROOT_LOCALES}/"
+    echo "then fan it back out to every crate:"
+  else
+    echo "Run:"
+  fi
+  echo "  cp locales/*.yml crates/agnix-{core,cli,lsp}/locales/"
   exit 1
 fi
 

--- a/scripts/check-locale-sync.sh
+++ b/scripts/check-locale-sync.sh
@@ -43,6 +43,19 @@ for crate in "${CRATES[@]}"; do
       errors=$((errors + 1))
     fi
   done
+
+  # Reverse direction: a locale added to a crate but never to the root would
+  # otherwise be invisible, since the loop above only walks the root's files.
+  # rust_i18n loads from the crate copy, so that file WOULD ship while the
+  # canonical root copy silently lacked it.
+  for crate_file in "${crate_locales}"/*.yml; do
+    [ -f "$crate_file" ] || continue
+    file="$(basename "$crate_file")"
+    if [ ! -f "${ROOT_LOCALES}/${file}" ]; then
+      echo "FAIL: ${crate_file} has no counterpart in ${ROOT_LOCALES}/ (add it there too; the root copy is canonical)"
+      errors=$((errors + 1))
+    fi
+  done
 done
 
 if [ "$errors" -gt 0 ]; then

--- a/scripts/check-locale-sync.sh
+++ b/scripts/check-locale-sync.sh
@@ -45,6 +45,8 @@ fi
 errors=0
 # Counted separately: a crate-only file needs the opposite copy direction.
 missing_from_root=0
+# Counted separately: a non-.yml locale needs a rename, not a copy.
+non_yml=0
 
 for crate in "${CRATES[@]}"; do
   crate_locales="${crate}/locales"
@@ -74,15 +76,19 @@ for crate in "${CRATES[@]}"; do
   # rust_i18n loads from the crate copy, so that file WOULD ship while the
   # canonical root copy silently lacked it.
   for glob in "${LOCALE_GLOBS[@]}"; do
-   for crate_file in "${crate_locales}"/$glob; do
-    [ -f "$crate_file" ] || continue
-    file="$(basename "$crate_file")"
-    if [ ! -f "${ROOT_LOCALES}/${file}" ]; then
-      echo "FAIL: ${crate_file} has no counterpart in ${ROOT_LOCALES}/ (add it there too; the root copy is canonical)"
-      errors=$((errors + 1))
-      missing_from_root=$((missing_from_root + 1))
-    fi
-   done
+    for crate_file in "${crate_locales}"/$glob; do
+      [ -f "$crate_file" ] || continue
+      file="$(basename "$crate_file")"
+      if [ ! -f "${ROOT_LOCALES}/${file}" ]; then
+        echo "FAIL: ${crate_file} has no counterpart in ${ROOT_LOCALES}/ (add it there too; the root copy is canonical)"
+        errors=$((errors + 1))
+        missing_from_root=$((missing_from_root + 1))
+        case "$crate_file" in
+          *.yml) ;;
+          *) non_yml=$((non_yml + 1)) ;;
+        esac
+      fi
+    done
   done
 done
 
@@ -92,14 +98,30 @@ if [ "$errors" -gt 0 ]; then
   # Direction matters: the outward copy cannot fix a crate-only file, since it
   # never creates the root copy. Printing only that hint sent a contributor who
   # tripped the reverse check into a no-op and identical output on re-run.
-  if [ "$missing_from_root" -gt 0 ]; then
+  # Derived from CRATES, not hardcoded: the discovery pass can add a crate, and
+  # a literal list here would silently exclude it from the advice while the gate
+  # still checked it.
+  crate_targets=""
+  for crate in "${CRATES[@]}"; do
+    crate_targets="${crate_targets} ${crate}/locales/"
+  done
+
+  if [ "$non_yml" -gt 0 ]; then
+    # A non-.yml locale is a convention violation, not a sync problem. Telling
+    # the contributor to propagate it would spread the deviation; the fix is a
+    # rename. See docs/TRANSLATING.md.
+    echo "A locale file uses an extension other than .yml. Rename it, e.g."
+    echo "  mv crates/<crate>/locales/<locale>.json crates/<crate>/locales/<locale>.yml"
+    echo "then make sure ${ROOT_LOCALES}/ has the canonical copy and fan it out."
+  elif [ "$missing_from_root" -gt 0 ]; then
     echo "For a file present in a crate but not in ${ROOT_LOCALES}/: copy it inward first,"
     echo "  cp crates/<crate>/locales/<locale>.yml ${ROOT_LOCALES}/"
     echo "then fan it back out to every crate:"
+    echo "  for d in${crate_targets}; do cp ${ROOT_LOCALES}/*.yml \"\$d\"; done"
   else
     echo "Run:"
+    echo "  for d in${crate_targets}; do cp ${ROOT_LOCALES}/*.yml \"\$d\"; done"
   fi
-  echo "  cp locales/*.yml crates/agnix-{core,cli,lsp}/locales/"
   exit 1
 fi
 


### PR DESCRIPTION
The `claude-review` job has reported success in ~11 seconds and posted **nothing** on every PR for months — including all six drift PRs merged today. CLAUDE.md rule 11 treats it as "the major quality gate, and most thorough review", so this was a green check gating nothing.

Two separate defects.

## 1. No `prompt` on a `pull_request` event, so there was nothing to do

The job triggers on `pull_request`. With no `prompt` input, the action looks for an `@claude` trigger, finds none, has nothing to do, and exits successfully. That is the entire 11 seconds.

The fix is `track_progress: true`, which the action documents as:

> Force tag mode with tracking comments for **pull_request** and issue events.

That's the same mechanism the action's own [`examples/pr-review-comprehensive.yml`](https://github.com/anthropics/claude-code-action/blob/main/examples/pr-review-comprehensive.yml) uses for exactly this shape of job.

Added a prompt scoped to this repo rather than a generic one, in priority order:

1. **Correctness** — for a validator change, does the rule still reject what it should while accepting what the upstream doc endorses?
2. **Evidence** — every rule claim must trace to a cited source; flag behavior no `evidence.source_urls` entry supports, and any autofix that could change a config's *meaning* rather than its spelling.
3. **Test quality** — tests must assert both directions; a happy-path-only test is a gap.
4. **Bookkeeping** — `rules.json` ↔ `VALIDATION-RULES.md`, rule counts, locales, `AGENTS.md`/`CLAUDE.md` parity.

Formatting nits are explicitly excluded, since `cargo fmt` and clippy already gate them — otherwise the review spends its attention on noise.

The three items after correctness are the failure classes that actually showed up in today's work: two rules had no upstream origin at all, and one autofix silently changed when a hook fired.

## 2. `model` is not an action input

Both workflows passed `model: claude-opus-4-6` as an input. The logs show:

```
##[warning]Unexpected input(s) 'model', valid inputs are ['trigger_phrase', ...]
```

It was ignored, so any run that *had* worked would have used the default model, not the pinned one. It belongs in `claude_args` as `--model`.

## `claude.yml` deliberately keeps no prompt

That workflow fires on an explicit `@claude` mention, so the comment body *is* the instruction — adding a prompt would override what the user asked for. It only needed the `model` fix.

## Verification

- Both files parse as YAML.
- Cross-checked every remaining input against the action's own `action.yml` input list: **no unknown keys** in either workflow. That check is what would have caught the original bug.
- The real proof is behavioral and arrives on this PR: `claude-review` should now take minutes rather than 11 seconds and leave an actual review. I'll confirm before merging.

`[skip changelog]`: CI-only, no user-facing behavior change.
