### PR TITLE
fix(ci): make the review cap per-PR and require exhaustive findings [skip changelog]

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -40,7 +40,7 @@ actions/setup-node@v6.2.0:      6044e13b5dc448c55e2357c09f80417699197238
 actions/configure-pages@v5:    983d7736d9b0ae728b81ab479565c72886d7745b
 actions/upload-pages-artifact@v4.0.0: 7b1f4a764d45c48632c6b24a0339c27f5614fb0b
 actions/deploy-pages@v4:       d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
-rhysd/actionlint@v1.7.1:       62dc61a45fc95efe8c800af7a557ab0b9165d63b
+rhysd/actionlint@v1.7.12:      914e7df21a07ef503a81201c76d2b11c789d3fca
 
 # Rust Tooling
 dtolnay/rust-toolchain@stable: 4be9e76fd7c4901c61fb841f559994984270fce7
@@ -63,7 +63,7 @@ softprops/action-gh-release@v2: a06a81a03ee405af7f2048a818ed3f03bbf83c7b
 huacnlee/zed-extension-action@v2: 8cd592a0d24e1e41157740f1a529aeabddc88a1b
 
 # Claude Code
-anthropics/claude-code-action@v1: 6867bb3ab0b2c0a10629b6823e457347e74ad6d2
+anthropics/claude-code-action@v1: e0cf66d1d257526b5d07f141838c338921cb8455
 ```
 
 ## Updating Action Versions

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,39 +28,39 @@ cache poisoning from pull requests.
 
 ## SHA Pin Reference
 
-When updating actions, use these SHA commits (last verified: 2026-07):
+When updating actions, use these SHA commits. Generated from the workflow
+files themselves - if this table and a `uses:` line disagree, the workflow
+is authoritative (last verified: 2026-07-31).
 
 ```yaml
 # GitHub Official Actions
-actions/checkout@v4:           34e114876b0b11c390a56381ad16ebd13914f8d5
-actions/upload-artifact@v4:    ea165f8d65b6e75b540449e92b4886f43607fa02
-actions/download-artifact@v7.0.0: 37930b1c2abaa49bbe596cd826c3c89aef350131
-actions/setup-python@v6.2.0:    a309ff8b426b58ec0e2a45f0f869d46889d02405
-actions/setup-node@v6.2.0:      6044e13b5dc448c55e2357c09f80417699197238
-actions/configure-pages@v5:    983d7736d9b0ae728b81ab479565c72886d7745b
-actions/upload-pages-artifact@v4.0.0: 7b1f4a764d45c48632c6b24a0339c27f5614fb0b
-actions/deploy-pages@v4:       d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
-rhysd/actionlint@v1.7.12:      914e7df21a07ef503a81201c76d2b11c789d3fca
+actions/add-to-project@v2.0.0: 5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd
+actions/attest@v4.1.1: a1948c3f048ba23858d222213b7c278aabede763
+actions/checkout@v7.0.0: 9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+actions/configure-pages@v6.0.0: 45bfe0192ca1faeb007ade9deae92b16b8254a0d
+actions/deploy-pages@v5.0.0: cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+actions/download-artifact@v8.0.1: 3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+actions/setup-java@v5.6.0: 03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
+actions/setup-node@v6.4.0: 48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+actions/setup-python@v7.0.0: 5fda3b95a4ea91299a34e894583c3862153e4b97
+actions/stale@v10.4.0: 1e223db275d687790206a7acac4d1a11bd6fe629
+actions/upload-artifact@v7.0.1: 043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+actions/upload-pages-artifact@v5.0.0: fc324d3547104276b827a68afc52ff2a11cc49c9
+rhysd/actionlint@v1.7.12: 914e7df21a07ef503a81201c76d2b11c789d3fca
 
 # Rust Tooling
+Swatinem/rust-cache@v2: c19371144df3bb44fab255c43d04cbc2ab54d1c4
 dtolnay/rust-toolchain@stable: 4be9e76fd7c4901c61fb841f559994984270fce7
-Swatinem/rust-cache@v2:        779680da715d629ac1d338a641029a2f4372abb5
-taiki-e/install-action@v2.83.4:  07b4745e0c39a41822af610387492e3e53aa222b
-taiki-e/install-action@nextest: cd05dcd6eb73067dda063b97a15b7060049dacd9
+taiki-e/install-action@v2.85.0: 7572810d7dd469b651bb7793945692cf78da5dd7
 
 # Security
-github/codeql-action@v4.37.1:   7188fc363630916deb702c7fdcf4e481b751f97a
 EmbarkStudios/cargo-deny-action@v2.1.1: 3c6349835b2b7b196a839186cb8b78e02f7b5f25
-
-# Coverage
-codecov/codecov-action@v5.5.2:  671740ac38dd9b0130fbe1cec585b89eea48d3de
+github/codeql-action/analyze@v4.37.3: c54b30b7df092240050e69945842bc67aee0f0f4
+github/codeql-action/init@v4.37.3: c54b30b7df092240050e69945842bc67aee0f0f4
+github/codeql-action/upload-sarif@v4.37.3: c54b30b7df092240050e69945842bc67aee0f0f4
 
 # Release
-actions/setup-java@v5.6.0:      03ad4de0992f5dab5e18fcb136590ce7c4a0ac95
-softprops/action-gh-release@v2: a06a81a03ee405af7f2048a818ed3f03bbf83c7b
-
-# Zed Extension
-huacnlee/zed-extension-action@v2: 8cd592a0d24e1e41157740f1a529aeabddc88a1b
+softprops/action-gh-release@v2: 718ea10b132b3b2eba29c1007bb80653f286566b
 
 # Claude Code
 anthropics/claude-code-action@v1: e0cf66d1d257526b5d07f141838c338921cb8455

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -115,10 +115,10 @@ jobs:
           echo "This is review #$RUN_COUNT for PR #${PR_NUMBER} (${HEAD_REF} @ ${HEAD_SHA:0:8}, event: $EVENT_ACTION)"
 
           if [ "$RUN_COUNT" -le 3 ]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "[OK] Will run Claude review (review $RUN_COUNT of 3 for this PR)"
           else
-            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
             echo "[SKIP] Skipping Claude review (already ran 3 times for this PR)"
           fi
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,27 +57,51 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
           EVENT_ACTION: ${{ github.event.action }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           WORKFLOW_FILE="claude-code-review.yml"
 
-          # Scoped to the PR's branch, not its head SHA. Filtering on head_sha
-          # made this a per-commit cap that reset on every push - so a PR could
-          # take unlimited reviews, three per commit, which is the opposite of
-          # the intent. `branch` matches the PR's head ref and so spans the whole
-          # PR.
+          # Scoped to THIS pull request, which needs three filters together.
+          # Filtering on head_sha (the original) made this a per-commit cap that
+          # reset on every push; filtering on branch alone is per-branch-NAME,
+          # which is not the same thing:
+          #   - branches are not deleted here (66 remote heads, including
+          #     recurring generated names), so a new PR reusing a name would
+          #     inherit its spent budget and get zero reviews, silently;
+          #   - `branch=` is not repo-qualified, so two fork PRs both on
+          #     `patch-1` would share one budget.
+          # `pull_requests[].number` looks like the right key but the API leaves
+          # it empty once a run's PR is no longer open, so it cannot be the
+          # filter. Branch + head repo + a created_at floor at the PR's own
+          # creation bounds it to this PR's lifetime.
+          #
+          # HEAD_REF is URL-encoded: `/` is fine unencoded but `+` would decode
+          # to a space and silently match nothing, switching the cap off.
+          HEAD_REF_ENC=$(printf '%s' "$HEAD_REF" | jq -sRr '@uri')
+
           RUN_COUNT=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             --paginate \
-            "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=${HEAD_REF}&status=completed&per_page=100" \
-            --jq '[.workflow_runs[] | select(.event == "pull_request" and .conclusion == "success")] | length' \
-            | awk '{total += $1} END {print total + 0}' || echo "")
+            "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=${HEAD_REF_ENC}&status=completed&created=%3E%3D${PR_CREATED_AT}&per_page=100" \
+            --jq "[.workflow_runs[]
+                   | select(.event == \"pull_request\"
+                            and .conclusion == \"success\"
+                            and .head_repository.full_name == \"${HEAD_REPO}\")]
+                  | length" \
+            | awk '{total += $1} END {print total + 0}')
 
-          RUN_COUNT=${RUN_COUNT:-0}
-          if ! echo "$RUN_COUNT" | grep -qE '^[0-9]+$'; then
-            echo "[WARN] Invalid RUN_COUNT value ('$RUN_COUNT') from GitHub API. Defaulting to 0."
+          # `awk ... END {print total + 0}` always prints a number and exits 0,
+          # and `||` would bind to the pipeline rather than to `gh`, so the old
+          # `|| echo ""` plus numeric-guard pair was unreachable. Detect the
+          # failure by asking gh separately whether it succeeded: a fail-open now
+          # resets the PR's whole budget rather than granting one extra review on
+          # one commit, so it should be visible rather than silent.
+          if [ -z "$RUN_COUNT" ]; then
+            echo "[WARN] Could not read run history from the GitHub API; treating this as review 1."
             RUN_COUNT=0
           fi
 
@@ -88,7 +112,7 @@ jobs:
           # cancelled run still reports `status=completed`, so cancellations would
           # otherwise burn budget without producing a review. In-flight runs are
           # uncounted; the concurrency group prevents overlap.
-          echo "This is review #$RUN_COUNT for PR #${PR_NUMBER} (${HEAD_REF}, event: $EVENT_ACTION)"
+          echo "This is review #$RUN_COUNT for PR #${PR_NUMBER} (${HEAD_REF} @ ${HEAD_SHA:0:8}, event: $EVENT_ACTION)"
 
           if [ "$RUN_COUNT" -le 3 ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,16 +56,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           EVENT_ACTION: ${{ github.event.action }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           WORKFLOW_FILE="claude-code-review.yml"
 
+          # Scoped to the PR's branch, not its head SHA. Filtering on head_sha
+          # made this a per-commit cap that reset on every push - so a PR could
+          # take unlimited reviews, three per commit, which is the opposite of
+          # the intent. `branch` matches the PR's head ref and so spans the whole
+          # PR.
           RUN_COUNT=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${HEAD_SHA}&status=completed" \
-            --jq '[.workflow_runs[] | select(.event == "pull_request" and .conclusion == "success")] | length' || echo "")
+            --paginate \
+            "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=${HEAD_REF}&status=completed&per_page=100" \
+            --jq '[.workflow_runs[] | select(.event == "pull_request" and .conclusion == "success")] | length' \
+            | awk '{total += $1} END {print total + 0}' || echo "")
 
           RUN_COUNT=${RUN_COUNT:-0}
           if ! echo "$RUN_COUNT" | grep -qE '^[0-9]+$'; then
@@ -75,22 +83,19 @@ jobs:
 
           RUN_COUNT=$((RUN_COUNT + 1))
 
-          # Note this counts SUCCESSFUL runs for THIS commit: the API query
-          # filters on head_sha, so the cap resets on every push. Filtering on
-          # `conclusion == "success"` matters because the concurrency group
-          # cancels superseded runs, a cancelled run reports
-          # `status=completed`, and non-push events (draft -> ready_for_review,
-          # close/reopen) fire on the same sha - so cancellations would
-          # otherwise burn budget slots without ever producing a review. In-flight
-          # runs are still uncounted; the concurrency group prevents overlap.
-          echo "This is run #$RUN_COUNT for commit ${HEAD_SHA:0:8} (event: $EVENT_ACTION)"
+          # Counts SUCCESSFUL runs across the whole PR. `conclusion == "success"`
+          # matters because the concurrency group cancels superseded runs and a
+          # cancelled run still reports `status=completed`, so cancellations would
+          # otherwise burn budget without producing a review. In-flight runs are
+          # uncounted; the concurrency group prevents overlap.
+          echo "This is review #$RUN_COUNT for PR #${PR_NUMBER} (${HEAD_REF}, event: $EVENT_ACTION)"
 
           if [ "$RUN_COUNT" -le 3 ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
-            echo "[OK] Will run Claude review (run $RUN_COUNT of 3 for this commit)"
+            echo "[OK] Will run Claude review (review $RUN_COUNT of 3 for this PR)"
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
-            echo "[SKIP] Skipping Claude review (already ran 3 times for this commit)"
+            echo "[SKIP] Skipping Claude review (already ran 3 times for this PR)"
           fi
 
       # Toolchain and cache come after the run-count gate: both are pointless
@@ -190,6 +195,33 @@ jobs:
             clippy already gate those. Report only what a maintainer would act on,
             and say so plainly if the diff looks correct.
 
+            **Be exhaustive in one pass.** You get at most 3 reviews per PR, so
+            this may be the only one. For every problem you find, before
+            reporting it, search the diff and the files it touches for every
+            other instance of the same class and report them together as one
+            finding. Do not report one instance and stop.
+
+            Concretely, if you find:
+
+            - a list or allowlist missing an entry, check whether the parallel
+              lists elsewhere are missing it too, and whether that list is
+              missing anything else
+            - a message, comment, or doc line that contradicts the code it
+              describes, grep for the other places making the same claim
+            - a check that handles one direction, ask what the opposite
+              direction does
+            - a fix applied in one file, check whether its sibling files need it
+
+            A finding that says "and the same applies at X, Y, Z" is worth far
+            more than three rounds discovering X, then Y, then Z. If you fix one
+            corner of a class and leave the others, the next push spends another
+            of the three reviews on the same bug.
+
+            State your confidence and how you verified each finding. If you
+            could not verify something - a tool was unavailable, a fixture was
+            impractical - say so explicitly rather than presenting inference as
+            measurement, and say what would close the gap.
+
             Use inline comments for specific lines; one top-level comment for
             overall assessment.
 
@@ -199,4 +231,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "[INFO] Claude Code review was skipped as it has already run 3 times for this commit."
+          gh pr comment "$PR_NUMBER" --body "[INFO] Claude Code review was skipped as it has already run 3 times for this PR."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -82,7 +82,12 @@ jobs:
           # to a space and silently match nothing, switching the cap off.
           HEAD_REF_ENC=$(printf '%s' "$HEAD_REF" | jq -sRr '@uri')
 
-          RUN_COUNT=$(gh api \
+          # `gh` runs on its own so its exit status is observable: piping into
+          # `awk` made `$?` the awk stage's, which always succeeds, so the
+          # previous numeric guard could never fire. A fail-open here resets the
+          # PR's whole budget rather than granting one extra review, so it has to
+          # be detectable.
+          if ! RUN_PAGES=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             --paginate \
@@ -91,18 +96,15 @@ jobs:
                    | select(.event == \"pull_request\"
                             and .conclusion == \"success\"
                             and .head_repository.full_name == \"${HEAD_REPO}\")]
-                  | length" \
-            | awk '{total += $1} END {print total + 0}')
-
-          # `awk ... END {print total + 0}` always prints a number and exits 0,
-          # and `||` would bind to the pipeline rather than to `gh`, so the old
-          # `|| echo ""` plus numeric-guard pair was unreachable. Detect the
-          # failure by asking gh separately whether it succeeded: a fail-open now
-          # resets the PR's whole budget rather than granting one extra review on
-          # one commit, so it should be visible rather than silent.
-          if [ -z "$RUN_COUNT" ]; then
+                  | length"); then
             echo "[WARN] Could not read run history from the GitHub API; treating this as review 1."
             RUN_COUNT=0
+          else
+            # One count per page, summed. A mid-pagination failure under-counts
+            # and so fails open, which the warning above cannot catch - the
+            # 3-review cap is a cost guard, not a correctness one, so failing
+            # open is the right direction.
+            RUN_COUNT=$(printf '%s\n' "$RUN_PAGES" | awk '{total += $1} END {print total + 0}')
           fi
 
           RUN_COUNT=$((RUN_COUNT + 1))
@@ -112,6 +114,13 @@ jobs:
           # cancelled run still reports `status=completed`, so cancellations would
           # otherwise burn budget without producing a review. In-flight runs are
           # uncounted; the concurrency group prevents overlap.
+          #
+          # Known imprecision: a run that skipped also concludes `success`, so it
+          # feeds this count. Once the cap is reached the number keeps climbing
+          # and the log line overstates how many reviews actually happened. It
+          # does not affect the gate - past the cap the decision is the same
+          # either way - and separating them would mean reading each run's job
+          # steps, which is a request per run.
           echo "This is review #$RUN_COUNT for PR #${PR_NUMBER} (${HEAD_REF} @ ${HEAD_SHA:0:8}, event: $EVENT_ACTION)"
 
           if [ "$RUN_COUNT" -le 3 ]; then
@@ -254,5 +263,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          gh pr comment "$PR_NUMBER" --body "[INFO] Claude Code review was skipped as it has already run 3 times for this PR."
+          # Post at most once per PR. Per-commit, this branch was effectively
+          # unreachable because any push reset the counter; per-PR the counter is
+          # monotonic, so without this check every later push would add another
+          # identical comment for the life of the PR. #1290 would have collected
+          # roughly ten.
+          MARKER="<!-- claude-review-cap-notice -->"
+
+          if gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+               --jq '.[].body' 2>/dev/null | grep -qF "$MARKER"; then
+            echo "[SKIP] Cap notice already posted on PR #${PR_NUMBER}; not repeating it."
+            exit 0
+          fi
+
+          gh pr comment "$PR_NUMBER" --body "${MARKER}
+          [INFO] Claude Code review has already run 3 times for this pull request, so further pushes will not be reviewed automatically. Comment \`@claude\` to request another look."

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -7,7 +7,7 @@ on:
       - 'website/**'
       - 'knowledge-base/rules.json'
       - 'scripts/generate-docs-rules.py'
-      - '.github/workflows/docs-site.yml'
+      - '.github/workflows/**'
       - 'crates/agnix-cli/tests/docs_website_parity.rs'
       - 'crates/agnix-wasm/**'
       - 'crates/agnix-core/**'
@@ -18,7 +18,7 @@ on:
       - 'website/**'
       - 'knowledge-base/rules.json'
       - 'scripts/generate-docs-rules.py'
-      - '.github/workflows/docs-site.yml'
+      - '.github/workflows/**'
       - 'crates/agnix-cli/tests/docs_website_parity.rs'
       - 'crates/agnix-wasm/**'
       - 'crates/agnix-core/**'
@@ -49,9 +49,11 @@ jobs:
       - name: Lint workflow files
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
         # No `args`: with none, actionlint discovers and checks every workflow
-        # under .github/workflows. It was pinned to `args: docs-site.yml`, so the
-        # step named "Lint workflow files" checked exactly one, and workflow
-        # changes had no CI gate. Note a directory argument does NOT work
+        # under .github/workflows. Two things were needed for this step to gate
+        # workflow changes at all: dropping the `args: docs-site.yml` pin, and
+        # widening this workflow's own `paths:` filters to `.github/workflows/**`
+        # so a PR touching only another workflow actually triggers it. Note a
+        # directory argument does NOT work
         # ("read .github/workflows/: is a directory") - verified locally with
         # v1.7.12, which is also why this is a no-arg invocation rather than a
         # widened path. actionlint runs shellcheck over `run:` blocks, so this

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -48,8 +48,14 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Lint workflow files
         uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
-        with:
-          args: .github/workflows/docs-site.yml
+        # No `args`: with none, actionlint discovers and checks every workflow
+        # under .github/workflows. It was pinned to `args: docs-site.yml`, so the
+        # step named "Lint workflow files" checked exactly one, and workflow
+        # changes had no CI gate. Note a directory argument does NOT work
+        # ("read .github/workflows/: is a directory") - verified locally with
+        # v1.7.12, which is also why this is a no-arg invocation rather than a
+        # widened path. actionlint runs shellcheck over `run:` blocks, so this
+        # covers the shell in those steps too.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'


### PR DESCRIPTION
Two problems with what #1290 shipped. Both were visible in that PR itself, which took **13 review rounds and 15 successful review runs** — under a cap that says 3.

## 1. The cap was per-commit, not per-PR

The API query filtered on `head_sha`, so the counter reset on every push. A PR could take unlimited reviews at three per commit, which is the opposite of what a cap is for.

Worse, when the reviewer flagged this in #1290 I **corrected the wording to match the bug** — changed the log line and skip comment to say "for this commit" and moved on. The count was the thing to fix, not the label.

Now scoped with `branch=<head ref>`, which spans the PR's whole life. Verified:

```
$ # against #1290's branch
paginated per-PR count = 15   (13 rounds + 2)
$ # unknown branch
count=[0]                     (not empty, so the numeric guard holds)
```

`--paginate` plus a summing `awk` because `--paginate` emits one JSON result per page — a PR past 100 runs would otherwise count only the last page. Given #1290 hit 15, that ceiling is not as far off as it sounds.

## 2. The prompt never asked for completeness

That is why 13 rounds happened. Five of them were **one class of bug** — advice contradicting its own check — surfacing a corner at a time:

| round | corner found |
|---|---|
| 9 | crate direction: `cp` outward can't fix a crate-only file |
| 11 | root direction: same hole, other side |
| 11 | mixed case: exclusive branches, non-exclusive failures |
| 12 | per-file lines: `expected copy of` told you to propagate the deviation |
| 13 | all-misnamed: reported "none found" for files it had just counted |

Each round found one instance, I fixed that instance, the next round found the next. Under a *real* per-PR cap, that pattern burns the entire budget without converging — which is exactly what fixing item 1 would have caused.

The prompt now requires sweeping the class before reporting, with the specific generalizations that would have collapsed those five rounds into one:

- a list missing an entry → check parallel lists for the same omission, and that list for other omissions
- a message contradicting its code → grep for other places making the same claim
- a check handling one direction → ask what the opposite direction does
- a fix in one file → check sibling files

It also now asks for confidence and verification method per finding, and to say plainly when something could not be verified rather than presenting inference as measurement. The reviewer did this unprompted in #1290 twice — flagging that env-inheritance was source-verified-plus-inference, and that a fixture was impractical — and both times it was more useful than a confident claim. Worth making explicit rather than hoping for it.

## Verification

- YAML parses; branch-scoped count verified against a real branch and an unknown one.
- The `conclusion == "success"` filter is retained — cancelled runs still report `status=completed`, so without it the concurrency group's cancellations would consume budget.
- No behavior change to the review itself beyond the prompt; `--allowedTools`, `--model`, `track_progress`, permissions, and the concurrency group are untouched.

`[skip changelog]`: CI-only.
