### PR TITLE
feat: support Cursor 3.14 and harden spec monitoring

### DIFF
--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -273,6 +273,14 @@
           "CUR-016"
         ]
       },
+      "cursor-environment-schema": {
+        "url": "https://cursor.com/schemas/environment.schema.json",
+        "content_url": "https://cursor.com/schemas/environment.schema.json",
+        "hash": "08f44a331857d2f0b866a4cc3a3ac334e4724a8bf63971228764dbbd5faa0472",
+        "rules": [
+          "CUR-016"
+        ]
+      },
       "cursor-mcp": {
         "url": "https://cursor.com/docs/mcp",
         "content_url": "https://cursor.com/docs/mcp.md",

--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -1,12 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "Baseline content hashes for spec-drift sentinel. Updated automatically by workflow.",
-  "last_updated": "2026-07-31T10:14:31Z",
+  "description": "Baseline hashes for canonical specification content. Human-facing URLs are kept separately from machine-readable content URLs.",
+  "last_updated": "2026-08-01T00:00:00Z",
   "sources": {
     "s-tier": {
       "agent-skills-spec": {
         "url": "https://agentskills.io/specification",
-        "hash": "5c5ca872a1c4ac8596b903b90c931847eaad8da5f7bd5916a1ee1f44a7a1eec5",
+        "content_url": "https://raw.githubusercontent.com/agentskills/agentskills/main/docs/specification.mdx",
+        "hash": "4e758a27be17f5bd9af8d6506890895a412f774a4c09f08ee1cc7565391d16ef",
         "rules": [
           "AS-001",
           "AS-002",
@@ -22,23 +23,101 @@
         ]
       },
       "mcp-spec": {
-        "url": "https://modelcontextprotocol.io/specification/2025-11-25",
-        "hash": "596023030ef80f6769857c05b15946c157d3ef7024c26a5da2d28d5f7e8eaa7e",
-        "github_repo": "modelcontextprotocol/specification",
+        "url": "https://modelcontextprotocol.io/specification/2026-07-28",
+        "content_url": "https://modelcontextprotocol.io/specification/2026-07-28/index.md",
+        "hash": "44e96c2715af9074905a5c47ff7c6c0bb77a50000eb577ed772242a077efd086",
+        "github_repo": "modelcontextprotocol/modelcontextprotocol",
         "rules": [
           "MCP-001",
+          "MCP-005",
+          "MCP-007"
+        ]
+      },
+      "mcp-spec-schema": {
+        "url": "https://modelcontextprotocol.io/specification/2026-07-28/schema",
+        "content_url": "https://raw.githubusercontent.com/modelcontextprotocol/modelcontextprotocol/2026-07-28/schema/2026-07-28/schema.ts",
+        "hash": "680f5b5ee98ed107a3b6638d7662bff22656056c5014452f87e4a4fc8f0db8e7",
+        "rules": [
+          "MCP-001",
+          "MCP-002",
+          "MCP-003",
+          "MCP-007",
+          "MCP-008",
+          "MCP-013",
+          "MCP-014",
+          "MCP-015",
+          "MCP-016",
+          "MCP-020"
+        ]
+      },
+      "mcp-spec-tools": {
+        "url": "https://modelcontextprotocol.io/specification/2026-07-28/server/tools",
+        "content_url": "https://modelcontextprotocol.io/specification/2026-07-28/server/tools.md",
+        "hash": "465e76457fe4ce0825efde208fc2ea4f00877fd72e0610a663a11a21812a484b",
+        "rules": [
           "MCP-002",
           "MCP-003",
           "MCP-004",
           "MCP-005",
           "MCP-006",
-          "MCP-007",
-          "MCP-008"
+          "MCP-013",
+          "MCP-014"
+        ]
+      },
+      "mcp-spec-resources": {
+        "url": "https://modelcontextprotocol.io/specification/2026-07-28/server/resources",
+        "content_url": "https://modelcontextprotocol.io/specification/2026-07-28/server/resources.md",
+        "hash": "026934f8e3bc46c705205555ab5f1d5cb9f7ffce1e51840e7cbb53b2500b389e",
+        "rules": [
+          "MCP-015"
+        ]
+      },
+      "mcp-spec-prompts": {
+        "url": "https://modelcontextprotocol.io/specification/2026-07-28/server/prompts",
+        "content_url": "https://modelcontextprotocol.io/specification/2026-07-28/server/prompts.md",
+        "hash": "0719ebea71899029d37f56691308369d6cda170647376ead96b097e994c59da0",
+        "rules": [
+          "MCP-016"
+        ]
+      },
+      "mcp-spec-transports": {
+        "url": "https://modelcontextprotocol.io/specification/2026-07-28/basic/transports",
+        "content_url": "https://modelcontextprotocol.io/specification/2026-07-28/basic/transports.md",
+        "hash": "89251827c733dabd578cb9a2bd225dcb76849a3496ac2d3aab1d969334ff789c",
+        "rules": [
+          "MCP-009",
+          "MCP-010",
+          "MCP-011",
+          "MCP-012",
+          "MCP-017",
+          "MCP-022",
+          "MCP-023",
+          "MCP-024"
+        ]
+      },
+      "mcp-spec-security": {
+        "url": "https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices",
+        "content_url": "https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices.md",
+        "hash": "bb9f423d0bb7189d06559c60a9e209b696da2eab5f15d225f6b2b09ed346688e",
+        "rules": [
+          "MCP-018",
+          "MCP-019",
+          "MCP-021"
+        ]
+      },
+      "mcp-spec-versioning": {
+        "url": "https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning",
+        "content_url": "https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning.md",
+        "hash": "83178defeda24c09389a964334c3806a73cec78a65c3c3a3b297085f3d73e6bd",
+        "rules": [
+          "MCP-008",
+          "MCP-020"
         ]
       },
       "claude-code-memory": {
         "url": "https://code.claude.com/docs/en/memory",
-        "hash": "24530d887609888d1b5d8abec4e659dd9fc74fff1fb3d2cf0af383a5b7abeea4",
+        "content_url": "https://code.claude.com/docs/en/memory.md",
+        "hash": "eea3a7b7d4da9409c6a627e26142373f52171526fcfe901070ac77d20cf15513",
         "rules": [
           "CC-MEM-001",
           "CC-MEM-002",
@@ -48,7 +127,8 @@
       },
       "claude-code-hooks": {
         "url": "https://code.claude.com/docs/en/hooks",
-        "hash": "f8673e2e6c30b9a3a08d30590020207af3221f714d129a4efd2eae1096e26998",
+        "content_url": "https://code.claude.com/docs/en/hooks.md",
+        "hash": "b318b60616297d4a5a8c83d628a2061bf2c65dc0d05a17b5579482b971165ebb",
         "rules": [
           "CC-HK-001",
           "CC-HK-002",
@@ -65,7 +145,8 @@
       },
       "claude-code-skills": {
         "url": "https://code.claude.com/docs/en/skills",
-        "hash": "b4386cd9f7aa8da4e505afa37e0550b770fb259b6a4626339560dc4c98a1b7d6",
+        "content_url": "https://code.claude.com/docs/en/skills.md",
+        "hash": "1f08c689cea03dc2d12ff6646c33b740a3219ba0c2bec960ac05fcd7a4a4c308",
         "rules": [
           "CC-SK-001",
           "CC-SK-002",
@@ -75,7 +156,8 @@
       },
       "claude-code-plugins": {
         "url": "https://code.claude.com/docs/en/plugins-reference",
-        "hash": "3cba97ea5d7d1055d223458387b9214d2c77bbbf46437c136be3d9afe0bd801d",
+        "content_url": "https://code.claude.com/docs/en/plugins-reference.md",
+        "hash": "a07104858eefd300ed179c1e8727d5d92d1611140f0e524e82f68ae010e13cf7",
         "rules": [
           "CC-PL-002",
           "CC-PL-003",
@@ -86,7 +168,8 @@
       },
       "claude-code-subagents": {
         "url": "https://code.claude.com/docs/en/sub-agents",
-        "hash": "9326cd9931f2c31a3d04cd0d520e6f414e698f98671040efc45fc7a8035b7caf",
+        "content_url": "https://code.claude.com/docs/en/sub-agents.md",
+        "hash": "5b209909ee8304b3af61709d9a5fe7bacaf87feeec9b1dc8f8c48b3f4136d4cb",
         "rules": [
           "CC-AG-001",
           "CC-AG-002",
@@ -110,7 +193,8 @@
       },
       "codex-cli-agents-md": {
         "url": "https://learn.chatgpt.com/docs/agent-configuration/agents-md",
-        "hash": "daa9ae6966e3c4125f5a84111fc85fa44b8ce763853b6781c0992aab38c16534",
+        "content_url": "https://learn.chatgpt.com/docs/agent-configuration/agents-md.md",
+        "hash": "9d1f87a2d1cb55b4782b95abe710692b35b9659789c2db31a22c7074a3383e8e",
         "rules": [
           "AGM-001",
           "AGM-002",
@@ -128,7 +212,8 @@
       },
       "opencode-rules": {
         "url": "https://opencode.ai/docs/rules/",
-        "hash": "6301a2a1a80af127fb120d05943c412a3a3d3ddb2431b0746407472ae41cefc9",
+        "content_url": "https://raw.githubusercontent.com/anomalyco/opencode/dev/packages/web/src/content/docs/rules.mdx",
+        "hash": "9ec707ba349c3eb2c37f2085d40875247b59e135386217b7150ba98f7e293aa8",
         "rules": [
           "XP-001",
           "XP-002",
@@ -142,7 +227,8 @@
     "a-tier": {
       "cursor-rules": {
         "url": "https://cursor.com/docs/rules",
-        "hash": "24529507938b37d3e3815e86b8c1c87cbaf78230c899854f0d74b2d5356c676a",
+        "content_url": "https://cursor.com/docs/rules.md",
+        "hash": "c861f9650a843824b496f0a3190ecd9671c121acae623e150b041d0eb9e84d70",
         "rules": [
           "CUR-001",
           "CUR-002",
@@ -152,22 +238,28 @@
           "CUR-006",
           "CUR-007",
           "CUR-008",
-          "CUR-009"
+          "CUR-009",
+          "CUR-020"
         ]
       },
       "cursor-hooks": {
         "url": "https://cursor.com/docs/hooks",
-        "hash": "4f55df64b01fe7d2c55a9d544eafdda070e35d7f84045c021f4a5ea9fcdd05d8",
+        "content_url": "https://cursor.com/docs/hooks.md",
+        "hash": "952d09cb40387dcb70944ce73fffa446317b6cb4f107c9bc2a52d236bc887e3b",
         "rules": [
           "CUR-010",
           "CUR-011",
           "CUR-012",
-          "CUR-013"
+          "CUR-013",
+          "CUR-017",
+          "CUR-018",
+          "CUR-019"
         ]
       },
       "cursor-subagents": {
         "url": "https://cursor.com/docs/subagents",
-        "hash": "f849221f0342190122e8411587e47f129c915902077da6995753f26c8a03cc9a",
+        "content_url": "https://cursor.com/docs/subagents.md",
+        "hash": "c9c01a48171c3a0bcaa37f9412654395c27fecbd5f50535bfa59363f49c8bd46",
         "rules": [
           "CUR-014",
           "CUR-015"
@@ -175,14 +267,35 @@
       },
       "cursor-environment": {
         "url": "https://cursor.com/docs/cloud-agent/setup",
-        "hash": "326a48176a4541dc5e1d94d7f1ef94c50a007dc4798b85e97e8ada5ec75e8a9e",
+        "content_url": "https://cursor.com/docs/cloud-agent/setup.md",
+        "hash": "058418e383b5bf20786c8a858f37856aa73719759774874b73bf7fb86f18fcd0",
         "rules": [
           "CUR-016"
         ]
       },
+      "cursor-mcp": {
+        "url": "https://cursor.com/docs/mcp",
+        "content_url": "https://cursor.com/docs/mcp.md",
+        "hash": "0d85294f9c849ef4f69194ca97242599e4d8f1c6bc44b77cfaedcc2bfc56da98",
+        "rules": [
+          "MCP-009",
+          "MCP-010",
+          "MCP-011",
+          "MCP-012",
+          "MCP-017",
+          "MCP-018",
+          "MCP-019",
+          "MCP-020",
+          "MCP-021",
+          "MCP-022",
+          "MCP-023",
+          "MCP-024"
+        ]
+      },
       "github-copilot": {
         "url": "https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions",
-        "hash": "668c75acb7948484e1334aeb040332961836fbe187561fa830219afcde8ae289",
+        "content_url": "https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions.md",
+        "hash": "4e5454048929b4aee6357c707cd28cd3ff86a2b3717bea094be98458b1c7bc98",
         "rules": [
           "COP-001",
           "COP-002",
@@ -214,7 +327,8 @@
       },
       "cline-rules": {
         "url": "https://docs.cline.bot/customization/cline-rules",
-        "hash": "3a42acacd88e62655c440c04214bed9e622793007489f1d9ef68a2ea85360063",
+        "content_url": "https://raw.githubusercontent.com/cline/cline/main/docs/customization/cline-rules.mdx",
+        "hash": "b50f382a5626c0627cfb47b7fad2eab724be354fa21b445752f8c8abf5403e88",
         "rules": [
           "CL-SK-001",
           "CL-SK-002",

--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-07-30",
+  "last_updated": "2026-08-01",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -136,7 +136,7 @@
       "html_url": "https://kiro.dev/changelog/cli/",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
       "notes_extractor": "glm",
-      "last_known_version": "2.15.0",
+      "last_known_version": "2.16.0",
       "tracked": true,
       "notes": "Proprietary CLI; no GH releases. Tracked via HTML scrape of kiro.dev/changelog/cli/ - the first NN.NN.NN version on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). The CLI itself exposes `kiro-cli version --changelog`. IDE has a separate changelog at https://kiro.dev/changelog/ide/ (not tracked here; could be added as a separate kiro-ide entry if needed).",
       "changes_of_interest": {
@@ -239,12 +239,12 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.13.25",
+      "last_known_version": "3.14.7",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {
         "config_surfaces": [
-          ".cursor/rules/**/*.{md,mdc}",
+          ".cursor/rules/**/*.mdc",
           ".cursorrules (legacy)",
           ".cursor/hooks.json",
           ".cursor/agents/**/*.md",
@@ -252,7 +252,7 @@
           ".cursor/mcp.json"
         ],
         "relevant": [
-          "Changes to .cursor/rules/**/*.{md,mdc} frontmatter (globs, description, alwaysApply)",
+          "Changes to .cursor/rules/**/*.mdc extension requirements or frontmatter (globs, description, alwaysApply)",
           "New hook shapes in .cursor/hooks.json",
           "Agent frontmatter schema in .cursor/agents/**/*.md",
           "environment.json schema changes",
@@ -339,7 +339,7 @@
         "gemini_ignore"
       ],
       "github_repo": "google-gemini/gemini-cli",
-      "last_known_version": "v0.53.0",
+      "last_known_version": "v0.53.1",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/.github/workflows/mcp-release-watch.yml
+++ b/.github/workflows/mcp-release-watch.yml
@@ -54,26 +54,29 @@ jobs:
             latest_release=""
           fi
 
+          # Ignore prerelease/suffixed tags such as 2026-07-28-RC. Only final
+          # date tags can identify a published specification revision.
+          if [[ -n "$latest_release" && ! "$latest_release" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "Ignoring non-final MCP release/tag: $latest_release"
+            latest_release=""
+          fi
+
           if [[ -z "$latest_release" ]]; then
-            # No releases, check tags instead
-            if ! latest_release=$(gh api "repos/$MCP_REPO/tags" --jq '.[0].name // empty' 2>/dev/null); then
+            # No final release, select the newest final date tag instead of
+            # blindly accepting an RC/final-suffixed tag at index zero.
+            if ! latest_release=$(gh api "repos/$MCP_REPO/tags" --jq '[.[].name | select(test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$"))][0] // empty' 2>/dev/null); then
               echo "ERROR: Failed to query MCP releases and tags"
               exit 1
             fi
           fi
 
           if [[ -z "$latest_release" ]]; then
-            echo "ERROR: MCP repository returned no releases or tags"
-            exit 1
+            echo "No final date-based MCP release found; ignoring prerelease tags"
+            echo "NEW_RELEASE=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           echo "Latest release/tag: $latest_release"
-
-          # MCP uses date-based versioning like "2025-11-25"
-          if [[ ! "$latest_release" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
-            echo "ERROR: Unsupported MCP release format: $latest_release"
-            exit 1
-          fi
 
           if [[ "$latest_release" > "$baseline_version" ]]; then
             echo "NEW_RELEASE=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mcp-release-watch.yml
+++ b/.github/workflows/mcp-release-watch.yml
@@ -1,5 +1,5 @@
 # MCP Release Watcher
-# Watches modelcontextprotocol/specification for new releases and triggers spec-drift check.
+# Watches modelcontextprotocol/modelcontextprotocol for new releases and triggers spec-drift check.
 # Runs daily - faster detection than weekly polling for this critical S-tier source.
 
 name: MCP Release Watch
@@ -34,48 +34,54 @@ jobs:
           set -euo pipefail
 
           BASELINE_FILE=".github/spec-baselines.json"
-          MCP_REPO="modelcontextprotocol/specification"
+          MCP_REPO="modelcontextprotocol/modelcontextprotocol"
 
           # Get current baseline URL (contains version date)
           baseline_url=$(jq -r '.sources["s-tier"]["mcp-spec"].url' "$BASELINE_FILE")
           echo "Baseline URL: $baseline_url"
 
           # Extract version from URL (e.g., 2025-11-25 from .../specification/2025-11-25)
-          baseline_version=$(echo "$baseline_url" | grep -oP '\d{4}-\d{2}-\d{2}$' || echo "unknown")
+          baseline_version=$(echo "$baseline_url" | grep -oP '\d{4}-\d{2}-\d{2}$' || true)
+          if [[ -z "$baseline_version" ]]; then
+            echo "ERROR: Could not parse the pinned MCP version"
+            exit 1
+          fi
           echo "Baseline version: $baseline_version"
 
           # Get latest release from GitHub
-          latest_release=$(gh api "repos/$MCP_REPO/releases/latest" --jq '.tag_name // .name // empty' 2>/dev/null || echo "")
+          latest_release=""
+          if ! latest_release=$(gh api "repos/$MCP_REPO/releases/latest" --jq '.tag_name // .name // empty' 2>/dev/null); then
+            latest_release=""
+          fi
 
           if [[ -z "$latest_release" ]]; then
             # No releases, check tags instead
-            latest_release=$(gh api "repos/$MCP_REPO/tags" --jq '.[0].name // empty' 2>/dev/null || echo "")
+            if ! latest_release=$(gh api "repos/$MCP_REPO/tags" --jq '.[0].name // empty' 2>/dev/null); then
+              echo "ERROR: Failed to query MCP releases and tags"
+              exit 1
+            fi
+          fi
+
+          if [[ -z "$latest_release" ]]; then
+            echo "ERROR: MCP repository returned no releases or tags"
+            exit 1
           fi
 
           echo "Latest release/tag: $latest_release"
 
-          # Check if this looks like a new version
           # MCP uses date-based versioning like "2025-11-25"
-          if [[ -n "$latest_release" && "$latest_release" != "$baseline_version" ]]; then
-            # Could be a new version - check if it's actually newer
-            if [[ "$latest_release" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
-              if [[ "$latest_release" > "$baseline_version" ]]; then
-                echo "NEW_RELEASE=true" >> "$GITHUB_OUTPUT"
-                echo "NEW_VERSION=$latest_release" >> "$GITHUB_OUTPUT"
-                echo "New MCP spec version detected: $latest_release (was: $baseline_version)"
-              else
-                echo "NEW_RELEASE=false" >> "$GITHUB_OUTPUT"
-                echo "Release $latest_release is not newer than baseline $baseline_version"
-              fi
-            else
-              # Non-date format, might still be new
-              echo "NEW_RELEASE=true" >> "$GITHUB_OUTPUT"
-              echo "NEW_VERSION=$latest_release" >> "$GITHUB_OUTPUT"
-              echo "Potential new MCP version detected: $latest_release"
-            fi
+          if [[ ! "$latest_release" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "ERROR: Unsupported MCP release format: $latest_release"
+            exit 1
+          fi
+
+          if [[ "$latest_release" > "$baseline_version" ]]; then
+            echo "NEW_RELEASE=true" >> "$GITHUB_OUTPUT"
+            echo "NEW_VERSION=$latest_release" >> "$GITHUB_OUTPUT"
+            echo "New MCP spec version detected: $latest_release (was: $baseline_version)"
           else
             echo "NEW_RELEASE=false" >> "$GITHUB_OUTPUT"
-            echo "No new release detected"
+            echo "Release $latest_release is not newer than baseline $baseline_version"
           fi
 
       - name: Trigger spec-drift check
@@ -86,4 +92,4 @@ jobs:
         run: |
           set -euo pipefail
           echo "Triggering spec-drift workflow for MCP version: $NEW_VERSION"
-          gh workflow run spec-drift.yml -f tier=s-tier
+          gh workflow run spec-drift.yml -f tier=s-tier -f mcp_version="$NEW_VERSION"

--- a/.github/workflows/mcp-release-watch.yml
+++ b/.github/workflows/mcp-release-watch.yml
@@ -64,7 +64,7 @@ jobs:
           if [[ -z "$latest_release" ]]; then
             # No final release, select the newest final date tag instead of
             # blindly accepting an RC/final-suffixed tag at index zero.
-            if ! latest_release=$(gh api "repos/$MCP_REPO/tags" --jq '[.[].name | select(test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$"))][0] // empty' 2>/dev/null); then
+            if ! latest_release=$(gh api "repos/$MCP_REPO/tags" --jq '[.[].name | select(test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$"))] | max // empty' 2>/dev/null); then
               echo "ERROR: Failed to query MCP releases and tags"
               exit 1
             fi

--- a/.github/workflows/spec-drift.yml
+++ b/.github/workflows/spec-drift.yml
@@ -26,6 +26,11 @@ on:
           - s-tier
           - a-tier
         default: all
+      mcp_version:
+        description: 'Optional MCP release version to compare against the pinned baseline'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -52,6 +57,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPDATE_BASELINES: ${{ inputs.update_baselines || 'false' }}
           TIER_FILTER: ${{ inputs.tier || 'all' }}
+          MCP_VERSION: ${{ inputs.mcp_version || '' }}
           SCHEDULE_CRON: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
@@ -68,6 +74,12 @@ jobs:
           DRIFT_REPORT=""
           NEW_HASHES=""
           DRIFT_SOURCES_JSON="[]"
+          FETCH_ERRORS=false
+
+          if [[ -n "$MCP_VERSION" && ! "$MCP_VERSION" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "ERROR: mcp_version must use YYYY-MM-DD format"
+            exit 1
+          fi
 
           # Determine which tiers to check based on trigger
           check_s_tier=false
@@ -100,8 +112,9 @@ jobs:
 
           # Function to normalize content for consistent hashing
           normalize_content() {
-            # Remove extra whitespace, normalize line endings
-            tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//'
+            # Normalize CRLF line endings only. Whitespace can be semantically
+            # significant in Markdown, YAML, and source documents.
+            sed 's/\r$//'
           }
 
           # Function to compute hash of URL content
@@ -127,7 +140,7 @@ jobs:
             fi
 
             # Normalize and hash
-            hash=$(echo "$content" | normalize_content | sha256sum | cut -d' ' -f1)
+            hash=$(printf '%s' "$content" | normalize_content | sha256sum | cut -d' ' -f1)
             echo "$hash"
           }
 
@@ -162,33 +175,55 @@ jobs:
 
             for source in $sources; do
               local url
+              local content_url
               local baseline_hash
               local rules
               local github_repo
 
               url=$(jq -r ".sources[\"$tier\"][\"$source\"].url" "$BASELINES_FILE")
+              content_url=$(jq -r ".sources[\"$tier\"][\"$source\"].content_url // .sources[\"$tier\"][\"$source\"].url" "$BASELINES_FILE")
               baseline_hash=$(jq -r ".sources[\"$tier\"][\"$source\"].hash" "$BASELINES_FILE")
               rules=$(jq -r ".sources[\"$tier\"][\"$source\"].rules // [] | join(\", \")" "$BASELINES_FILE")
               github_repo=$(jq -r ".sources[\"$tier\"][\"$source\"].github_repo // empty" "$BASELINES_FILE")
 
-              echo "Checking: $source ($url)"
+              # Release-watch dispatches compare every versioned MCP source
+              # against the newly detected release rather than re-fetching the
+              # permanently pinned baseline URL.
+              if [[ "$source" == mcp-spec* && -n "$MCP_VERSION" ]]; then
+                local baseline_version
+                baseline_version=$(jq -r '.sources["s-tier"]["mcp-spec"].url' "$BASELINES_FILE" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || true)
+                if [[ -z "$baseline_version" ]]; then
+                  echo "ERROR: Could not determine pinned MCP version"
+                  exit 1
+                fi
+                url=${url//$baseline_version/$MCP_VERSION}
+                content_url=${content_url//$baseline_version/$MCP_VERSION}
+              fi
 
-              current_hash=$(compute_hash "$url")
+              echo "Checking: $source ($content_url)"
+
+              current_hash=$(compute_hash "$content_url")
 
               if [[ "$current_hash" == "FETCH_FAILED" ]]; then
-                echo "  WARNING: Failed to fetch $source"
+                echo "  WARNING: Failed to fetch $source ($content_url)"
                 DRIFT_REPORT="${DRIFT_REPORT}\n- **$source**: Failed to fetch (may be temporary)"
+                DRIFT_DETECTED=true
+                FETCH_ERRORS=true
+                DRIFT_SOURCES_JSON=$(echo "$DRIFT_SOURCES_JSON" | jq --arg src "$source" --arg tier "$tier" --arg url "$url" --arg content_url "$content_url" --arg rules "$rules" '. += [{"source": $src, "tier": $tier, "url": $url, "content_url": $content_url, "rules": $rules}]')
                 continue
               fi
 
               if [[ "$current_hash" == "INVALID_URL" ]]; then
                 echo "  ERROR: Invalid URL for $source (must be https://)"
                 DRIFT_REPORT="${DRIFT_REPORT}\n- **$source**: Invalid URL (must be https://)"
+                DRIFT_DETECTED=true
+                FETCH_ERRORS=true
+                DRIFT_SOURCES_JSON=$(echo "$DRIFT_SOURCES_JSON" | jq --arg src "$source" --arg tier "$tier" --arg url "$url" --arg content_url "$content_url" --arg rules "$rules" '. += [{"source": $src, "tier": $tier, "url": $url, "content_url": $content_url, "rules": $rules}]')
                 continue
               fi
 
               # Store new hash for potential baseline update
-              NEW_HASHES="${NEW_HASHES}${tier}|${source}|${current_hash}\n"
+              NEW_HASHES="${NEW_HASHES}${tier}|${source}|${current_hash}|${url}|${content_url}\n"
 
               if [[ -z "$baseline_hash" ]]; then
                 echo "  INFO: No baseline hash set for $source (first run)"
@@ -201,6 +236,9 @@ jobs:
 
                 DRIFT_REPORT="${DRIFT_REPORT}\n### $source ($tier)"
                 DRIFT_REPORT="${DRIFT_REPORT}\n- **URL**: $url"
+                if [[ "$content_url" != "$url" ]]; then
+                  DRIFT_REPORT="${DRIFT_REPORT}\n- **Content URL**: $content_url"
+                fi
                 DRIFT_REPORT="${DRIFT_REPORT}\n- **Previous hash**: \`${baseline_hash:0:12}...\`"
                 DRIFT_REPORT="${DRIFT_REPORT}\n- **Current hash**: \`${current_hash:0:12}...\`"
 
@@ -225,7 +263,7 @@ jobs:
                 DRIFT_DETECTED=true
 
                 # Add to drift sources JSON for downstream jobs
-                DRIFT_SOURCES_JSON=$(echo "$DRIFT_SOURCES_JSON" | jq --arg src "$source" --arg tier "$tier" --arg url "$url" --arg rules "$rules" '. += [{"source": $src, "tier": $tier, "url": $url, "rules": $rules}]')
+                DRIFT_SOURCES_JSON=$(echo "$DRIFT_SOURCES_JSON" | jq --arg src "$source" --arg tier "$tier" --arg url "$url" --arg content_url "$content_url" --arg rules "$rules" '. += [{"source": $src, "tier": $tier, "url": $url, "content_url": $content_url, "rules": $rules}]')
               else
                 echo "  OK: No change"
               fi
@@ -243,6 +281,11 @@ jobs:
             echo ""
             echo "=== Checking A-tier sources ==="
             check_tier "a-tier"
+          fi
+
+          if [[ "$UPDATE_BASELINES" == "true" && "$FETCH_ERRORS" == "true" ]]; then
+            echo "ERROR: Refusing to write a partial baseline after source fetch errors"
+            exit 1
           fi
 
           # Output results
@@ -282,9 +325,9 @@ jobs:
             temp_file=$(mktemp)
             cp "$BASELINES_FILE" "$temp_file"
 
-            echo -e "$NEW_HASHES" | while IFS='|' read -r tier source hash; do
+            echo -e "$NEW_HASHES" | while IFS='|' read -r tier source hash url content_url; do
               if [[ -n "$tier" && -n "$source" && -n "$hash" ]]; then
-                jq ".sources[\"$tier\"][\"$source\"].hash = \"$hash\"" "$temp_file" > "${temp_file}.new"
+                jq --arg hash "$hash" --arg url "$url" --arg content_url "$content_url" ".sources[\"$tier\"][\"$source\"].hash = \$hash | .sources[\"$tier\"][\"$source\"].url = \$url | .sources[\"$tier\"][\"$source\"].content_url = \$content_url" "$temp_file" > "${temp_file}.new"
                 mv "${temp_file}.new" "$temp_file"
               fi
             done
@@ -324,6 +367,15 @@ jobs:
           # Build affected rules list
           ALL_RULES=$(echo "$DRIFT_SOURCES" | jq -r '.[].rules' | tr ',' '\n' | tr -d ' ' | sort -u | tr '\n' ', ' | sed 's/,$//')
 
+          # A release-triggered MCP run must carry the detected version through
+          # when maintainers generate the replacement baseline.
+          MCP_INPUT_LINE=""
+          detected_mcp_version=$(echo "$DRIFT_SOURCES" | jq -r '[.[] | select(.source == "mcp-spec") | (try (.url | capture("specification/(?<version>[0-9]{4}-[0-9]{2}-[0-9]{2})").version) catch empty)] | first // empty')
+          pinned_mcp_version=$(jq -r '.sources["s-tier"]["mcp-spec"].url' .github/spec-baselines.json | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || true)
+          if [[ -n "$detected_mcp_version" && "$detected_mcp_version" != "$pinned_mcp_version" ]]; then
+            MCP_INPUT_LINE="- \`mcp_version: $detected_mcp_version\`"
+          fi
+
           ISSUE_BODY="## Spec Drift Sentinel Alert
 
           The following upstream specification sources have changed since our last baseline check.
@@ -352,6 +404,7 @@ jobs:
           Run the spec-drift workflow manually with:
           - \`update_baselines: true\`
           - \`tier: all\` (or specific tier)
+          $MCP_INPUT_LINE
 
           Then copy the output JSON to \`.github/spec-baselines.json\`.
 
@@ -399,7 +452,7 @@ jobs:
         run: |
           set -euo pipefail
           # Build analysis request
-          SOURCES_LIST=$(echo "$DRIFT_SOURCES" | jq -r '.[] | "- \(.source) (\(.tier)): \(.url)"' | head -10)
+          SOURCES_LIST=$(echo "$DRIFT_SOURCES" | jq -r '.[] | "- \(.source) (\(.tier)): \(.content_url // .url)"' | head -10)
           RULES_LIST=$(echo "$DRIFT_SOURCES" | jq -r '.[].rules' | tr ',' '\n' | tr -d ' ' | sort -u | head -20 | tr '\n' ', ' | sed 's/,$//')
 
           COMMENT_BODY="@claude Please analyze the spec drift detected above and help with the following:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 443 rules, 75+ sources, rules.json
+knowledge-base/     # 444 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-443 rules defined in `knowledge-base/rules.json` (source of truth)
+444 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 443 validation rules across 40 validators
+- 444 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CUR-020: Ignored Plain Markdown Cursor Rule**. Cursor now explicitly documents that project rules under `.cursor/rules/` must use `.mdc`; plain `.md` files are ignored. agnix reports the silent failure and suggests renaming the file. Rule count 443 -> 444.
+
+### Fixed
+- **Cursor 3.14 configuration compatibility**. Accept parameterized subagent model IDs such as `composer-2.5[]` and `claude-opus-5[effort=high]`; validate prompt hooks as non-empty strings; accept comments and enforce the full published `environment.json` schema; and infer HTTP transport for documented URL-only servers in `.cursor/mcp.json` (closes #1306).
+- **Spec Drift Sentinel HTML noise**. Hash canonical Markdown/raw source documents instead of rendered site chrome, monitor MCP overview/schema/component sources at `2026-07-28`, compare newly detected MCP releases directly, and add Cursor MCP documentation to drift coverage (closes #1305).
+
+### Changed
+- **Tool release baselines**. Advanced Cursor to `3.14.7`, Gemini CLI to `v0.53.1`, and Kiro CLI to `2.16.0` after reviewing their validated configuration surfaces. Gemini's patch is error-reporting only; Kiro adds `/tangent` and context display without changing persisted config (closes #1307, #1308).
+
 ## [0.44.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CUR-020: Ignored Plain Markdown Cursor Rule**. Cursor now explicitly documents that project rules under `.cursor/rules/` must use `.mdc`; plain `.md` files are ignored. agnix reports the silent failure and suggests renaming the file. Rule count 443 -> 444.
 
 ### Fixed
-- **Cursor 3.14 configuration compatibility**. Accept parameterized subagent model IDs such as `composer-2.5[]` and `claude-opus-5[effort=high]`; validate prompt hooks as non-empty strings; accept comments and enforce the full published `environment.json` schema; and infer HTTP transport for documented URL-only servers in `.cursor/mcp.json` (closes #1306).
+- **Cursor 3.14 configuration compatibility**. Accept parameterized subagent model IDs such as `composer-2.5[]` and `claude-opus-5[effort=high]`; validate prompt hooks as non-empty strings; accept comments and enforce the full published `environment.json` schema; and infer HTTP transport for documented URL-only servers in `.cursor/mcp.json`, including MCP-017 HTTPS enforcement for remote endpoints (closes #1306).
 - **Spec Drift Sentinel HTML noise**. Hash canonical Markdown/raw source documents instead of rendered site chrome, monitor MCP overview/schema/component sources at `2026-07-28`, compare newly detected MCP releases directly, and add Cursor MCP documentation to drift coverage (closes #1305).
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 443 rules, 75+ sources, rules.json
+knowledge-base/     # 444 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-443 rules defined in `knowledge-base/rules.json` (source of truth)
+444 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 443 validation rules across 40 validators
+- 444 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Rule IDs follow the format `[PREFIX]-[NUMBER]` where the prefix indicates the ru
 | `COP-` | 25 | COP-001 through COP-015, COP-017 through COP-020, COP-022 through COP-027 |
 | `CP-SK-` | 1 | CP-SK-001 |
 | `CR-SK-` | 1 | CR-SK-001 |
-| `CUR-` | 19 | CUR-001 through CUR-019 |
+| `CUR-` | 20 | CUR-001 through CUR-020 |
 | `CX-SK-` | 1 | CX-SK-001 |
 | `GM-` | 10 | GM-001 through GM-010 |
 | `GM-AG-` | 1 | GM-AG-001 |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>443 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>444 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 443 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 444 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -21,7 +21,7 @@
 | XML | all .md files | 3 |
 | References | @imports | 4 |
 | GitHub Copilot | .github/copilot-instructions.md, .github/instructions/*.instructions.md, .github/agents/*.agent.md, .github/prompts/*.prompt.md, .github/hooks/hooks.json, .github/workflows/copilot-setup-steps.yml | 25 |
-| Cursor Project Rules | .cursor/rules/*.mdc, .cursorrules, .cursor/hooks.json, .cursor/agents/**/*.md, .cursor/environment.json | 19 |
+| Cursor Project Rules | .cursor/rules/*.mdc, .cursorrules, .cursor/hooks.json, .cursor/agents/**/*.md, .cursor/environment.json | 20 |
 | Cline | .clinerules, .clinerules/*.md, .clinerules/*.txt | 7 |
 | OpenCode | opencode.json, opencode.jsonc | 47 |
 | Gemini Agents | .gemini/agents/*.json | 1 |

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -486,37 +486,48 @@ rules:
     message: hooks.%{event}[%{index}] has invalid 'type' value
     suggestion: If present, 'type' must be 'command' or 'prompt'
   cur_014:
-    message: Cursor subagent file must have valid YAML frontmatter with required fields
+    message: Cursor subagent file must have valid YAML frontmatter with supported field types
     invalid_frontmatter: Cursor subagent frontmatter is invalid YAML or not a mapping
-    missing_name: Cursor subagent frontmatter is missing required 'name' field
     invalid_name: Cursor subagent name must use lowercase letters, digits, and hyphens only
     name_not_string: Cursor subagent 'name' field must be a string
-    missing_description: Cursor subagent frontmatter is missing required 'description' field
     description_not_string: Cursor subagent 'description' field must be a string
-    invalid_model: Cursor subagent model must be 'fast', 'inherit', or a valid model ID
+    invalid_model: Cursor subagent model must be 'inherit' or a specific model ID with optional [id=value] parameters
     model_not_string: Cursor subagent 'model' field must be a string
     readonly_not_bool: Cursor subagent 'readonly' field must be a boolean
     is_background_not_bool: Cursor subagent 'is_background' field must be a boolean
-    suggestion: 'Use frontmatter fields: name, description, model, readonly, and is_background with valid types'
+    suggestion: 'Use optional frontmatter fields name, description, model, readonly, and is_background with valid types'
   cur_015:
     message: Cursor subagent definition is empty after frontmatter
     suggestion: Add body instructions below the frontmatter section
   cur_016:
-    message: .cursor/environment.json must be an object with install (required) and optional start, update, build, terminals
+    message: .cursor/environment.json must be an object matching Cursor's published environment schema
     parse_error: 'Failed to parse .cursor/environment.json: %{error}'
     install: Field 'install' must be a string
-    missing_install: Field 'install' is required and must be a string
     update_renamed: "Field 'update' is not part of the environment schema - it was renamed to 'install'"
     update_renamed_suggestion: Rename 'update' to 'install'; the published schema sets unevaluatedProperties=false, so unknown keys are invalid
     start: Field 'start' must be a string when present
-    update: Field 'update' must be a string when present
     invalid_build: Field 'build' must be an object when present
-    build_dockerfile: Field 'build.dockerfile' must be a string when present
+    build_dockerfile: Field 'build.dockerfile' is required and must be a string
     build_context: Field 'build.context' must be a string when present
     invalid_terminals: Field 'terminals' must be an array, got %{got}
     terminal: "terminals[%{index}] must have a string 'command' field"
     terminal_not_object: terminals[%{index}] must be a JSON object
-    suggestion: 'Use schema: {"install":"...","start":"...","build":{"dockerfile":"...","context":"..."},"terminals":[{"name":"...","command":"..."}]}'
+    terminal_field_type: terminals[%{index}].%{field} must be a string when present
+    unknown_root_field: "Unknown field '%{field}' in .cursor/environment.json"
+    unknown_root_field_suggestion: Remove fields not defined by Cursor's environment schema
+    string_field: "Field '%{field}' must be a string when present"
+    agent_can_update_snapshot: Field 'agentCanUpdateSnapshot' must be a boolean when present
+    unknown_build_field: "Unknown field 'build.%{field}'"
+    unknown_build_field_suggestion: Use only 'dockerfile' and optional 'context' in build
+    repository_dependencies: Field 'repositoryDependencies' must be an array of strings
+    port_object: ports[%{index}] must be an object
+    port_number: ports[%{index}].port must be an integer from 1 through 65535
+    port_name: ports[%{index}].name must be a string when present
+    ports_array: Field 'ports' must be an array
+    suggestion: 'Use Cursor''s schema: string setup fields, a valid build object, string repository dependencies, valid ports, and command-bearing terminals'
+  cur_020:
+    message: Cursor ignores plain .md files in .cursor/rules
+    suggestion: Rename the project rule with the .mdc extension
   cln_001:
     message_empty: Cline rules file is empty
     message_no_content: Cline rules file has no content after frontmatter

--- a/crates/agnix-cli/src/watch.rs
+++ b/crates/agnix-cli/src/watch.rs
@@ -61,6 +61,10 @@ where
 fn is_relevant_file(path: &Path) -> bool {
     let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
     let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let is_cursor_rule = matches!(
+        agnix_core::detect_file_type(path),
+        agnix_core::FileType::CursorRule
+    );
     let parent = path
         .parent()
         .and_then(|p| p.file_name())
@@ -91,7 +95,8 @@ fn is_relevant_file(path: &Path) -> bool {
     ) || extension == "mcp"
         || is_codex_config
         || filename.ends_with(".mcp.json")
-        || filename.ends_with(".mdc")
+        || extension.eq_ignore_ascii_case("mdc")
+        || is_cursor_rule
         || filename.ends_with(".instructions.md")
         // Also watch for agent files
         || (extension == "md"
@@ -125,5 +130,19 @@ mod tests {
     fn non_codex_config_files_are_not_relevant_by_name() {
         assert!(!is_relevant_file(Path::new("configs/config.yaml")));
         assert!(!is_relevant_file(Path::new("configs/config.json")));
+    }
+
+    #[test]
+    fn cursor_rule_files_are_relevant() {
+        for path in [
+            ".cursor/rules/test.md",
+            ".cursor/rules/test.MD",
+            ".cursor/rules/test.mdc",
+            ".cursor/rules/test.MDC",
+        ] {
+            assert!(is_relevant_file(Path::new(path)));
+        }
+
+        assert!(!is_relevant_file(Path::new("docs/test.md")));
     }
 }

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -486,37 +486,48 @@ rules:
     message: hooks.%{event}[%{index}] has invalid 'type' value
     suggestion: If present, 'type' must be 'command' or 'prompt'
   cur_014:
-    message: Cursor subagent file must have valid YAML frontmatter with required fields
+    message: Cursor subagent file must have valid YAML frontmatter with supported field types
     invalid_frontmatter: Cursor subagent frontmatter is invalid YAML or not a mapping
-    missing_name: Cursor subagent frontmatter is missing required 'name' field
     invalid_name: Cursor subagent name must use lowercase letters, digits, and hyphens only
     name_not_string: Cursor subagent 'name' field must be a string
-    missing_description: Cursor subagent frontmatter is missing required 'description' field
     description_not_string: Cursor subagent 'description' field must be a string
-    invalid_model: Cursor subagent model must be 'fast', 'inherit', or a valid model ID
+    invalid_model: Cursor subagent model must be 'inherit' or a specific model ID with optional [id=value] parameters
     model_not_string: Cursor subagent 'model' field must be a string
     readonly_not_bool: Cursor subagent 'readonly' field must be a boolean
     is_background_not_bool: Cursor subagent 'is_background' field must be a boolean
-    suggestion: 'Use frontmatter fields: name, description, model, readonly, and is_background with valid types'
+    suggestion: 'Use optional frontmatter fields name, description, model, readonly, and is_background with valid types'
   cur_015:
     message: Cursor subagent definition is empty after frontmatter
     suggestion: Add body instructions below the frontmatter section
   cur_016:
-    message: .cursor/environment.json must be an object with install (required) and optional start, update, build, terminals
+    message: .cursor/environment.json must be an object matching Cursor's published environment schema
     parse_error: 'Failed to parse .cursor/environment.json: %{error}'
     install: Field 'install' must be a string
-    missing_install: Field 'install' is required and must be a string
     update_renamed: "Field 'update' is not part of the environment schema - it was renamed to 'install'"
     update_renamed_suggestion: Rename 'update' to 'install'; the published schema sets unevaluatedProperties=false, so unknown keys are invalid
     start: Field 'start' must be a string when present
-    update: Field 'update' must be a string when present
     invalid_build: Field 'build' must be an object when present
-    build_dockerfile: Field 'build.dockerfile' must be a string when present
+    build_dockerfile: Field 'build.dockerfile' is required and must be a string
     build_context: Field 'build.context' must be a string when present
     invalid_terminals: Field 'terminals' must be an array, got %{got}
     terminal: "terminals[%{index}] must have a string 'command' field"
     terminal_not_object: terminals[%{index}] must be a JSON object
-    suggestion: 'Use schema: {"install":"...","start":"...","build":{"dockerfile":"...","context":"..."},"terminals":[{"name":"...","command":"..."}]}'
+    terminal_field_type: terminals[%{index}].%{field} must be a string when present
+    unknown_root_field: "Unknown field '%{field}' in .cursor/environment.json"
+    unknown_root_field_suggestion: Remove fields not defined by Cursor's environment schema
+    string_field: "Field '%{field}' must be a string when present"
+    agent_can_update_snapshot: Field 'agentCanUpdateSnapshot' must be a boolean when present
+    unknown_build_field: "Unknown field 'build.%{field}'"
+    unknown_build_field_suggestion: Use only 'dockerfile' and optional 'context' in build
+    repository_dependencies: Field 'repositoryDependencies' must be an array of strings
+    port_object: ports[%{index}] must be an object
+    port_number: ports[%{index}].port must be an integer from 1 through 65535
+    port_name: ports[%{index}].name must be a string when present
+    ports_array: Field 'ports' must be an array
+    suggestion: 'Use Cursor''s schema: string setup fields, a valid build object, string repository dependencies, valid ports, and command-bearing terminals'
+  cur_020:
+    message: Cursor ignores plain .md files in .cursor/rules
+    suggestion: Rename the project rule with the .mdc extension
   cln_001:
     message_empty: Cline rules file is empty
     message_no_content: Cline rules file has no content after frontmatter

--- a/crates/agnix-core/src/file_types/detection.rs
+++ b/crates/agnix-core/src/file_types/detection.rs
@@ -424,7 +424,8 @@ pub fn detect_file_type(path: &Path) -> FileType {
             FileType::ClaudeOutputStyle
         }
         // Cursor project rules (.cursor/rules/**/*.md and .mdc)
-        name if (ends_with_ignore_ascii_case(name, ".md") || name.ends_with(".mdc"))
+        name if (ends_with_ignore_ascii_case(name, ".md")
+            || ends_with_ignore_ascii_case(name, ".mdc"))
             && is_under_cursor_rules(path) =>
         {
             FileType::CursorRule
@@ -930,7 +931,7 @@ mod tests {
             detect_file_type(Path::new(".cursor/rules/custom.MD")),
             FileType::CursorRule
         );
-        assert_ne!(
+        assert_eq!(
             detect_file_type(Path::new(".cursor/rules/custom.MDC")),
             FileType::CursorRule
         );

--- a/crates/agnix-core/src/file_types/detection.rs
+++ b/crates/agnix-core/src/file_types/detection.rs
@@ -424,7 +424,7 @@ pub fn detect_file_type(path: &Path) -> FileType {
             FileType::ClaudeOutputStyle
         }
         // Cursor project rules (.cursor/rules/**/*.md and .mdc)
-        name if (name.ends_with(".md") || name.ends_with(".mdc"))
+        name if (ends_with_ignore_ascii_case(name, ".md") || name.ends_with(".mdc"))
             && is_under_cursor_rules(path) =>
         {
             FileType::CursorRule
@@ -924,6 +924,14 @@ mod tests {
         );
         assert_eq!(
             detect_file_type(Path::new(".cursor/rules/frontend/components.md")),
+            FileType::CursorRule
+        );
+        assert_eq!(
+            detect_file_type(Path::new(".cursor/rules/custom.MD")),
+            FileType::CursorRule
+        );
+        assert_ne!(
+            detect_file_type(Path::new(".cursor/rules/custom.MDC")),
             FileType::CursorRule
         );
     }

--- a/crates/agnix-core/src/rules/claude_md.rs
+++ b/crates/agnix-core/src/rules/claude_md.rs
@@ -44,7 +44,12 @@ fn is_cursor_rules_file(path: &Path) -> bool {
         return true;
     }
 
-    (filename.ends_with(".md") || filename.ends_with(".mdc")) && is_path_under_cursor_rules(path)
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("md") || extension.eq_ignore_ascii_case("mdc")
+        })
+        && is_path_under_cursor_rules(path)
 }
 
 impl Validator for ClaudeMdValidator {
@@ -404,28 +409,29 @@ mod tests {
     fn test_cursor_rules_mdc_gets_rules() {
         let content = "Be helpful and accurate when responding.";
         let validator = ClaudeMdValidator;
-        let diagnostics = validator.validate(
-            Path::new(".cursor/rules/typescript.mdc"),
-            content,
-            &LintConfig::default(),
-        );
 
-        assert!(!diagnostics.is_empty());
-        assert!(diagnostics.iter().any(|d| d.rule == "CC-MEM-005"));
+        for path in [
+            ".cursor/rules/typescript.mdc",
+            ".cursor/rules/typescript.MDC",
+        ] {
+            let diagnostics = validator.validate(Path::new(path), content, &LintConfig::default());
+
+            assert!(!diagnostics.is_empty());
+            assert!(diagnostics.iter().any(|d| d.rule == "CC-MEM-005"));
+        }
     }
 
     #[test]
     fn test_cursor_rules_md_gets_rules() {
         let content = "Be helpful and accurate when responding.";
         let validator = ClaudeMdValidator;
-        let diagnostics = validator.validate(
-            Path::new(".cursor/rules/typescript.md"),
-            content,
-            &LintConfig::default(),
-        );
 
-        assert!(!diagnostics.is_empty());
-        assert!(diagnostics.iter().any(|d| d.rule == "CC-MEM-005"));
+        for path in [".cursor/rules/typescript.md", ".cursor/rules/typescript.MD"] {
+            let diagnostics = validator.validate(Path::new(path), content, &LintConfig::default());
+
+            assert!(!diagnostics.is_empty());
+            assert!(diagnostics.iter().any(|d| d.rule == "CC-MEM-005"));
+        }
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -996,7 +996,7 @@ fn validate_cursor_environment_file(
         }
     }
 
-    for field in ["$schema", "name", "user", "snapshot"] {
+    for field in ["name", "user", "snapshot"] {
         if root.get(field).is_some_and(|value| !value.is_string()) {
             diagnostics.push(
                 cursor_environment_error(
@@ -2492,7 +2492,6 @@ is_background: false
 
         for (name, content) in [
             ("unknown root field", r#"{"unknown":true}"#),
-            ("invalid schema association", r#"{"$schema":42}"#),
             ("invalid name", r#"{"name":1}"#),
             ("invalid user", r#"{"user":false}"#),
             (

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -1,4 +1,4 @@
-//! Cursor project rules validation rules (CUR-001 to CUR-019)
+//! Cursor project rules validation rules (CUR-001 to CUR-020)
 //!
 //! Validates:
 //! - CUR-001: Empty .mdc rule file (HIGH) - files must have content
@@ -20,6 +20,7 @@
 //! - CUR-017: Invalid hook entry field types (MEDIUM) - timeout/loop_limit/failClosed type checks
 //! - CUR-018: Prompt-type hook missing prompt field (MEDIUM) - type:"prompt" needs prompt key
 //! - CUR-019: Invalid model field on prompt hook (LOW) - model must be a string
+//! - CUR-020: Ignored .md project rule (HIGH) - project rules must use .mdc
 
 use crate::{
     FileType,
@@ -31,6 +32,7 @@ use crate::{
         ParsedMdcFrontmatter, is_body_empty, is_content_empty, parse_mdc_frontmatter,
         validate_glob_pattern,
     },
+    schemas::gemini_settings::strip_jsonc_comments,
 };
 use rust_i18n::t;
 use serde_json::Value as JsonValue;
@@ -40,7 +42,7 @@ use std::path::Path;
 const RULE_IDS: &[&str] = &[
     "CUR-001", "CUR-002", "CUR-003", "CUR-004", "CUR-005", "CUR-006", "CUR-007", "CUR-008",
     "CUR-009", "CUR-010", "CUR-011", "CUR-012", "CUR-013", "CUR-014", "CUR-015", "CUR-016",
-    "CUR-017", "CUR-018", "CUR-019",
+    "CUR-017", "CUR-018", "CUR-019", "CUR-020",
 ];
 
 const CURSOR_HOOK_EVENTS: &[&str] = &[
@@ -149,10 +151,197 @@ fn is_valid_cursor_agent_name(name: &str) -> bool {
 }
 
 fn is_valid_cursor_model_id(model: &str) -> bool {
-    !model.trim().is_empty()
-        && model
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':' | '/'))
+    fn is_valid_part(value: &str) -> bool {
+        !value.is_empty()
+            && value
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':' | '/'))
+    }
+
+    let trimmed = model.trim();
+    if trimmed != model {
+        return false;
+    }
+    let model = trimmed;
+    let Some(open_bracket) = model.find('[') else {
+        return is_valid_part(model);
+    };
+
+    if !model.ends_with(']') {
+        return false;
+    }
+
+    let base = &model[..open_bracket];
+    let parameters = &model[open_bracket + 1..model.len() - 1];
+    if !is_valid_part(base) || parameters.contains(['[', ']']) {
+        return false;
+    }
+
+    parameters.is_empty()
+        || parameters.split(',').all(|parameter| {
+            let Some((name, value)) = parameter.split_once('=') else {
+                return false;
+            };
+            is_valid_part(name) && is_valid_part(value) && !value.contains('=')
+        })
+}
+
+fn find_root_json_key_location(content: &str, key: &str) -> (usize, usize) {
+    let bytes = content.as_bytes();
+    let mut index = 0usize;
+    let mut object_depth = 0usize;
+    let mut location = None;
+
+    while index < bytes.len() {
+        if bytes[index] == b'/' && index + 1 < bytes.len() {
+            if bytes[index + 1] == b'/' {
+                index += 2;
+                while index < bytes.len() && !matches!(bytes[index], b'\n' | b'\r') {
+                    index += 1;
+                }
+                continue;
+            }
+            if bytes[index + 1] == b'*' {
+                index += 2;
+                while index + 1 < bytes.len() && !(bytes[index] == b'*' && bytes[index + 1] == b'/')
+                {
+                    index += 1;
+                }
+                index = (index + 2).min(bytes.len());
+                continue;
+            }
+        }
+
+        if bytes[index] != b'"' {
+            if bytes[index] == b'{' {
+                object_depth += 1;
+            } else if bytes[index] == b'}' {
+                object_depth = object_depth.saturating_sub(1);
+            }
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        index += 1;
+        let value_start = index;
+        let mut escaped = false;
+        let mut has_escape = false;
+        while index < bytes.len() {
+            if escaped {
+                escaped = false;
+            } else if bytes[index] == b'\\' {
+                escaped = true;
+                has_escape = true;
+            } else if bytes[index] == b'"' {
+                break;
+            }
+            index += 1;
+        }
+
+        if index >= bytes.len() {
+            break;
+        }
+
+        let value_end = index;
+        index += 1;
+        let mut next = index;
+        loop {
+            while next < bytes.len() && bytes[next].is_ascii_whitespace() {
+                next += 1;
+            }
+            if bytes.get(next..next + 2) == Some(b"//") {
+                next += 2;
+                while next < bytes.len() && !matches!(bytes[next], b'\n' | b'\r') {
+                    next += 1;
+                }
+                continue;
+            }
+            if bytes.get(next..next + 2) == Some(b"/*") {
+                next += 2;
+                while next + 1 < bytes.len() && !(bytes[next] == b'*' && bytes[next + 1] == b'/') {
+                    next += 1;
+                }
+                next = (next + 2).min(bytes.len());
+                continue;
+            }
+            break;
+        }
+
+        let key_matches = if has_escape {
+            serde_json::from_str::<String>(&content[start..=value_end])
+                .is_ok_and(|decoded| decoded == key)
+        } else {
+            bytes.get(value_start..value_end) == Some(key.as_bytes())
+        };
+
+        if object_depth == 1 && key_matches && bytes.get(next) == Some(&b':') {
+            let line = content[..start]
+                .bytes()
+                .filter(|byte| *byte == b'\n')
+                .count()
+                + 1;
+            let line_start = content[..start]
+                .rfind('\n')
+                .map(|offset| offset + 1)
+                .unwrap_or(0);
+            let column = content[line_start..start].chars().count() + 1;
+            location = Some((line, column));
+        }
+    }
+
+    location.unwrap_or((1, 0))
+}
+
+fn cursor_environment_error(
+    path: &Path,
+    content: &str,
+    field: &str,
+    message: impl Into<String>,
+) -> Diagnostic {
+    let (line, column) = find_root_json_key_location(content, field);
+    Diagnostic::error(path.to_path_buf(), line, column, "CUR-016", message)
+}
+
+fn validate_cursor_terminal_object(
+    path: &Path,
+    content: &str,
+    terminal: &serde_json::Map<String, JsonValue>,
+    index: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if terminal
+        .get("command")
+        .and_then(JsonValue::as_str)
+        .is_none()
+    {
+        diagnostics.push(
+            cursor_environment_error(
+                path,
+                content,
+                "terminals",
+                t!("rules.cur_016.terminal", index = index),
+            )
+            .with_suggestion(t!("rules.cur_016.suggestion")),
+        );
+    }
+
+    for field in ["name", "description"] {
+        if terminal.get(field).is_some_and(|value| !value.is_string()) {
+            diagnostics.push(
+                cursor_environment_error(
+                    path,
+                    content,
+                    "terminals",
+                    format!(
+                        "terminals[{}].{} must be a string when present",
+                        index, field
+                    ),
+                )
+                .with_suggestion(t!("rules.cur_016.suggestion")),
+            );
+        }
+    }
 }
 
 fn validate_cursor_hooks_file(
@@ -490,14 +679,19 @@ fn validate_cursor_hooks_file(
                 }
             }
 
-            // CUR-018: Prompt-type hook missing prompt field
+            // CUR-018: Prompt-type hook missing or invalid prompt field
             if config.is_rule_enabled("CUR-018") {
                 let is_prompt_type = hook_obj
                     .get("type")
                     .and_then(JsonValue::as_str)
                     .is_some_and(|t| t == "prompt");
 
-                if is_prompt_type && !hook_obj.contains_key("prompt") {
+                let has_valid_prompt = hook_obj
+                    .get("prompt")
+                    .and_then(JsonValue::as_str)
+                    .is_some_and(|prompt| !prompt.trim().is_empty());
+
+                if is_prompt_type && !has_valid_prompt {
                     diagnostics.push(
                         Diagnostic::warning(
                             path.to_path_buf(),
@@ -505,7 +699,7 @@ fn validate_cursor_hooks_file(
                             0,
                             "CUR-018",
                             format!(
-                                "Hook entry {} in '{}' has type 'prompt' but is missing the 'prompt' field",
+                                "Hook entry {} in '{}' has type 'prompt' but lacks a non-empty string 'prompt' field",
                                 index + 1,
                                 event_name
                             ),
@@ -737,14 +931,17 @@ fn validate_cursor_environment_file(
 
     let path_buf = path.to_path_buf();
 
-    let parsed = match serde_json::from_str::<JsonValue>(content) {
+    let stripped = strip_jsonc_comments(content);
+    let parsed = match serde_json::from_str::<JsonValue>(&stripped) {
         Ok(value) => value,
         Err(error) => {
+            let line = error.line();
+            let column = error.column();
             diagnostics.push(
                 Diagnostic::error(
                     path_buf.clone(),
-                    1,
-                    0,
+                    line,
+                    column,
                     "CUR-016",
                     t!("rules.cur_016.parse_error", error = error.to_string()),
                 )
@@ -771,17 +968,67 @@ fn validate_cursor_environment_file(
         }
     };
 
+    const ALLOWED_ROOT_FIELDS: &[&str] = &[
+        "name",
+        "user",
+        "install",
+        "start",
+        "repositoryDependencies",
+        "ports",
+        "terminals",
+        "build",
+        "snapshot",
+        "agentCanUpdateSnapshot",
+    ];
+
+    for field in root.keys() {
+        if field != "update" && !ALLOWED_ROOT_FIELDS.contains(&field.as_str()) {
+            diagnostics.push(
+                cursor_environment_error(
+                    path,
+                    content,
+                    field,
+                    format!("Unknown field '{}' in .cursor/environment.json", field),
+                )
+                .with_suggestion("Remove fields not defined by Cursor's environment schema"),
+            );
+        }
+    }
+
+    for field in ["name", "user", "snapshot"] {
+        if root.get(field).is_some_and(|value| !value.is_string()) {
+            diagnostics.push(
+                cursor_environment_error(
+                    path,
+                    content,
+                    field,
+                    format!("Field '{}' must be a string when present", field),
+                )
+                .with_suggestion(t!("rules.cur_016.suggestion")),
+            );
+        }
+    }
+
+    if root
+        .get("agentCanUpdateSnapshot")
+        .is_some_and(|value| !value.is_boolean())
+    {
+        diagnostics.push(
+            cursor_environment_error(
+                path,
+                content,
+                "agentCanUpdateSnapshot",
+                "Field 'agentCanUpdateSnapshot' must be a boolean when present",
+            )
+            .with_suggestion(t!("rules.cur_016.suggestion")),
+        );
+    }
+
     match root.get("install") {
         Some(v) if v.as_str().is_none() => {
             diagnostics.push(
-                Diagnostic::error(
-                    path_buf.clone(),
-                    1,
-                    0,
-                    "CUR-016",
-                    t!("rules.cur_016.install"),
-                )
-                .with_suggestion(t!("rules.cur_016.suggestion")),
+                cursor_environment_error(path, content, "install", t!("rules.cur_016.install"))
+                    .with_suggestion(t!("rules.cur_016.suggestion")),
             );
         }
         // `install` is absent from every `required` array in the published
@@ -798,7 +1045,7 @@ fn validate_cursor_environment_file(
         && start.as_str().is_none()
     {
         diagnostics.push(
-            Diagnostic::error(path_buf.clone(), 1, 0, "CUR-016", t!("rules.cur_016.start"))
+            cursor_environment_error(path, content, "start", t!("rules.cur_016.start"))
                 .with_suggestion(t!("rules.cur_016.suggestion")),
         );
     }
@@ -808,11 +1055,12 @@ fn validate_cursor_environment_file(
     // The setup page notes the install script "was previously called the update
     // script", so this is a rename: report it as one instead of blessing it.
     if root.get("update").is_some() {
+        let (line, column) = find_root_json_key_location(content, "update");
         diagnostics.push(
             Diagnostic::warning(
                 path_buf.clone(),
-                1,
-                0,
+                line,
+                column,
                 "CUR-016",
                 t!("rules.cur_016.update_renamed"),
             )
@@ -823,15 +1071,15 @@ fn validate_cursor_environment_file(
     if let Some(build) = root.get("build") {
         match build.as_object() {
             Some(build_obj) => {
-                if let Some(dockerfile) = build_obj.get("dockerfile")
-                    && dockerfile.as_str().is_none()
+                if !build_obj
+                    .get("dockerfile")
+                    .is_some_and(JsonValue::is_string)
                 {
                     diagnostics.push(
-                        Diagnostic::error(
-                            path_buf.clone(),
-                            1,
-                            0,
-                            "CUR-016",
+                        cursor_environment_error(
+                            path,
+                            content,
+                            "build",
                             t!("rules.cur_016.build_dockerfile"),
                         )
                         .with_suggestion(t!("rules.cur_016.suggestion")),
@@ -841,24 +1089,38 @@ fn validate_cursor_environment_file(
                     && context.as_str().is_none()
                 {
                     diagnostics.push(
-                        Diagnostic::error(
-                            path_buf.clone(),
-                            1,
-                            0,
-                            "CUR-016",
+                        cursor_environment_error(
+                            path,
+                            content,
+                            "build",
                             t!("rules.cur_016.build_context"),
                         )
                         .with_suggestion(t!("rules.cur_016.suggestion")),
                     );
                 }
+
+                for field in build_obj.keys() {
+                    if !["dockerfile", "context"].contains(&field.as_str()) {
+                        diagnostics.push(
+                            cursor_environment_error(
+                                path,
+                                content,
+                                "build",
+                                format!("Unknown field 'build.{}'", field),
+                            )
+                            .with_suggestion(
+                                "Use only 'dockerfile' and optional 'context' in build",
+                            ),
+                        );
+                    }
+                }
             }
             None => {
                 diagnostics.push(
-                    Diagnostic::error(
-                        path_buf.clone(),
-                        1,
-                        0,
-                        "CUR-016",
+                    cursor_environment_error(
+                        path,
+                        content,
+                        "build",
                         t!("rules.cur_016.invalid_build"),
                     )
                     .with_suggestion(t!("rules.cur_016.suggestion")),
@@ -867,48 +1129,111 @@ fn validate_cursor_environment_file(
         }
     }
 
+    if let Some(dependencies) = root.get("repositoryDependencies") {
+        let valid = dependencies
+            .as_array()
+            .is_some_and(|items| items.iter().all(JsonValue::is_string));
+        if !valid {
+            diagnostics.push(
+                cursor_environment_error(
+                    path,
+                    content,
+                    "repositoryDependencies",
+                    "Field 'repositoryDependencies' must be an array of strings",
+                )
+                .with_suggestion(t!("rules.cur_016.suggestion")),
+            );
+        }
+    }
+
+    if let Some(ports_value) = root.get("ports") {
+        match ports_value.as_array() {
+            Some(ports) => {
+                for (index, port) in ports.iter().enumerate() {
+                    let Some(port_obj) = port.as_object() else {
+                        diagnostics.push(
+                            cursor_environment_error(
+                                path,
+                                content,
+                                "ports",
+                                format!("ports[{}] must be an object", index),
+                            )
+                            .with_suggestion(t!("rules.cur_016.suggestion")),
+                        );
+                        continue;
+                    };
+
+                    let valid_port = port_obj.get("port").is_some_and(|value| {
+                        value.as_f64().is_some_and(|number| {
+                            number.fract() == 0.0 && (1.0..=65535.0).contains(&number)
+                        })
+                    });
+                    if !valid_port {
+                        diagnostics.push(
+                            cursor_environment_error(
+                                path,
+                                content,
+                                "ports",
+                                format!(
+                                    "ports[{}].port must be an integer from 1 through 65535",
+                                    index
+                                ),
+                            )
+                            .with_suggestion(t!("rules.cur_016.suggestion")),
+                        );
+                    }
+
+                    if port_obj.get("name").is_some_and(|value| !value.is_string()) {
+                        diagnostics.push(
+                            cursor_environment_error(
+                                path,
+                                content,
+                                "ports",
+                                format!("ports[{}].name must be a string when present", index),
+                            )
+                            .with_suggestion(t!("rules.cur_016.suggestion")),
+                        );
+                    }
+                }
+            }
+            None => diagnostics.push(
+                cursor_environment_error(path, content, "ports", "Field 'ports' must be an array")
+                    .with_suggestion(t!("rules.cur_016.suggestion")),
+            ),
+        }
+    }
+
     if let Some(terminals_value) = root.get("terminals") {
         match terminals_value {
             JsonValue::Array(terminals) => {
                 for (index, terminal) in terminals.iter().enumerate() {
-                    // The schema types `terminals.items` as a `oneOf` whose
-                    // object branch requires only `["command"]` - `name` and
-                    // `description` are optional - so requiring `name` rejected
-                    // valid config.
+                    let index_label = (index + 1).to_string();
                     if let Some(obj) = terminal.as_object() {
-                        let has_command = obj.get("command").and_then(JsonValue::as_str).is_some();
-                        if !has_command {
-                            diagnostics.push(
-                                Diagnostic::error(
-                                    path_buf.clone(),
-                                    1,
-                                    0,
-                                    "CUR-016",
-                                    t!("rules.cur_016.terminal", index = index + 1),
-                                )
-                                .with_suggestion(t!("rules.cur_016.suggestion")),
-                            );
-                        }
+                        validate_cursor_terminal_object(
+                            path,
+                            content,
+                            obj,
+                            &index_label,
+                            &mut diagnostics,
+                        );
                     } else if let Some(nested) = terminal.as_array() {
-                        // `terminals.items` is a `oneOf` whose first branch is an
-                        // array of command-bearing objects, so a nested list is
-                        // schema-valid. Its contents still have to hold up:
-                        // accepting the branch without checking inside let
-                        // `[[{"name": "x"}]]` pass with no `command`.
-                        for entry in nested {
-                            let ok = entry
-                                .as_object()
-                                .and_then(|obj| obj.get("command"))
-                                .and_then(JsonValue::as_str)
-                                .is_some();
-                            if !ok {
+                        for (nested_index, entry) in nested.iter().enumerate() {
+                            let nested_label = format!("{}][{}", index + 1, nested_index + 1);
+                            if let Some(obj) = entry.as_object() {
+                                validate_cursor_terminal_object(
+                                    path,
+                                    content,
+                                    obj,
+                                    &nested_label,
+                                    &mut diagnostics,
+                                );
+                            } else {
                                 diagnostics.push(
-                                    Diagnostic::error(
-                                        path_buf.clone(),
-                                        1,
-                                        0,
-                                        "CUR-016",
-                                        t!("rules.cur_016.terminal", index = index + 1),
+                                    cursor_environment_error(
+                                        path,
+                                        content,
+                                        "terminals",
+                                        t!("rules.cur_016.terminal", index = nested_label),
                                     )
                                     .with_suggestion(t!("rules.cur_016.suggestion")),
                                 );
@@ -916,11 +1241,10 @@ fn validate_cursor_environment_file(
                         }
                     } else {
                         diagnostics.push(
-                            Diagnostic::error(
-                                path_buf.clone(),
-                                1,
-                                0,
-                                "CUR-016",
+                            cursor_environment_error(
+                                path,
+                                content,
+                                "terminals",
                                 t!("rules.cur_016.terminal_not_object", index = index + 1),
                             )
                             .with_suggestion(t!("rules.cur_016.suggestion")),
@@ -930,11 +1254,10 @@ fn validate_cursor_environment_file(
             }
             other => {
                 diagnostics.push(
-                    Diagnostic::error(
-                        path_buf.clone(),
-                        1,
-                        0,
-                        "CUR-016",
+                    cursor_environment_error(
+                        path,
+                        content,
+                        "terminals",
                         t!(
                             "rules.cur_016.invalid_terminals",
                             got = json_type_name(other)
@@ -966,6 +1289,27 @@ impl Validator for CursorValidator {
         let mut diagnostics = Vec::new();
 
         let file_type = crate::detect_file_type(path);
+
+        if file_type == FileType::CursorRule
+            && path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+        {
+            if config.is_rule_enabled("CUR-020") {
+                diagnostics.push(
+                    Diagnostic::error(
+                        path.to_path_buf(),
+                        1,
+                        0,
+                        "CUR-020",
+                        "Cursor ignores plain .md files in .cursor/rules",
+                    )
+                    .with_suggestion("Rename the project rule with the .mdc extension"),
+                );
+            }
+            return diagnostics;
+        }
 
         match file_type {
             FileType::CursorHooks => return validate_cursor_hooks_file(path, content, config),
@@ -1273,6 +1617,11 @@ mod tests {
     fn validate_mdc_with_config(content: &str, config: &LintConfig) -> Vec<Diagnostic> {
         let validator = CursorValidator;
         validator.validate(Path::new(".cursor/rules/typescript.mdc"), content, config)
+    }
+
+    fn validate_cursor_rule(path: &str, content: &str) -> Vec<Diagnostic> {
+        let validator = CursorValidator;
+        validator.validate(Path::new(path), content, &LintConfig::default())
     }
 
     fn validate_cursor_hooks(content: &str) -> Vec<Diagnostic> {
@@ -1763,6 +2112,42 @@ Review changes."#,
     }
 
     #[test]
+    fn test_cur_014_accepts_parameterized_model_ids() {
+        for model in [
+            "composer-2.5[]",
+            "composer-2.5[fast=false]",
+            "claude-opus-5[effort=high]",
+            "claude-opus-5[effort=high,context=300k]",
+        ] {
+            let content = format!("---\nmodel: {model}\n---\nReview changes.");
+            let diagnostics = validate_cursor_agent(&content);
+            assert!(
+                diagnostics.iter().all(|d| d.rule != "CUR-014"),
+                "documented model ID '{model}' must validate, got: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cur_014_rejects_malformed_parameterized_model_ids() {
+        for model in [
+            "composer-2.5[fast]",
+            "composer-2.5[=false]",
+            "composer-2.5[fast=]",
+            "composer-2.5[fast=false,]",
+            "composer-2.5[fast=false",
+            "\" composer-2.5[] \"",
+        ] {
+            let content = format!("---\nmodel: {model}\n---\nReview changes.");
+            let diagnostics = validate_cursor_agent(&content);
+            assert!(
+                diagnostics.iter().any(|d| d.rule == "CUR-014"),
+                "malformed model ID '{model}' must be rejected, got: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_cur_015_empty_cursor_agent_body() {
         let content = r#"---
 name: reviewer-agent
@@ -1787,6 +2172,109 @@ is_background: false
     fn test_cur_016_environment_parse_error() {
         let diagnostics = validate_cursor_environment(r#"{"install":}"#);
         assert!(diagnostics.iter().any(|d| d.rule == "CUR-016"));
+    }
+
+    #[test]
+    fn test_cur_016_environment_accepts_json_comments() {
+        let diagnostics = validate_cursor_environment(
+            r#"{
+  // Cursor's schema explicitly allows comments.
+  "install": "npm ci",
+  /* Keep the dev server running for the agent. */
+  "start": "npm run dev"
+}"#,
+        );
+        assert!(
+            diagnostics.iter().all(|d| d.rule != "CUR-016"),
+            "comments are valid in environment.json, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_cur_016_environment_rejects_unterminated_json_comment() {
+        let diagnostics = validate_cursor_environment(r#"{"install":"npm ci"} /*"#);
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "CUR-016"),
+            "an unterminated block comment must remain invalid JSONC"
+        );
+    }
+
+    #[test]
+    fn test_cur_016_comment_removal_does_not_join_json_tokens() {
+        let diagnostics = validate_cursor_environment(r#"{"agentCanUpdateSnapshot":tr/*x*/ue}"#);
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "CUR-016"),
+            "comments must not turn adjacent invalid tokens into a valid value"
+        );
+    }
+
+    #[test]
+    fn test_cur_016_environment_diagnostic_points_to_field() {
+        let diagnostics = validate_cursor_environment(
+            r#"{
+  // Keep diagnostics aligned with the original JSONC input.
+  "install": "npm ci",
+  "start": 42
+}"#,
+        );
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| d.rule == "CUR-016" && d.message.contains("start"))
+            .expect("invalid start field should be reported");
+        assert_eq!((diagnostic.line, diagnostic.column), (4, 3));
+    }
+
+    #[test]
+    fn test_cur_016_field_location_handles_escaped_key_and_comment_before_colon() {
+        let diagnostics =
+            validate_cursor_environment("{\n  \"st\\u0061rt\" /* documented JSONC */ : 42\n}");
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| d.rule == "CUR-016" && d.message.contains("start"))
+            .expect("escaped start field should be reported");
+        assert_eq!((diagnostic.line, diagnostic.column), (2, 3));
+    }
+
+    #[test]
+    fn test_cur_016_root_field_location_skips_matching_nested_key() {
+        let diagnostics = validate_cursor_environment(
+            r#"{
+  "terminals": [
+    {"name": "nested", "command": "npm test"}
+  ],
+  "name": 42
+}"#,
+        );
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| d.rule == "CUR-016" && d.message.contains("Field 'name'"))
+            .expect("invalid root name field should be reported");
+        assert_eq!((diagnostic.line, diagnostic.column), (5, 3));
+    }
+
+    #[test]
+    fn test_cur_016_root_field_location_uses_last_duplicate_key() {
+        let diagnostics = validate_cursor_environment(
+            r#"{
+  "start": "npm test",
+  "start": 42
+}"#,
+        );
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| d.rule == "CUR-016" && d.message.contains("start"))
+            .expect("invalid final start field should be reported");
+        assert_eq!((diagnostic.line, diagnostic.column), (3, 3));
+    }
+
+    #[test]
+    fn test_cur_016_root_field_location_counts_unicode_characters() {
+        let diagnostics = validate_cursor_environment(r#"{"name":"é","start":42}"#);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|d| d.rule == "CUR-016" && d.message.contains("start"))
+            .expect("invalid start field should be reported");
+        assert_eq!((diagnostic.line, diagnostic.column), (1, 13));
     }
 
     #[test]
@@ -1950,8 +2438,9 @@ is_background: false
 
     #[test]
     fn test_cur_016_environment_build_context_invalid() {
-        let diagnostics =
-            validate_cursor_environment(r#"{"install":"npm ci","build":{"context":true}}"#);
+        let diagnostics = validate_cursor_environment(
+            r#"{"install":"npm ci","build":{"dockerfile":"Dockerfile","context":true}}"#,
+        );
         let cur_016: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-016").collect();
         assert_eq!(
             cur_016.len(),
@@ -1962,19 +2451,72 @@ is_background: false
     }
 
     #[test]
-    fn test_cur_016_environment_snapshot_ignored() {
-        // Snapshot is a UI concept, not part of the environment.json spec.
-        // This regression test ensures we do not validate or reject it.
+    fn test_cur_016_environment_snapshot_must_be_string() {
         let diagnostics = validate_cursor_environment(r#"{"install":"npm ci","snapshot":42}"#);
         assert!(
-            diagnostics.iter().all(|d| d.rule != "CUR-016"),
-            "snapshot field should be silently ignored, got: {:?}",
-            diagnostics
-                .iter()
-                .filter(|d| d.rule == "CUR-016")
-                .map(|d| &d.message)
-                .collect::<Vec<_>>()
+            diagnostics.iter().any(|d| d.rule == "CUR-016"),
+            "the published schema types snapshot as a string, got: {diagnostics:?}"
         );
+    }
+
+    #[test]
+    fn test_cur_016_environment_validates_full_published_schema() {
+        let valid = validate_cursor_environment(
+            r#"{
+  "name": "development",
+  "user": "ubuntu",
+  "install": "npm ci",
+  "start": "npm run dev",
+  "repositoryDependencies": ["github.com/acme/shared"],
+  "ports": [{"name": "web", "port": 3000}],
+  "terminals": [{"name": "app", "command": "npm run dev", "description": "dev server"}],
+  "build": {"dockerfile": "Dockerfile", "context": ".."},
+  "snapshot": "snap_abc123",
+  "agentCanUpdateSnapshot": true
+}"#,
+        );
+        assert!(
+            valid.iter().all(|d| d.rule != "CUR-016"),
+            "the full documented schema must validate, got: {valid:?}"
+        );
+
+        for (name, content) in [
+            ("unknown root field", r#"{"unknown":true}"#),
+            ("invalid name", r#"{"name":1}"#),
+            ("invalid user", r#"{"user":false}"#),
+            (
+                "invalid repository dependency",
+                r#"{"repositoryDependencies":["github.com/acme/shared",42]}"#,
+            ),
+            ("invalid ports container", r#"{"ports":{}}"#),
+            ("missing port", r#"{"ports":[{"name":"web"}]}"#),
+            ("out-of-range port", r#"{"ports":[{"port":70000}]}"#),
+            ("invalid port name", r#"{"ports":[{"name":1,"port":3000}]}"#),
+            ("missing dockerfile", r#"{"build":{"context":".."}}"#),
+            (
+                "unknown build field",
+                r#"{"build":{"dockerfile":"Dockerfile","target":"dev"}}"#,
+            ),
+            (
+                "invalid terminal name",
+                r#"{"terminals":[{"name":1,"command":"npm run dev"}]}"#,
+            ),
+            (
+                "invalid terminal description",
+                r#"{"terminals":[{"command":"npm run dev","description":1}]}"#,
+            ),
+            ("invalid snapshot", r#"{"snapshot":false}"#),
+            (
+                "invalid snapshot update flag",
+                r#"{"agentCanUpdateSnapshot":"yes"}"#,
+            ),
+        ] {
+            let diagnostics = validate_cursor_environment(content);
+            assert!(
+                diagnostics.iter().any(|d| d.rule == "CUR-016"),
+                "{name} must be rejected, got: {diagnostics:?}"
+            );
+        }
     }
 
     #[test]
@@ -2171,6 +2713,20 @@ Review the diff and suggest improvements."#;
     }
 
     #[test]
+    fn test_cur_018_prompt_must_be_non_empty_string() {
+        for prompt in ["null", "42", "\"\"", "\"   \""] {
+            let content = format!(
+                r#"{{"hooks":{{"beforeShellExecution":[{{"type":"prompt","prompt":{prompt}}}]}}}}"#
+            );
+            let diagnostics = validate_cursor_hooks(&content);
+            assert!(
+                diagnostics.iter().any(|d| d.rule == "CUR-018"),
+                "invalid prompt value {prompt} must be rejected, got: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_cur_018_command_type_no_prompt_no_warning() {
         let diagnostics = validate_cursor_hooks(
             r#"{"version":1,"hooks":{"sessionStart":[{"type":"command","command":"echo hi"}]}}"#,
@@ -2209,6 +2765,45 @@ Review the diff and suggest improvements."#;
         );
         let cur_019: Vec<_> = diagnostics.iter().filter(|d| d.rule == "CUR-019").collect();
         assert!(cur_019.is_empty());
+    }
+
+    // ===== CUR-020: Ignored .md project rule =====
+
+    #[test]
+    fn test_cur_020_plain_markdown_rule_is_ignored_by_cursor() {
+        let diagnostics = validate_cursor_rule(
+            ".cursor/rules/typescript.md",
+            "---\ndescription: TypeScript rules\n---\nUse strict mode.",
+        );
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "CUR-020"),
+            "Cursor ignores plain .md files in .cursor/rules, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_cur_020_mdc_rule_is_recognized() {
+        let diagnostics = validate_cursor_rule(
+            ".cursor/rules/typescript.mdc",
+            "---\ndescription: TypeScript rules\n---\nUse strict mode.",
+        );
+        assert!(diagnostics.iter().all(|d| d.rule != "CUR-020"));
+    }
+
+    #[test]
+    fn test_cur_020_disabled_does_not_validate_ignored_markdown_as_mdc() {
+        let mut config = LintConfig::default();
+        config.rules_mut().disabled_rules = vec!["CUR-020".to_string()];
+        let validator = CursorValidator;
+        let diagnostics = validator.validate(
+            Path::new(".cursor/rules/typescript.md"),
+            "Plain Markdown without MDC frontmatter",
+            &config,
+        );
+        assert!(
+            diagnostics.is_empty(),
+            "ignored .md rules must not fall through to MDC validation: {diagnostics:?}"
+        );
     }
 
     // ===== Config Integration =====
@@ -2405,7 +3000,7 @@ Body"#;
         let rules = [
             "CUR-001", "CUR-002", "CUR-003", "CUR-004", "CUR-005", "CUR-006", "CUR-007", "CUR-008",
             "CUR-009", "CUR-010", "CUR-011", "CUR-012", "CUR-013", "CUR-014", "CUR-015", "CUR-016",
-            "CUR-017", "CUR-018", "CUR-019",
+            "CUR-017", "CUR-018", "CUR-019", "CUR-020",
         ];
 
         for rule in rules {
@@ -2458,6 +3053,10 @@ Body"#;
                 "CUR-019" => (
                     r#"{"version":1,"hooks":{"sessionStart":[{"type":"prompt","command":"echo hi","prompt":"test","model":123}]}}"#,
                     ".cursor/hooks.json",
+                ),
+                "CUR-020" => (
+                    "---\ndescription: ignored\n---\nBody",
+                    ".cursor/rules/test.md",
                 ),
                 _ => ("---\nunknown: value\n---\n", ".cursor/rules/test.mdc"),
             };
@@ -2948,10 +3547,13 @@ Use strict mode.
             "the array branch is schema-valid, got: {ok:?}"
         );
 
-        let bad = validate_cursor_environment(r#"{"terminals":[[{"name":"no command"}]]}"#);
+        let bad = validate_cursor_environment(
+            r#"{"terminals":[[{"name":"no command"},{"description":1}]]}"#,
+        );
         assert!(
-            bad.iter().any(|d| d.rule == "CUR-016"),
-            "an entry inside the array branch still needs `command`, got: {bad:?}"
+            bad.iter().any(|d| d.message.contains("terminals[1][1]"))
+                && bad.iter().any(|d| d.message.contains("terminals[1][2]")),
+            "nested terminal diagnostics must identify each inner entry, got: {bad:?}"
         );
     }
 

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -18,7 +18,7 @@
 //! - CUR-015: Empty Cursor subagent body (MEDIUM)
 //! - CUR-016: Invalid .cursor/environment.json schema (HIGH)
 //! - CUR-017: Invalid hook entry field types (MEDIUM) - timeout/loop_limit/failClosed type checks
-//! - CUR-018: Prompt-type hook missing prompt field (MEDIUM) - type:"prompt" needs prompt key
+//! - CUR-018: Invalid or missing prompt hook field (MEDIUM) - type:"prompt" requires a non-empty string
 //! - CUR-019: Invalid model field on prompt hook (LOW) - model must be a string
 //! - CUR-020: Ignored .md project rule (HIGH) - project rules must use .mdc
 
@@ -182,7 +182,7 @@ fn is_valid_cursor_model_id(model: &str) -> bool {
             let Some((name, value)) = parameter.split_once('=') else {
                 return false;
             };
-            is_valid_part(name) && is_valid_part(value) && !value.contains('=')
+            is_valid_part(name) && is_valid_part(value)
         })
 }
 
@@ -333,9 +333,10 @@ fn validate_cursor_terminal_object(
                     path,
                     content,
                     "terminals",
-                    format!(
-                        "terminals[{}].{} must be a string when present",
-                        index, field
+                    t!(
+                        "rules.cur_016.terminal_field_type",
+                        index = index,
+                        field = field
                     ),
                 )
                 .with_suggestion(t!("rules.cur_016.suggestion")),
@@ -969,6 +970,7 @@ fn validate_cursor_environment_file(
     };
 
     const ALLOWED_ROOT_FIELDS: &[&str] = &[
+        "$schema",
         "name",
         "user",
         "install",
@@ -988,9 +990,9 @@ fn validate_cursor_environment_file(
                     path,
                     content,
                     field,
-                    format!("Unknown field '{}' in .cursor/environment.json", field),
+                    t!("rules.cur_016.unknown_root_field", field = field.as_str()),
                 )
-                .with_suggestion("Remove fields not defined by Cursor's environment schema"),
+                .with_suggestion(t!("rules.cur_016.unknown_root_field_suggestion")),
             );
         }
     }
@@ -1002,7 +1004,7 @@ fn validate_cursor_environment_file(
                     path,
                     content,
                     field,
-                    format!("Field '{}' must be a string when present", field),
+                    t!("rules.cur_016.string_field", field = field),
                 )
                 .with_suggestion(t!("rules.cur_016.suggestion")),
             );
@@ -1018,7 +1020,7 @@ fn validate_cursor_environment_file(
                 path,
                 content,
                 "agentCanUpdateSnapshot",
-                "Field 'agentCanUpdateSnapshot' must be a boolean when present",
+                t!("rules.cur_016.agent_can_update_snapshot"),
             )
             .with_suggestion(t!("rules.cur_016.suggestion")),
         );
@@ -1106,11 +1108,9 @@ fn validate_cursor_environment_file(
                                 path,
                                 content,
                                 "build",
-                                format!("Unknown field 'build.{}'", field),
+                                t!("rules.cur_016.unknown_build_field", field = field.as_str()),
                             )
-                            .with_suggestion(
-                                "Use only 'dockerfile' and optional 'context' in build",
-                            ),
+                            .with_suggestion(t!("rules.cur_016.unknown_build_field_suggestion")),
                         );
                     }
                 }
@@ -1139,7 +1139,7 @@ fn validate_cursor_environment_file(
                     path,
                     content,
                     "repositoryDependencies",
-                    "Field 'repositoryDependencies' must be an array of strings",
+                    t!("rules.cur_016.repository_dependencies"),
                 )
                 .with_suggestion(t!("rules.cur_016.suggestion")),
             );
@@ -1156,7 +1156,7 @@ fn validate_cursor_environment_file(
                                 path,
                                 content,
                                 "ports",
-                                format!("ports[{}] must be an object", index),
+                                t!("rules.cur_016.port_object", index = index),
                             )
                             .with_suggestion(t!("rules.cur_016.suggestion")),
                         );
@@ -1174,10 +1174,7 @@ fn validate_cursor_environment_file(
                                 path,
                                 content,
                                 "ports",
-                                format!(
-                                    "ports[{}].port must be an integer from 1 through 65535",
-                                    index
-                                ),
+                                t!("rules.cur_016.port_number", index = index),
                             )
                             .with_suggestion(t!("rules.cur_016.suggestion")),
                         );
@@ -1189,7 +1186,7 @@ fn validate_cursor_environment_file(
                                 path,
                                 content,
                                 "ports",
-                                format!("ports[{}].name must be a string when present", index),
+                                t!("rules.cur_016.port_name", index = index),
                             )
                             .with_suggestion(t!("rules.cur_016.suggestion")),
                         );
@@ -1197,7 +1194,7 @@ fn validate_cursor_environment_file(
                 }
             }
             None => diagnostics.push(
-                cursor_environment_error(path, content, "ports", "Field 'ports' must be an array")
+                cursor_environment_error(path, content, "ports", t!("rules.cur_016.ports_array"))
                     .with_suggestion(t!("rules.cur_016.suggestion")),
             ),
         }
@@ -1303,9 +1300,9 @@ impl Validator for CursorValidator {
                         1,
                         0,
                         "CUR-020",
-                        "Cursor ignores plain .md files in .cursor/rules",
+                        t!("rules.cur_020.message"),
                     )
-                    .with_suggestion("Rename the project rule with the .mdc extension"),
+                    .with_suggestion(t!("rules.cur_020.suggestion")),
                 );
             }
             return diagnostics;
@@ -2191,6 +2188,19 @@ is_background: false
     }
 
     #[test]
+    fn test_cur_016_environment_rejects_trailing_comma() {
+        let diagnostics = validate_cursor_environment(
+            r#"{
+  "install": "npm ci",
+}"#,
+        );
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "CUR-016"),
+            "Cursor's environment schema disallows trailing commas"
+        );
+    }
+
+    #[test]
     fn test_cur_016_environment_rejects_unterminated_json_comment() {
         let diagnostics = validate_cursor_environment(r#"{"install":"npm ci"} /*"#);
         assert!(
@@ -2463,6 +2473,7 @@ is_background: false
     fn test_cur_016_environment_validates_full_published_schema() {
         let valid = validate_cursor_environment(
             r#"{
+  "$schema": "https://cursor.com/schemas/environment.schema.json",
   "name": "development",
   "user": "ubuntu",
   "install": "npm ci",
@@ -2771,14 +2782,27 @@ Review the diff and suggest improvements."#;
 
     #[test]
     fn test_cur_020_plain_markdown_rule_is_ignored_by_cursor() {
-        let diagnostics = validate_cursor_rule(
-            ".cursor/rules/typescript.md",
-            "---\ndescription: TypeScript rules\n---\nUse strict mode.",
-        );
-        assert!(
-            diagnostics.iter().any(|d| d.rule == "CUR-020"),
-            "Cursor ignores plain .md files in .cursor/rules, got: {diagnostics:?}"
-        );
+        for path in [".cursor/rules/typescript.md", ".cursor/rules/typescript.MD"] {
+            let diagnostics = validate_cursor_rule(
+                path,
+                "---\ndescription: TypeScript rules\n---\nUse strict mode.",
+            );
+            assert!(
+                diagnostics.iter().any(|d| d.rule == "CUR-020"),
+                "Cursor ignores plain Markdown files in .cursor/rules, got: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cur_020_does_not_flag_legacy_or_unrelated_markdown() {
+        for path in [".cursorrules", ".cursorrules.md", "docs/typescript.md"] {
+            let diagnostics = validate_cursor_rule(path, "Use strict mode.");
+            assert!(
+                diagnostics.iter().all(|d| d.rule != "CUR-020"),
+                "CUR-020 must stay scoped to .cursor/rules Markdown: {path}: {diagnostics:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/cursor.rs
+++ b/crates/agnix-core/src/rules/cursor.rs
@@ -828,10 +828,7 @@ fn validate_cursor_agent_file(
 
                 if let Some(model_value) = frontmatter_map.get(key("model")) {
                     match model_value {
-                        YamlValue::String(model)
-                            if model == "fast"
-                                || model == "inherit"
-                                || is_valid_cursor_model_id(model) => {}
+                        YamlValue::String(model) if is_valid_cursor_model_id(model) => {}
                         YamlValue::String(_) => diagnostics.push(
                             Diagnostic::error(
                                 path.to_path_buf(),
@@ -969,6 +966,8 @@ fn validate_cursor_environment_file(
         }
     };
 
+    // Cursor's VS Code JSON service treats root `$schema` as the schema-association
+    // key even though the published schema's closed property set does not declare it.
     const ALLOWED_ROOT_FIELDS: &[&str] = &[
         "$schema",
         "name",
@@ -997,7 +996,7 @@ fn validate_cursor_environment_file(
         }
     }
 
-    for field in ["name", "user", "snapshot"] {
+    for field in ["$schema", "name", "user", "snapshot"] {
         if root.get(field).is_some_and(|value| !value.is_string()) {
             diagnostics.push(
                 cursor_environment_error(
@@ -2493,6 +2492,7 @@ is_background: false
 
         for (name, content) in [
             ("unknown root field", r#"{"unknown":true}"#),
+            ("invalid schema association", r#"{"$schema":42}"#),
             ("invalid name", r#"{"name":1}"#),
             ("invalid user", r#"{"user":false}"#),
             (
@@ -2807,11 +2807,16 @@ Review the diff and suggest improvements."#;
 
     #[test]
     fn test_cur_020_mdc_rule_is_recognized() {
-        let diagnostics = validate_cursor_rule(
+        for path in [
             ".cursor/rules/typescript.mdc",
-            "---\ndescription: TypeScript rules\n---\nUse strict mode.",
-        );
-        assert!(diagnostics.iter().all(|d| d.rule != "CUR-020"));
+            ".cursor/rules/typescript.MDC",
+        ] {
+            let diagnostics = validate_cursor_rule(
+                path,
+                "---\ndescription: TypeScript rules\n---\nUse strict mode.",
+            );
+            assert!(diagnostics.iter().all(|d| d.rule != "CUR-020"));
+        }
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/gemini_settings.rs
+++ b/crates/agnix-core/src/rules/gemini_settings.rs
@@ -310,6 +310,20 @@ mod tests {
     }
 
     #[test]
+    fn test_gm_009_unterminated_jsonc_comment_is_invalid() {
+        let diagnostics = validate(r#"{"general": {}} /* "memoryManager": true"#);
+        assert!(diagnostics.iter().any(|d| d.rule == "GM-009"));
+        assert!(diagnostics.iter().all(|d| d.rule == "GM-009"));
+    }
+
+    #[test]
+    fn test_gm_009_comment_removal_does_not_join_tokens() {
+        let diagnostics = validate(r#"{"experimental":{"autoMemory":tr/*x*/ue}}"#);
+        assert!(diagnostics.iter().any(|d| d.rule == "GM-009"));
+        assert!(diagnostics.iter().all(|d| d.rule == "GM-009"));
+    }
+
+    #[test]
     fn test_gm_009_empty_content() {
         let diagnostics = validate("");
         let gm_009: Vec<_> = diagnostics.iter().filter(|d| d.rule == "GM-009").collect();

--- a/crates/agnix-core/src/rules/mcp.rs
+++ b/crates/agnix-core/src/rules/mcp.rs
@@ -356,7 +356,16 @@ impl Validator for McpValidator {
 
         // Validate MCP server configurations (MCP-009 to MCP-012, MCP-024)
         for (name, server) in extract_mcp_servers(&raw_value) {
-            validate_server(&name, &server, path, content, config, &mut diagnostics);
+            let raw_server_type = find_raw_server_type(&raw_value, &name);
+            validate_server(
+                &name,
+                &server,
+                raw_server_type,
+                path,
+                content,
+                config,
+                &mut diagnostics,
+            );
         }
 
         diagnostics
@@ -486,6 +495,19 @@ fn extract_mcp_servers(raw_value: &serde_json::Value) -> Vec<(String, McpServerC
     }
 
     Vec::new()
+}
+
+fn find_raw_server_type<'a>(
+    raw_value: &'a serde_json::Value,
+    name: &str,
+) -> Option<&'a serde_json::Value> {
+    let server = if let Some(servers) = raw_value.get("mcpServers").and_then(|v| v.as_object()) {
+        servers.get(name)
+    } else {
+        raw_value.as_object().and_then(|root| root.get(name))
+    }?;
+
+    server.as_object()?.get("type")
 }
 
 /// Parse a JSON object into `(name, McpServerConfig)` entries. Strict
@@ -1448,17 +1470,32 @@ fn is_dangerous_command(command: &str) -> bool {
     has_remote_pipe || has_sudo_rm || has_exfil_pattern
 }
 
+fn has_usable_command(server: &McpServerConfig) -> bool {
+    server.command.as_ref().is_some_and(|value| match value {
+        serde_json::Value::String(command) => !command.trim().is_empty(),
+        serde_json::Value::Array(items) => !items.is_empty(),
+        serde_json::Value::Null => false,
+        _ => true,
+    })
+}
+
+fn is_cursor_mcp_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.eq_ignore_ascii_case("mcp.json"))
+        && path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.eq_ignore_ascii_case(".cursor"))
+}
+
 fn has_meaningful_server_config(server: &McpServerConfig) -> bool {
     let has_type = server
         .server_type
         .as_deref()
         .is_some_and(|value| !value.trim().is_empty());
-    let has_command = server.command.as_ref().is_some_and(|value| match value {
-        serde_json::Value::String(command) => !command.trim().is_empty(),
-        serde_json::Value::Array(items) => !items.is_empty(),
-        serde_json::Value::Null => false,
-        _ => true,
-    });
+    let has_command = has_usable_command(server);
     let has_args = server
         .args
         .as_ref()
@@ -1482,6 +1519,7 @@ fn has_meaningful_server_config(server: &McpServerConfig) -> bool {
 fn validate_server(
     name: &str,
     server: &McpServerConfig,
+    raw_server_type: Option<&serde_json::Value>,
     path: &Path,
     content: &str,
     config: &PerFileLintConfig<'_>,
@@ -1489,11 +1527,42 @@ fn validate_server(
 ) {
     let (line, col) = find_json_field_location(content, name);
 
-    // Determine effective type (default is "stdio" when type is absent)
-    let effective_type = server.server_type.as_deref().unwrap_or("stdio");
+    // Cursor documents URL-only remote entries. Other clients, including
+    // Claude Code, still default an omitted type to stdio.
+    let effective_type = server.server_type.as_deref().unwrap_or_else(|| {
+        if raw_server_type.is_none()
+            && is_cursor_mcp_file(path)
+            && !has_usable_command(server)
+            && server.url.is_some()
+        {
+            "http"
+        } else {
+            "stdio"
+        }
+    });
 
     // MCP-011: Invalid server type (check first, skip other type-based rules if invalid)
     if config.is_rule_enabled("MCP-011") {
+        if let Some(raw_type) = raw_server_type
+            && !raw_type.is_string()
+        {
+            diagnostics.push(
+                Diagnostic::error(
+                    path.to_path_buf(),
+                    line,
+                    col,
+                    "MCP-011",
+                    t!(
+                        "rules.mcp_011.message",
+                        server = name,
+                        server_type = raw_type.to_string()
+                    ),
+                )
+                .with_suggestion(t!("rules.mcp_011.suggestion")),
+            );
+            return;
+        }
+
         if let Some(ref server_type) = server.server_type {
             if !VALID_MCP_SERVER_TYPES.contains(&server_type.as_str()) {
                 let mut diagnostic = Diagnostic::error(
@@ -1536,13 +1605,7 @@ fn validate_server(
     // MCP-009: Missing command for stdio server
     // Treat null and empty string/array as missing (not a usable command)
     if config.is_rule_enabled("MCP-009") && effective_type == "stdio" {
-        let has_command = server.command.as_ref().is_some_and(|v| match v {
-            serde_json::Value::String(s) => !s.trim().is_empty(),
-            serde_json::Value::Array(a) => !a.is_empty(),
-            serde_json::Value::Null => false,
-            _ => true,
-        });
-        if !has_command {
+        if !has_usable_command(server) {
             diagnostics.push(
                 Diagnostic::error(
                     path.to_path_buf(),
@@ -1841,6 +1904,11 @@ mod tests {
         let validator = McpValidator;
         let path = PathBuf::from("test.mcp.json");
         validator.validate(&path, content, config)
+    }
+
+    fn validate_path(path: &str, content: &str) -> Vec<Diagnostic> {
+        let validator = McpValidator;
+        validator.validate(Path::new(path), content, &LintConfig::default())
     }
 
     #[test]
@@ -2948,6 +3016,62 @@ mod tests {
         }"#;
         let diagnostics = validate(content);
         assert!(!diagnostics.iter().any(|d| d.rule == "MCP-009"));
+    }
+
+    #[test]
+    fn test_mcp_009_url_only_server_infers_http_transport() {
+        let content = r#"{
+            "mcpServers": {
+                "cursor-remote": {
+                    "url": "https://example.com/mcp",
+                    "headers": {"Authorization": "Bearer ${env:MCP_TOKEN}"}
+                }
+            }
+        }"#;
+        let diagnostics = validate_path(".cursor/mcp.json", content);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| d.rule != "MCP-009" && d.rule != "MCP-010"),
+            "Cursor's documented URL-only remote form must validate, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_cursor_url_server_does_not_infer_transport_for_non_string_type() {
+        for invalid_type in ["42", "null"] {
+            let content = format!(
+                r#"{{
+                    "mcpServers": {{
+                        "cursor-remote": {{
+                            "type": {invalid_type},
+                            "url": "https://example.com/mcp"
+                        }}
+                    }}
+                }}"#
+            );
+            let diagnostics = validate_path(".cursor/mcp.json", &content);
+            assert!(
+                diagnostics.iter().any(|d| d.rule == "MCP-011"),
+                "an explicit non-string type must not be treated as omitted: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_mcp_009_url_only_server_still_defaults_to_stdio_outside_cursor() {
+        let content = r#"{
+            "mcpServers": {
+                "remote": {
+                    "url": "https://example.com/mcp"
+                }
+            }
+        }"#;
+        let diagnostics = validate_path(".mcp.json", content);
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "MCP-009"),
+            "Non-Cursor configs with no type must retain the stdio default"
+        );
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/mcp.rs
+++ b/crates/agnix-core/src/rules/mcp.rs
@@ -3038,6 +3038,65 @@ mod tests {
     }
 
     #[test]
+    fn test_mcp_009_cursor_server_without_url_or_command_stays_stdio() {
+        let content = r#"{
+            "mcpServers": {
+                "incomplete": {
+                    "headers": {"Authorization": "Bearer ${env:MCP_TOKEN}"}
+                }
+            }
+        }"#;
+        let diagnostics = validate_path(".cursor/mcp.json", content);
+        assert!(
+            diagnostics.iter().any(|d| d.rule == "MCP-009"),
+            "a Cursor entry without a URL or command must retain the stdio error"
+        );
+    }
+
+    #[test]
+    fn test_mcp_009_cursor_url_inference_respects_path_boundaries() {
+        let content = r#"{
+            "mcpServers": {
+                "remote": {"url": "https://example.com/mcp"}
+            }
+        }"#;
+        for path in ["mcp.json", ".cursor/sub/mcp.json"] {
+            let diagnostics = validate_path(path, content);
+            assert!(
+                diagnostics.iter().any(|d| d.rule == "MCP-009"),
+                "URL-only inference must not apply to {path}: {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cursor_url_server_with_command_retains_stdio_default() {
+        let content = r#"{
+            "mcpServers": {
+                "local": {
+                    "command": "node",
+                    "url": "http://api.example.com/mcp"
+                }
+            }
+        }"#;
+        let diagnostics = validate_path(".cursor/mcp.json", content);
+        assert!(diagnostics.iter().all(|d| d.rule != "MCP-009"));
+        assert!(diagnostics.iter().all(|d| d.rule != "MCP-017"));
+    }
+
+    #[test]
+    fn test_cursor_url_only_server_reaches_mcp_017() {
+        let content = r#"{
+            "mcpServers": {
+                "remote": {"url": "http://api.example.com/mcp"}
+            }
+        }"#;
+        let diagnostics = validate_path(".cursor/mcp.json", content);
+        assert!(diagnostics.iter().any(|d| d.rule == "MCP-017"));
+        assert!(diagnostics.iter().all(|d| d.rule != "MCP-009"));
+    }
+
+    #[test]
     fn test_cursor_url_server_does_not_infer_transport_for_non_string_type() {
         for invalid_type in ["42", "null"] {
             let content = format!(

--- a/crates/agnix-core/src/schemas/gemini_settings.rs
+++ b/crates/agnix-core/src/schemas/gemini_settings.rs
@@ -142,23 +142,34 @@ pub fn strip_jsonc_comments(input: &str) -> String {
 
         if chars[i] == '/' && i + 1 < len {
             if chars[i + 1] == '/' {
-                // Single-line comment: skip until end of line
+                // Replace comments with spaces so removing one cannot join
+                // otherwise separate JSON tokens.
+                result.push_str("  ");
                 i += 2;
-                while i < len && chars[i] != '\n' {
+                while i < len && !matches!(chars[i], '\n' | '\r') {
+                    result.push(' ');
                     i += 1;
                 }
                 continue;
             } else if chars[i + 1] == '*' {
-                // Multi-line comment: skip until */
+                let comment_start = i;
                 i += 2;
+                let body_start = i;
                 while i + 1 < len && !(chars[i] == '*' && chars[i + 1] == '/') {
-                    if chars[i] == '\n' {
-                        result.push('\n');
-                    }
                     i += 1;
                 }
                 if i + 1 < len {
+                    result.push_str("  ");
+                    for ch in &chars[body_start..i] {
+                        result.push(if matches!(*ch, '\n' | '\r') { *ch } else { ' ' });
+                    }
+                    result.push_str("  ");
                     i += 2; // skip */
+                } else {
+                    // Preserve malformed input so the JSON parser reports the
+                    // unterminated comment instead of accepting it silently.
+                    result.extend(chars[comment_start..].iter());
+                    break;
                 }
                 continue;
             }
@@ -277,6 +288,27 @@ mod tests {
         let result = parse_gemini_settings(content);
         assert!(result.parse_error.is_none());
         assert!(result.schema.is_some());
+    }
+
+    #[test]
+    fn test_parse_jsonc_line_comment_with_cr_line_endings() {
+        let result = parse_gemini_settings("{\r// comment\r\"general\": {}\r}");
+        assert!(result.parse_error.is_none());
+        assert!(result.schema.is_some());
+    }
+
+    #[test]
+    fn test_parse_unterminated_jsonc_comment_is_invalid() {
+        let result = parse_gemini_settings(r#"{"general": {}} /*"#);
+        assert!(result.parse_error.is_some());
+        assert!(result.schema.is_none());
+    }
+
+    #[test]
+    fn test_jsonc_comment_removal_does_not_join_tokens() {
+        let result = parse_gemini_settings(r#"{"experimental":{"autoMemory":tr/*x*/ue}}"#);
+        assert!(result.parse_error.is_some());
+        assert!(result.schema.is_none());
     }
 
     #[test]

--- a/crates/agnix-core/src/schemas/opencode.rs
+++ b/crates/agnix-core/src/schemas/opencode.rs
@@ -11,6 +11,7 @@
 //! - Permission configuration (OC-008)
 //! - Variable substitution syntax (OC-009)
 
+use crate::schemas::gemini_settings::strip_jsonc_comments;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -246,66 +247,6 @@ pub fn parse_opencode_json(content: &str) -> ParsedOpenCodeConfig {
     }
 }
 
-/// Strip single-line (//) and multi-line (/* */) comments from JSONC content
-fn strip_jsonc_comments(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
-    let chars: Vec<char> = input.chars().collect();
-    let len = chars.len();
-    let mut i = 0;
-    let mut in_string = false;
-
-    while i < len {
-        if in_string {
-            result.push(chars[i]);
-            if chars[i] == '\\' && i + 1 < len {
-                i += 1;
-                result.push(chars[i]);
-            } else if chars[i] == '"' {
-                in_string = false;
-            }
-            i += 1;
-            continue;
-        }
-
-        if chars[i] == '"' {
-            in_string = true;
-            result.push(chars[i]);
-            i += 1;
-            continue;
-        }
-
-        if chars[i] == '/' && i + 1 < len {
-            if chars[i + 1] == '/' {
-                // Single-line comment: skip until end of line
-                i += 2;
-                while i < len && chars[i] != '\n' {
-                    i += 1;
-                }
-                continue;
-            } else if chars[i + 1] == '*' {
-                // Multi-line comment: skip until */
-                i += 2;
-                while i + 1 < len && !(chars[i] == '*' && chars[i + 1] == '/') {
-                    // Preserve newlines for line counting
-                    if chars[i] == '\n' {
-                        result.push('\n');
-                    }
-                    i += 1;
-                }
-                if i + 1 < len {
-                    i += 2; // skip */
-                }
-                continue;
-            }
-        }
-
-        result.push(chars[i]);
-        i += 1;
-    }
-
-    result
-}
-
 /// Check if a path looks like a valid glob pattern (contains glob characters)
 pub fn is_glob_pattern(path: &str) -> bool {
     path.contains('*') || path.contains('?') || path.contains('[')
@@ -405,6 +346,20 @@ mod tests {
         assert!(result.parse_error.is_none());
         let schema = result.schema.unwrap();
         assert_eq!(schema.share, Some("auto".to_string()));
+    }
+
+    #[test]
+    fn test_parse_unterminated_jsonc_comment_is_invalid() {
+        let result = parse_opencode_json(r#"{"share":"manual"} /*"#);
+        assert!(result.parse_error.is_some());
+        assert!(result.schema.is_none());
+    }
+
+    #[test]
+    fn test_jsonc_comment_removal_does_not_join_tokens() {
+        let result = parse_opencode_json(r#"{"autoupdate":tr/*x*/ue}"#);
+        assert!(result.parse_error.is_some());
+        assert!(result.schema.is_none());
     }
 
     #[test]

--- a/crates/agnix-core/tests/lib_tests.rs
+++ b/crates/agnix-core/tests/lib_tests.rs
@@ -3092,6 +3092,21 @@ fn test_validate_cursor_mdc_missing_frontmatter() {
 }
 
 #[test]
+fn test_validate_cursor_plain_markdown_rule_reports_cur_020() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let cursor_dir = temp.path().join(".cursor").join("rules");
+    std::fs::create_dir_all(&cursor_dir).unwrap();
+    let file_path = cursor_dir.join("ignored.md");
+    std::fs::write(&file_path, "# Cursor silently ignores this rule").unwrap();
+
+    let diagnostics = expect_success(validate_file(&file_path, &LintConfig::default()).unwrap());
+    assert!(
+        diagnostics.iter().any(|d| d.rule == "CUR-020"),
+        "registry validation should report ignored Cursor Markdown rules"
+    );
+}
+
+#[test]
 fn test_validate_cursor_valid_mdc() {
     let temp = tempfile::TempDir::new().unwrap();
     let cursor_dir = temp.path().join(".cursor").join("rules");

--- a/crates/agnix-core/tests/lib_tests.rs
+++ b/crates/agnix-core/tests/lib_tests.rs
@@ -3092,9 +3092,9 @@ fn test_validate_cursor_mdc_missing_frontmatter() {
 }
 
 #[test]
-fn test_validate_cursor_plain_markdown_rule_reports_cur_020() {
+fn test_validate_cursor_nested_plain_markdown_rule_reports_cur_020() {
     let temp = tempfile::TempDir::new().unwrap();
-    let cursor_dir = temp.path().join(".cursor").join("rules");
+    let cursor_dir = temp.path().join(".cursor").join("rules").join("frontend");
     std::fs::create_dir_all(&cursor_dir).unwrap();
     let file_path = cursor_dir.join("ignored.md");
     std::fs::write(&file_path, "# Cursor silently ignores this rule").unwrap();

--- a/crates/agnix-lsp/README.md
+++ b/crates/agnix-lsp/README.md
@@ -81,7 +81,7 @@ The extension automatically downloads the `agnix-lsp` binary. See `editors/zed/R
 
 - Real-time diagnostics as you type (via textDocument/didChange)
 - Real-time diagnostics on file open and save
-- Supports all agnix validation rules (443 rules)
+- Supports all agnix validation rules (444 rules)
 - Project-level validation for cross-file rules (AGM-006, XP-004/005/006, VER-001)
 
 - Maps diagnostic severity levels (Error, Warning, Info)

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -486,37 +486,48 @@ rules:
     message: hooks.%{event}[%{index}] has invalid 'type' value
     suggestion: If present, 'type' must be 'command' or 'prompt'
   cur_014:
-    message: Cursor subagent file must have valid YAML frontmatter with required fields
+    message: Cursor subagent file must have valid YAML frontmatter with supported field types
     invalid_frontmatter: Cursor subagent frontmatter is invalid YAML or not a mapping
-    missing_name: Cursor subagent frontmatter is missing required 'name' field
     invalid_name: Cursor subagent name must use lowercase letters, digits, and hyphens only
     name_not_string: Cursor subagent 'name' field must be a string
-    missing_description: Cursor subagent frontmatter is missing required 'description' field
     description_not_string: Cursor subagent 'description' field must be a string
-    invalid_model: Cursor subagent model must be 'fast', 'inherit', or a valid model ID
+    invalid_model: Cursor subagent model must be 'inherit' or a specific model ID with optional [id=value] parameters
     model_not_string: Cursor subagent 'model' field must be a string
     readonly_not_bool: Cursor subagent 'readonly' field must be a boolean
     is_background_not_bool: Cursor subagent 'is_background' field must be a boolean
-    suggestion: 'Use frontmatter fields: name, description, model, readonly, and is_background with valid types'
+    suggestion: 'Use optional frontmatter fields name, description, model, readonly, and is_background with valid types'
   cur_015:
     message: Cursor subagent definition is empty after frontmatter
     suggestion: Add body instructions below the frontmatter section
   cur_016:
-    message: .cursor/environment.json must be an object with install (required) and optional start, update, build, terminals
+    message: .cursor/environment.json must be an object matching Cursor's published environment schema
     parse_error: 'Failed to parse .cursor/environment.json: %{error}'
     install: Field 'install' must be a string
-    missing_install: Field 'install' is required and must be a string
     update_renamed: "Field 'update' is not part of the environment schema - it was renamed to 'install'"
     update_renamed_suggestion: Rename 'update' to 'install'; the published schema sets unevaluatedProperties=false, so unknown keys are invalid
     start: Field 'start' must be a string when present
-    update: Field 'update' must be a string when present
     invalid_build: Field 'build' must be an object when present
-    build_dockerfile: Field 'build.dockerfile' must be a string when present
+    build_dockerfile: Field 'build.dockerfile' is required and must be a string
     build_context: Field 'build.context' must be a string when present
     invalid_terminals: Field 'terminals' must be an array, got %{got}
     terminal: "terminals[%{index}] must have a string 'command' field"
     terminal_not_object: terminals[%{index}] must be a JSON object
-    suggestion: 'Use schema: {"install":"...","start":"...","build":{"dockerfile":"...","context":"..."},"terminals":[{"name":"...","command":"..."}]}'
+    terminal_field_type: terminals[%{index}].%{field} must be a string when present
+    unknown_root_field: "Unknown field '%{field}' in .cursor/environment.json"
+    unknown_root_field_suggestion: Remove fields not defined by Cursor's environment schema
+    string_field: "Field '%{field}' must be a string when present"
+    agent_can_update_snapshot: Field 'agentCanUpdateSnapshot' must be a boolean when present
+    unknown_build_field: "Unknown field 'build.%{field}'"
+    unknown_build_field_suggestion: Use only 'dockerfile' and optional 'context' in build
+    repository_dependencies: Field 'repositoryDependencies' must be an array of strings
+    port_object: ports[%{index}] must be an object
+    port_number: ports[%{index}].port must be an integer from 1 through 65535
+    port_name: ports[%{index}].name must be a string when present
+    ports_array: Field 'ports' must be an array
+    suggestion: 'Use Cursor''s schema: string setup fields, a valid build object, string repository dependencies, valid ports, and command-bearing terminals'
+  cur_020:
+    message: Cursor ignores plain .md files in .cursor/rules
+    suggestion: Rename the project rule with the .mdc extension
   cln_001:
     message_empty: Cline rules file is empty
     message_no_content: Cline rules file has no content after frontmatter

--- a/crates/agnix-lsp/src/backend/helpers.rs
+++ b/crates/agnix-lsp/src/backend/helpers.rs
@@ -78,6 +78,10 @@ impl Backend {
             || file_name.eq_ignore_ascii_case("copilot-instructions.md")
             || file_name.to_lowercase().ends_with(".instructions.md")
             || file_name.to_lowercase().ends_with(".mdc")
+            || matches!(
+                agnix_core::detect_file_type(path),
+                agnix_core::FileType::CursorRule
+            )
             || file_name.eq_ignore_ascii_case("opencode.json")
             || file_name.eq_ignore_ascii_case("opencode.jsonc")
     }

--- a/crates/agnix-lsp/src/backend/tests.rs
+++ b/crates/agnix-lsp/src/backend/tests.rs
@@ -2064,6 +2064,12 @@ fn test_is_project_level_trigger() {
         "/project/.cursor/rules/test.mdc"
     )));
     assert!(Backend::is_project_level_trigger(Path::new(
+        "/project/.cursor/rules/test.MDC"
+    )));
+    assert!(Backend::is_project_level_trigger(Path::new(
+        "/project/.cursor/rules/test.MD"
+    )));
+    assert!(Backend::is_project_level_trigger(Path::new(
         "/project/GEMINI.md"
     )));
 

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 443,
-  "last_updated": "2026-07-31",
+  "total_rules": 444,
+  "last_updated": "2026-08-01",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -7489,7 +7489,7 @@
         "source_urls": [
           "https://cursor.com/docs/hooks"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor"
         },
@@ -7504,7 +7504,7 @@
         "autofix": true,
         "fix_safety": "safe"
       },
-      "good_example": "{\"version\":1,\"hooks\":{\"sessionStart\":[{\"type\":\"prompt\",\"command\":\"Summarize changes\"}]}}",
+      "good_example": "{\"version\":1,\"hooks\":{\"beforeShellExecution\":[{\"type\":\"prompt\",\"prompt\":\"Is this command safe?\"}]}}",
       "bad_example": "{\"version\":1,\"hooks\":{\"sessionStart\":[{\"type\":\"agent\",\"command\":\"echo start\"}]}}"
     },
     {
@@ -7517,7 +7517,7 @@
         "source_urls": [
           "https://cursor.com/docs/subagents"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor"
         },
@@ -7531,7 +7531,7 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "---\nname: reviewer-agent\ndescription: Reviews code for defects\nmodel: fast\nreadonly: true\nis_background: false\n---\nReview staged changes and prioritize findings.",
+      "good_example": "---\nname: reviewer-agent\ndescription: Reviews code for defects\nmodel: claude-opus-5[effort=high]\nreadonly: true\nis_background: false\n---\nReview staged changes and prioritize findings.",
       "bad_example": "---\nname: ReviewerAgent\ndescription: 123\nreadonly: \"true\"\n---\nReview staged changes."
     },
     {
@@ -7572,7 +7572,7 @@
           "https://cursor.com/docs/cloud-agent/setup",
           "https://cursor.com/schemas/environment.schema.json"
         ],
-        "verified_on": "2026-07-31",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor"
         },
@@ -7599,7 +7599,7 @@
         "source_urls": [
           "https://cursor.com/docs/hooks"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor",
           "file_types": [
@@ -7616,12 +7616,12 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\n  \"hooks\": {\n    \"save-file\": [{ \"command\": \"npm run lint\", \"events\": [\"file_saved\"] }]\n  }\n}",
-      "bad_example": "{\n  \"hooks\": {\n    \"save-file\": [{ \"command\": 42, \"events\": \"file_saved\" }]\n  }\n}"
+      "good_example": "{\n  \"hooks\": {\n    \"beforeShellExecution\": [{ \"type\": \"command\", \"command\": \"npm run lint\", \"timeout\": 30, \"failClosed\": true }]\n  }\n}",
+      "bad_example": "{\n  \"hooks\": {\n    \"beforeShellExecution\": [{ \"type\": \"command\", \"command\": \"npm run lint\", \"timeout\": \"slow\", \"failClosed\": \"yes\" }]\n  }\n}"
     },
     {
       "id": "CUR-018",
-      "name": "Prompt Hook Missing Prompt Field",
+      "name": "Invalid or Missing Prompt Hook Field",
       "severity": "MEDIUM",
       "category": "cursor",
       "evidence": {
@@ -7629,7 +7629,7 @@
         "source_urls": [
           "https://cursor.com/docs/hooks"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor",
           "file_types": [
@@ -7646,8 +7646,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\n  \"hooks\": {\n    \"ai-review\": [{ \"type\": \"prompt\", \"prompt\": \"Review this change\" }]\n  }\n}",
-      "bad_example": "{\n  \"hooks\": {\n    \"ai-review\": [{ \"type\": \"prompt\" }]\n  }\n}"
+      "good_example": "{\n  \"hooks\": {\n    \"beforeShellExecution\": [{ \"type\": \"prompt\", \"prompt\": \"Review this command\" }]\n  }\n}",
+      "bad_example": "{\n  \"hooks\": {\n    \"beforeShellExecution\": [{ \"type\": \"prompt\", \"prompt\": null }]\n  }\n}"
     },
     {
       "id": "CUR-019",
@@ -7678,6 +7678,36 @@
       },
       "good_example": "{\n  \"hooks\": {\n    \"ai-review\": [{ \"type\": \"prompt\", \"prompt\": \"Review\", \"model\": \"gpt-4\" }]\n  }\n}",
       "bad_example": "{\n  \"hooks\": {\n    \"ai-review\": [{ \"type\": \"prompt\", \"prompt\": \"Review\", \"model\": 123 }]\n  }\n}"
+    },
+    {
+      "id": "CUR-020",
+      "name": "Ignored Plain Markdown Cursor Rule",
+      "severity": "HIGH",
+      "category": "cursor",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://cursor.com/docs/rules"
+        ],
+        "verified_on": "2026-08-01",
+        "applies_to": {
+          "tool": "cursor",
+          "file_types": [
+            "cursor-rule"
+          ]
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": ".cursor/rules/typescript.mdc",
+      "bad_example": ".cursor/rules/typescript.md"
     },
     {
       "id": "CX-SK-001",
@@ -9891,9 +9921,10 @@
       "evidence": {
         "source_type": "spec",
         "source_urls": [
-          "https://modelcontextprotocol.io/specification"
+          "https://modelcontextprotocol.io/specification",
+          "https://cursor.com/docs/mcp"
         ],
-        "verified_on": "2026-02-13",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "spec_revision": "2025-11-25"
         },
@@ -9918,9 +9949,10 @@
       "evidence": {
         "source_type": "spec",
         "source_urls": [
-          "https://modelcontextprotocol.io/specification"
+          "https://modelcontextprotocol.io/specification",
+          "https://cursor.com/docs/mcp"
         ],
-        "verified_on": "2026-02-13",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "spec_revision": "2025-11-25"
         },
@@ -12862,7 +12894,7 @@
     },
     "cursor": {
       "prefix": "CUR",
-      "count": 19,
+      "count": 20,
       "description": "Cursor project rules"
     },
     "cline": {

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -7586,7 +7586,7 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\"build\":{\"dockerfile\":\"Dockerfile\",\"context\":\"..\"},\"install\":\"npm ci\",\"start\":\"npm run dev\",\"terminals\":[{\"name\":\"app\",\"command\":\"npm run dev\"}]}",
+      "good_example": "{\"$schema\":\"https://cursor.com/schemas/environment.schema.json\",\"build\":{\"dockerfile\":\"Dockerfile\",\"context\":\"..\"},\"install\":\"npm ci\",\"start\":\"npm run dev\",\"terminals\":[{\"name\":\"app\",\"command\":\"npm run dev\"}]}",
       "bad_example": "{\"install\":42,\"terminals\":[{\"name\":\"app\"}]}"
     },
     {

--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -300,6 +300,6 @@ cargo install agnix-lsp
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for frontmatter fields
-- 443 validation rules
+- 444 validation rules
 - Status bar indicator (VS Code)
 - Syntax highlighting for SKILL.md (VS Code)

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,7 +3,7 @@
 Real-time validation for AI agent configuration files in VS Code.
 Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix).
 
-**443 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
+**444 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
 
 
 ## Features
@@ -11,7 +11,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Real-time validation** - Diagnostics as you type
 - **Context-aware completions** - Frontmatter keys, values, and snippets
 - **JSON Schema validation and autocomplete for `.agnix.toml` config files**
-- **Validates 443 rules** - From official specs and best practices
+- **Validates 444 rules** - From official specs and best practices
 
 - **Diagnostics panel** - Sidebar tree view of all issues by file
 - **CodeLens** - Rule info shown inline above problematic lines
@@ -45,7 +45,7 @@ Access via Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | `agnix: Fix All Issues in File` | `Ctrl+Shift+.` | Apply all available fixes |
 | `agnix: Preview Fixes` | - | Browse fixes with diff preview |
 | `agnix: Fix All Safe Issues` | `Ctrl+Alt+.` | Apply only safe fixes |
-| `agnix: Show All Rules` | - | Browse 443 rules by category |
+| `agnix: Show All Rules` | - | Browse 444 rules by category |
 
 | `agnix: Show Rule Documentation` | - | Open docs for a rule (via CodeLens) |
 | `agnix: Ignore Rule in Project` | - | Add rule to `.agnix.toml` disabled list |

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 443 validation rules across 40 categories, sourced from 75+ references
+> 444 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 443 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 444 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (443 rules)
+├── VALIDATION-RULES.md             # Master validation reference (444 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **443 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **444 rules** |
 
 
 ### Validation Rules by Category
@@ -106,7 +106,7 @@ knowledge-base/
 | GitHub Copilot | 25 | 13 | 9 | 3 | 11 |
 | Copilot Skills | 1 | 0 | 1 | 0 | 1 |
 | Cross-Platform | 10 | 2 | 7 | 1 | 0 |
-| Cursor | 19 | 9 | 9 | 1 | 6 |
+| Cursor | 20 | 10 | 9 | 1 | 6 |
 | Cursor Skills | 1 | 0 | 1 | 0 | 1 |
 | Gemini Agents | 1 | 1 | 0 | 0 | 0 |
 | Gemini CLI | 10 | 3 | 5 | 2 | 3 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **443** | **214** | **199** | **30** | **124** |
+| **TOTAL** | **444** | **215** | **199** | **30** | **124** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 443 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 444 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     443 rules
+Validation Rules:     444 rules
 Auto-Fixable Rules:   127 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -293,7 +293,7 @@ Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
 Validation Rules:     444 rules
-Auto-Fixable Rules:   127 rules
+Auto-Fixable Rules:   124 rules
 
 Test Fixtures:        116 files
 Platforms Analyzed:   9 (Claude Code, Codex CLI, OpenCode, Copilot, Cursor, Cline, Roo-Cline, Continue.dev, Aider)

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 443 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 444 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -81,6 +81,7 @@ Authoritative sources monitored for changes that may affect validation rules.
 | Cursor - Hooks | https://cursor.com/docs/hooks | spec-drift.yml (weekly) | CUR-010 through CUR-013, CUR-017 through CUR-019 |
 | Cursor - Subagents | https://cursor.com/docs/subagents | spec-drift.yml (weekly) | CUR-014, CUR-015 |
 | Cursor - Environment | https://cursor.com/docs/cloud-agent/setup | spec-drift.yml (weekly) | CUR-016 |
+| Cursor - Environment Schema | https://cursor.com/schemas/environment.schema.json | spec-drift.yml (weekly) | CUR-016 |
 | Cursor - MCP | https://cursor.com/docs/mcp | spec-drift.yml (weekly) | MCP-009 through MCP-012, MCP-017 through MCP-024 |
 | GitHub Copilot | https://docs.github.com/en/copilot/customizing-copilot | spec-drift.yml (weekly) | COP-001 through COP-006 |
 | Cline - Rules | https://docs.cline.bot/features/cline-rules/overview | spec-drift.yml (weekly) | -- |

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-07-30
+**Last Updated**: 2026-08-01
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -19,15 +19,15 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-26 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
 | Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json`, Agent Plugins root `plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-30 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
 | OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-30 | AGM, XP, OC |
-| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/**/*.{json,md}`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-07-30 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
+| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/**/*.{json,md}`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-08-01 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 
 ### A Tier (test on major changes)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Monthly | 2026-07-26 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Monthly | 2026-07-31 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.{md,mdc}`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Monthly | 2026-07-30 | CUR |
+| GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Weekly | 2026-07-26 | COP |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-31 | CLN, CL-SK |
+| Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-01 | CUR, MCP |
 
 ### B Tier (test on significant changes if time permits)
 
@@ -40,7 +40,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-07-30 | GM |
+| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-08-01 | GM |
 
 ### D Tier (no support, nice to have)
 
@@ -63,8 +63,8 @@ Authoritative sources monitored for changes that may affect validation rules.
 | Source | URL | Watch Method | Rules Affected |
 |--------|-----|-------------|----------------|
 | Agent Skills Spec | https://agentskills.io/specification | spec-drift.yml (weekly) + tool-release-watch.yml (commit-path on agentskills/agentskills `docs/specification.mdx`) | AS-001 through AS-019 |
-| MCP Spec | https://modelcontextprotocol.io/specification/2025-11-25 | spec-drift.yml (weekly) | MCP-001 through MCP-008 |
-| MCP GitHub Repo | https://github.com/modelcontextprotocol/specification | mcp-release-watch.yml | MCP-001 through MCP-008 |
+| MCP Spec | https://modelcontextprotocol.io/specification/2026-07-28 | spec-drift.yml (weekly; overview, schema, tools, resources, prompts, transports, security, versioning) | MCP-001 through MCP-024 |
+| MCP GitHub Repo | https://github.com/modelcontextprotocol/modelcontextprotocol | mcp-release-watch.yml | MCP-001 through MCP-024 |
 
 ### Vendor Documentation (Secondary)
 
@@ -77,12 +77,13 @@ Authoritative sources monitored for changes that may affect validation rules.
 | Claude Code - Sub-agents | https://code.claude.com/docs/en/sub-agents | spec-drift.yml (weekly) | CC-AG-001 through CC-AG-007 |
 | Codex CLI - AGENTS.md | https://learn.chatgpt.com/docs/agent-configuration/agents-md | spec-drift.yml (weekly) | AGM-001 through AGM-006, XP-001 through XP-006 |
 | OpenCode - Rules | https://opencode.ai/docs/rules/ | spec-drift.yml (weekly) | XP-001 through XP-006 |
-| Cursor - Rules | https://cursor.com/docs/rules | spec-drift.yml (monthly) | CUR-001 through CUR-009 |
-| Cursor - Hooks | https://cursor.com/docs/hooks | spec-drift.yml (monthly) | CUR-010 through CUR-013, CUR-017 through CUR-019 |
-| Cursor - Subagents | https://cursor.com/docs/subagents | spec-drift.yml (monthly) | CUR-014, CUR-015 |
-| Cursor - Environment | https://cursor.com/docs/cloud-agent/setup | spec-drift.yml (monthly) | CUR-016 |
-| GitHub Copilot | https://docs.github.com/en/copilot/customizing-copilot | spec-drift.yml (monthly) | COP-001 through COP-006 |
-| Cline - Rules | https://docs.cline.bot/features/cline-rules/overview | spec-drift.yml (monthly) | -- |
+| Cursor - Rules | https://cursor.com/docs/rules | spec-drift.yml (weekly) | CUR-001 through CUR-009, CUR-020 |
+| Cursor - Hooks | https://cursor.com/docs/hooks | spec-drift.yml (weekly) | CUR-010 through CUR-013, CUR-017 through CUR-019 |
+| Cursor - Subagents | https://cursor.com/docs/subagents | spec-drift.yml (weekly) | CUR-014, CUR-015 |
+| Cursor - Environment | https://cursor.com/docs/cloud-agent/setup | spec-drift.yml (weekly) | CUR-016 |
+| Cursor - MCP | https://cursor.com/docs/mcp | spec-drift.yml (weekly) | MCP-009 through MCP-012, MCP-017 through MCP-024 |
+| GitHub Copilot | https://docs.github.com/en/copilot/customizing-copilot | spec-drift.yml (weekly) | COP-001 through COP-006 |
+| Cline - Rules | https://docs.cline.bot/features/cline-rules/overview | spec-drift.yml (weekly) | -- |
 
 ### Community Sources
 
@@ -156,9 +157,9 @@ The Model Context Protocol ecosystem is tracked separately due to its rapid evol
 
 ### Current MCP Coverage
 
-- **Protocol version monitored**: 2025-11-25
-- **Rules**: MCP-001 through MCP-008
-- **Automated monitoring**: mcp-release-watch.yml (GitHub releases), spec-drift.yml (spec content)
+- **Protocol version monitored**: 2026-07-28
+- **Rules implemented**: MCP-001 through MCP-026; MCP-025 and MCP-026 are Claude Code vendor rules
+- **Automated monitoring**: mcp-release-watch.yml plus spec-drift.yml for MCP-001 through MCP-024; Claude Code release tracking covers MCP-025 and MCP-026
 - **Baseline hash**: See `.github/spec-baselines.json` for current hash
 
 ### MCP Areas to Watch

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -1403,16 +1403,16 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 <a id="mcp-009"></a>
 ### MCP-009 [HIGH] Missing command for stdio server
 **Requirement**: Stdio MCP servers MUST have a `command` field
-**Detection**: Server entry has `type: "stdio"` (or no type, since stdio is default) but no `command` field
+**Detection**: Server entry has `type: "stdio"`, or omits `type` and has no usable `command`. In `.cursor/mcp.json` only, a URL-only entry is inferred as HTTP, matching Cursor's documented remote-server form.
 **Fix**: Add a `command` field specifying the executable to run
-**Source**: modelcontextprotocol.io/specification
+**Source**: modelcontextprotocol.io/specification, cursor.com/docs/mcp
 
 <a id="mcp-010"></a>
 ### MCP-010 [HIGH] Missing url for http/sse server
 **Requirement**: HTTP and SSE MCP servers MUST have a `url` field
-**Detection**: Server entry has `type: "http"` or `type: "sse"` but no `url` field
+**Detection**: Server entry has `type: "http"` or `type: "sse"` but no `url` field; URL-only entries in `.cursor/mcp.json` need no redundant `type`
 **Fix**: Add a `url` field specifying the server endpoint
-**Source**: modelcontextprotocol.io/specification
+**Source**: modelcontextprotocol.io/specification, cursor.com/docs/mcp
 
 <a id="mcp-011"></a>
 ### MCP-011 [HIGH] Invalid MCP server type
@@ -1803,8 +1803,8 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 
 <a id="cur-014"></a>
 ### CUR-014 [HIGH] Invalid Cursor Subagent Frontmatter
-**Requirement**: `.cursor/agents/**/*.md` files MUST have valid YAML frontmatter with required fields and valid optional field types
-**Detection**: Parse frontmatter and validate required keys (`name`, `description`), plus optional typed fields (`model`, `readonly`, `is_background`) when present
+**Requirement**: `.cursor/agents/**/*.md` files MUST have valid YAML frontmatter. All fields are optional: `name` defaults to the filename and `model` defaults to `inherit`. Specific model IDs may append `[id=value]` parameter lists, including empty `[]`.
+**Detection**: Parse frontmatter and validate optional typed fields (`name`, `description`, `model`, `readonly`, `is_background`) when present
 **Fix**: Correct frontmatter keys, naming format, and value types
 **Source**: cursor.com/docs/subagents
 
@@ -1817,8 +1817,8 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 
 <a id="cur-016"></a>
 ### CUR-016 [HIGH] Invalid .cursor/environment.json Schema
-**Requirement**: `.cursor/environment.json` MUST be an object. Per the published schema (cursor.com/schemas/environment.schema.json) **no field is required**: `definitions.common` has no `required` array and `definitions.container.required` is `[]`, so `install` is optional and the setup page's snapshot example omits it. Terminal entries require only `command` - `name` and `description` are optional, and the `oneOf` also permits an array branch. `update` is **not** in the schema and the root sets `unevaluatedProperties: false`, so it is reported as renamed to `install` rather than accepted.
-**Detection**: Parse JSON and type-check present fields; require `command` on terminal entries; flag `update` as a rename
+**Requirement**: `.cursor/environment.json` MUST match the published schema at cursor.com/schemas/environment.schema.json. Comments are allowed, trailing commas are not, no root field is required, `build.dockerfile` is required when `build` exists, and unknown root/build fields are rejected. Terminal entries require only `command`; `name` and `description` are optional. `update` is not in the schema and is reported as renamed to `install`.
+**Detection**: Strip JSON comments, parse JSON, enforce the root/build closed-field sets, and validate setup strings, repository dependencies, ports, build fields, snapshot fields, and terminal entries
 **Fix**: Correct field types; rename `update` to `install`
 **Source**: cursor.com/docs/cloud-agent/setup
 
@@ -1830,9 +1830,9 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 **Source**: cursor.com/docs/hooks
 
 <a id="cur-018"></a>
-### CUR-018 [MEDIUM] Prompt Hook Missing Prompt Field
-**Requirement**: Prompt-type hooks SHOULD have a prompt field
-**Detection**: Check for type:"prompt" without prompt key
+### CUR-018 [MEDIUM] Invalid or Missing Prompt Hook Field
+**Requirement**: Prompt-type hooks SHOULD have a non-empty string `prompt` field
+**Detection**: Check for `type: "prompt"` without a non-empty string prompt
 **Fix**: Manual
 **Source**: cursor.com/docs/hooks
 
@@ -1842,6 +1842,13 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 **Detection**: Check model field type
 **Fix**: Manual
 **Source**: cursor.com/docs/hooks
+
+<a id="cur-020"></a>
+### CUR-020 [HIGH] Ignored Plain Markdown Cursor Rule
+**Requirement**: Project rules under `.cursor/rules/` MUST use the `.mdc` extension. Cursor explicitly ignores plain `.md` files in this directory.
+**Detection**: Classify `.cursor/rules/**/*.md` so agnix can report the ignored extension before validating content
+**Fix**: Rename the file with a `.mdc` extension
+**Source**: cursor.com/docs/rules
 
 ---
 
@@ -3560,7 +3567,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | GitHub Copilot | 25 | 13 | 9 | 3 | 11 |
 | Copilot Skills | 1 | 0 | 1 | 0 | 1 |
 | Cross-Platform | 10 | 2 | 7 | 1 | 0 |
-| Cursor | 19 | 9 | 9 | 1 | 6 |
+| Cursor | 20 | 10 | 9 | 1 | 6 |
 | Cursor Skills | 1 | 0 | 1 | 0 | 1 |
 | Gemini Agents | 1 | 1 | 0 | 0 | 0 |
 | Gemini CLI | 10 | 3 | 5 | 2 | 3 |
@@ -3582,7 +3589,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **443** | **214** | **199** | **30** | **124** |
+| **TOTAL** | **444** | **215** | **199** | **30** | **124** |
 
 
 ---
@@ -3612,8 +3619,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 443 validation rules across 40 categories
+**Total Coverage**: 444 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 214 HIGH, 199 MEDIUM, 30 LOW
+**Certainty**: 215 HIGH, 199 MEDIUM, 30 LOW
 **Auto-Fixable**: 124 rules (28%)

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -1817,7 +1817,7 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 
 <a id="cur-016"></a>
 ### CUR-016 [HIGH] Invalid .cursor/environment.json Schema
-**Requirement**: `.cursor/environment.json` MUST match the published schema at cursor.com/schemas/environment.schema.json. Comments are allowed, trailing commas are not, no root field is required, `build.dockerfile` is required when `build` exists, and unknown root/build fields are rejected. Terminal entries require only `command`; `name` and `description` are optional. `update` is not in the schema and is reported as renamed to `install`.
+**Requirement**: `.cursor/environment.json` MUST match the published schema at cursor.com/schemas/environment.schema.json. Comments are allowed, trailing commas are not, no root field is required, `build.dockerfile` is required when `build` exists, and unknown root/build fields are rejected except for the conventional root `$schema` association key. Terminal entries require only `command`; `name` and `description` are optional. `update` is not in the schema and is reported as renamed to `install`.
 **Detection**: Strip JSON comments, parse JSON, enforce the root/build closed-field sets, and validate setup strings, repository dependencies, ports, build fields, snapshot fields, and terminal entries
 **Fix**: Correct field types; rename `update` to `install`
 **Source**: cursor.com/docs/cloud-agent/setup

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 443,
-  "last_updated": "2026-07-31",
+  "total_rules": 444,
+  "last_updated": "2026-08-01",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -7489,7 +7489,7 @@
         "source_urls": [
           "https://cursor.com/docs/hooks"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor"
         },
@@ -7504,7 +7504,7 @@
         "autofix": true,
         "fix_safety": "safe"
       },
-      "good_example": "{\"version\":1,\"hooks\":{\"sessionStart\":[{\"type\":\"prompt\",\"command\":\"Summarize changes\"}]}}",
+      "good_example": "{\"version\":1,\"hooks\":{\"beforeShellExecution\":[{\"type\":\"prompt\",\"prompt\":\"Is this command safe?\"}]}}",
       "bad_example": "{\"version\":1,\"hooks\":{\"sessionStart\":[{\"type\":\"agent\",\"command\":\"echo start\"}]}}"
     },
     {
@@ -7517,7 +7517,7 @@
         "source_urls": [
           "https://cursor.com/docs/subagents"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor"
         },
@@ -7531,7 +7531,7 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "---\nname: reviewer-agent\ndescription: Reviews code for defects\nmodel: fast\nreadonly: true\nis_background: false\n---\nReview staged changes and prioritize findings.",
+      "good_example": "---\nname: reviewer-agent\ndescription: Reviews code for defects\nmodel: claude-opus-5[effort=high]\nreadonly: true\nis_background: false\n---\nReview staged changes and prioritize findings.",
       "bad_example": "---\nname: ReviewerAgent\ndescription: 123\nreadonly: \"true\"\n---\nReview staged changes."
     },
     {
@@ -7572,7 +7572,7 @@
           "https://cursor.com/docs/cloud-agent/setup",
           "https://cursor.com/schemas/environment.schema.json"
         ],
-        "verified_on": "2026-07-31",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor"
         },
@@ -7599,7 +7599,7 @@
         "source_urls": [
           "https://cursor.com/docs/hooks"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor",
           "file_types": [
@@ -7616,12 +7616,12 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\n  \"hooks\": {\n    \"save-file\": [{ \"command\": \"npm run lint\", \"events\": [\"file_saved\"] }]\n  }\n}",
-      "bad_example": "{\n  \"hooks\": {\n    \"save-file\": [{ \"command\": 42, \"events\": \"file_saved\" }]\n  }\n}"
+      "good_example": "{\n  \"hooks\": {\n    \"beforeShellExecution\": [{ \"type\": \"command\", \"command\": \"npm run lint\", \"timeout\": 30, \"failClosed\": true }]\n  }\n}",
+      "bad_example": "{\n  \"hooks\": {\n    \"beforeShellExecution\": [{ \"type\": \"command\", \"command\": \"npm run lint\", \"timeout\": \"slow\", \"failClosed\": \"yes\" }]\n  }\n}"
     },
     {
       "id": "CUR-018",
-      "name": "Prompt Hook Missing Prompt Field",
+      "name": "Invalid or Missing Prompt Hook Field",
       "severity": "MEDIUM",
       "category": "cursor",
       "evidence": {
@@ -7629,7 +7629,7 @@
         "source_urls": [
           "https://cursor.com/docs/hooks"
         ],
-        "verified_on": "2026-04-22",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "tool": "cursor",
           "file_types": [
@@ -7646,8 +7646,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\n  \"hooks\": {\n    \"ai-review\": [{ \"type\": \"prompt\", \"prompt\": \"Review this change\" }]\n  }\n}",
-      "bad_example": "{\n  \"hooks\": {\n    \"ai-review\": [{ \"type\": \"prompt\" }]\n  }\n}"
+      "good_example": "{\n  \"hooks\": {\n    \"beforeShellExecution\": [{ \"type\": \"prompt\", \"prompt\": \"Review this command\" }]\n  }\n}",
+      "bad_example": "{\n  \"hooks\": {\n    \"beforeShellExecution\": [{ \"type\": \"prompt\", \"prompt\": null }]\n  }\n}"
     },
     {
       "id": "CUR-019",
@@ -7678,6 +7678,36 @@
       },
       "good_example": "{\n  \"hooks\": {\n    \"ai-review\": [{ \"type\": \"prompt\", \"prompt\": \"Review\", \"model\": \"gpt-4\" }]\n  }\n}",
       "bad_example": "{\n  \"hooks\": {\n    \"ai-review\": [{ \"type\": \"prompt\", \"prompt\": \"Review\", \"model\": 123 }]\n  }\n}"
+    },
+    {
+      "id": "CUR-020",
+      "name": "Ignored Plain Markdown Cursor Rule",
+      "severity": "HIGH",
+      "category": "cursor",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://cursor.com/docs/rules"
+        ],
+        "verified_on": "2026-08-01",
+        "applies_to": {
+          "tool": "cursor",
+          "file_types": [
+            "cursor-rule"
+          ]
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": ".cursor/rules/typescript.mdc",
+      "bad_example": ".cursor/rules/typescript.md"
     },
     {
       "id": "CX-SK-001",
@@ -9891,9 +9921,10 @@
       "evidence": {
         "source_type": "spec",
         "source_urls": [
-          "https://modelcontextprotocol.io/specification"
+          "https://modelcontextprotocol.io/specification",
+          "https://cursor.com/docs/mcp"
         ],
-        "verified_on": "2026-02-13",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "spec_revision": "2025-11-25"
         },
@@ -9918,9 +9949,10 @@
       "evidence": {
         "source_type": "spec",
         "source_urls": [
-          "https://modelcontextprotocol.io/specification"
+          "https://modelcontextprotocol.io/specification",
+          "https://cursor.com/docs/mcp"
         ],
-        "verified_on": "2026-02-13",
+        "verified_on": "2026-08-01",
         "applies_to": {
           "spec_revision": "2025-11-25"
         },
@@ -12862,7 +12894,7 @@
     },
     "cursor": {
       "prefix": "CUR",
-      "count": 19,
+      "count": 20,
       "description": "Cursor project rules"
     },
     "cline": {

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -7586,7 +7586,7 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\"build\":{\"dockerfile\":\"Dockerfile\",\"context\":\"..\"},\"install\":\"npm ci\",\"start\":\"npm run dev\",\"terminals\":[{\"name\":\"app\",\"command\":\"npm run dev\"}]}",
+      "good_example": "{\"$schema\":\"https://cursor.com/schemas/environment.schema.json\",\"build\":{\"dockerfile\":\"Dockerfile\",\"context\":\"..\"},\"install\":\"npm ci\",\"start\":\"npm run dev\",\"terminals\":[{\"name\":\"app\",\"command\":\"npm run dev\"}]}",
       "bad_example": "{\"install\":42,\"terminals\":[{\"name\":\"app\"}]}"
     },
     {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -486,23 +486,23 @@ rules:
     message: hooks.%{event}[%{index}] has invalid 'type' value
     suggestion: If present, 'type' must be 'command' or 'prompt'
   cur_014:
-    message: Cursor subagent file must have valid YAML frontmatter with required fields
+    message: Cursor subagent file must have valid YAML frontmatter with supported field types
     invalid_frontmatter: Cursor subagent frontmatter is invalid YAML or not a mapping
     missing_name: Cursor subagent frontmatter is missing required 'name' field
     invalid_name: Cursor subagent name must use lowercase letters, digits, and hyphens only
     name_not_string: Cursor subagent 'name' field must be a string
     missing_description: Cursor subagent frontmatter is missing required 'description' field
     description_not_string: Cursor subagent 'description' field must be a string
-    invalid_model: Cursor subagent model must be 'fast', 'inherit', or a valid model ID
+    invalid_model: Cursor subagent model must be 'fast', 'inherit', or a valid model ID with optional [id=value] parameters
     model_not_string: Cursor subagent 'model' field must be a string
     readonly_not_bool: Cursor subagent 'readonly' field must be a boolean
     is_background_not_bool: Cursor subagent 'is_background' field must be a boolean
-    suggestion: 'Use frontmatter fields: name, description, model, readonly, and is_background with valid types'
+    suggestion: 'Use optional frontmatter fields name, description, model, readonly, and is_background with valid types'
   cur_015:
     message: Cursor subagent definition is empty after frontmatter
     suggestion: Add body instructions below the frontmatter section
   cur_016:
-    message: .cursor/environment.json must be an object with install (required) and optional start, update, build, terminals
+    message: .cursor/environment.json must be an object matching Cursor's published environment schema
     parse_error: 'Failed to parse .cursor/environment.json: %{error}'
     install: Field 'install' must be a string
     missing_install: Field 'install' is required and must be a string
@@ -511,12 +511,12 @@ rules:
     start: Field 'start' must be a string when present
     update: Field 'update' must be a string when present
     invalid_build: Field 'build' must be an object when present
-    build_dockerfile: Field 'build.dockerfile' must be a string when present
+    build_dockerfile: Field 'build.dockerfile' is required and must be a string
     build_context: Field 'build.context' must be a string when present
     invalid_terminals: Field 'terminals' must be an array, got %{got}
     terminal: "terminals[%{index}] must have a string 'command' field"
     terminal_not_object: terminals[%{index}] must be a JSON object
-    suggestion: 'Use schema: {"install":"...","start":"...","build":{"dockerfile":"...","context":"..."},"terminals":[{"name":"...","command":"..."}]}'
+    suggestion: 'Use Cursor''s schema: string setup fields, a valid build object, string repository dependencies, valid ports, and command-bearing terminals'
   cln_001:
     message_empty: Cline rules file is empty
     message_no_content: Cline rules file has no content after frontmatter

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -488,12 +488,10 @@ rules:
   cur_014:
     message: Cursor subagent file must have valid YAML frontmatter with supported field types
     invalid_frontmatter: Cursor subagent frontmatter is invalid YAML or not a mapping
-    missing_name: Cursor subagent frontmatter is missing required 'name' field
     invalid_name: Cursor subagent name must use lowercase letters, digits, and hyphens only
     name_not_string: Cursor subagent 'name' field must be a string
-    missing_description: Cursor subagent frontmatter is missing required 'description' field
     description_not_string: Cursor subagent 'description' field must be a string
-    invalid_model: Cursor subagent model must be 'fast', 'inherit', or a valid model ID with optional [id=value] parameters
+    invalid_model: Cursor subagent model must be 'inherit' or a specific model ID with optional [id=value] parameters
     model_not_string: Cursor subagent 'model' field must be a string
     readonly_not_bool: Cursor subagent 'readonly' field must be a boolean
     is_background_not_bool: Cursor subagent 'is_background' field must be a boolean
@@ -505,18 +503,31 @@ rules:
     message: .cursor/environment.json must be an object matching Cursor's published environment schema
     parse_error: 'Failed to parse .cursor/environment.json: %{error}'
     install: Field 'install' must be a string
-    missing_install: Field 'install' is required and must be a string
     update_renamed: "Field 'update' is not part of the environment schema - it was renamed to 'install'"
     update_renamed_suggestion: Rename 'update' to 'install'; the published schema sets unevaluatedProperties=false, so unknown keys are invalid
     start: Field 'start' must be a string when present
-    update: Field 'update' must be a string when present
     invalid_build: Field 'build' must be an object when present
     build_dockerfile: Field 'build.dockerfile' is required and must be a string
     build_context: Field 'build.context' must be a string when present
     invalid_terminals: Field 'terminals' must be an array, got %{got}
     terminal: "terminals[%{index}] must have a string 'command' field"
     terminal_not_object: terminals[%{index}] must be a JSON object
+    terminal_field_type: terminals[%{index}].%{field} must be a string when present
+    unknown_root_field: "Unknown field '%{field}' in .cursor/environment.json"
+    unknown_root_field_suggestion: Remove fields not defined by Cursor's environment schema
+    string_field: "Field '%{field}' must be a string when present"
+    agent_can_update_snapshot: Field 'agentCanUpdateSnapshot' must be a boolean when present
+    unknown_build_field: "Unknown field 'build.%{field}'"
+    unknown_build_field_suggestion: Use only 'dockerfile' and optional 'context' in build
+    repository_dependencies: Field 'repositoryDependencies' must be an array of strings
+    port_object: ports[%{index}] must be an object
+    port_number: ports[%{index}].port must be an integer from 1 through 65535
+    port_name: ports[%{index}].name must be a string when present
+    ports_array: Field 'ports' must be an array
     suggestion: 'Use Cursor''s schema: string setup fields, a valid build object, string repository dependencies, valid ports, and command-bearing terminals'
+  cur_020:
+    message: Cursor ignores plain .md files in .cursor/rules
+    suggestion: Rename the project rule with the .mdc extension
   cln_001:
     message_empty: Cline rules file is empty
     message_no_content: Cline rules file has no content after frontmatter

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.44.0",
-  "description": "Lint agent configurations before they break your workflow. 443 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 444 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "aviarchi1994@gmail.com",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 443 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 444 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 443 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 444 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 443 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 444 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/tests/ci_workflow.rs
+++ b/tests/ci_workflow.rs
@@ -44,3 +44,24 @@ fn ci_keeps_linux_only_quality_gates_on_ubuntu() {
         );
     }
 }
+
+#[test]
+fn mcp_release_watch_filters_prerelease_tags() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let workflow = fs::read_to_string(format!("{root}/.github/workflows/mcp-release-watch.yml"))
+        .expect("failed to read MCP release-watch workflow")
+        .replace("\r\n", "\n");
+
+    assert!(
+        workflow.contains(r#"select(test("^[0-9]{4}-[0-9]{2}-[0-9]{2}$"))"#),
+        "MCP tag fallback must select only final date-based versions"
+    );
+    assert!(
+        workflow.contains("Ignoring non-final MCP release/tag"),
+        "MCP prerelease tags must be ignored instead of failing the workflow"
+    );
+    assert!(
+        !workflow.contains("ERROR: Unsupported MCP release format"),
+        "known MCP prerelease tag shapes must not hard-fail the workflow"
+    );
+}

--- a/tests/ci_workflow.rs
+++ b/tests/ci_workflow.rs
@@ -57,6 +57,10 @@ fn mcp_release_watch_filters_prerelease_tags() {
         "MCP tag fallback must select only final date-based versions"
     );
     assert!(
+        workflow.contains("] | max // empty"),
+        "MCP tag fallback must select the newest final date-based version"
+    );
+    assert!(
         workflow.contains("Ignoring non-final MCP release/tag"),
         "MCP prerelease tags must be ignored instead of failing the workflow"
     );

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 443 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 444 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -73,6 +73,6 @@ GitHub Copilot validation is enabled by default and can be targeted in config wi
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 443 rules
+- [Rules Reference](./rules/index.md) - browse all 444 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 443 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 444 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 443 rules derived from official specs and real-world testing
+- **Validates** configuration files against 444 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 443 validation rules
+- [Rules Reference](./rules/index.md) - browse all 444 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics

--- a/website/docs/rules/generated/cur-013.md
+++ b/website/docs/rules/generated/cur-013.md
@@ -13,7 +13,7 @@ keywords: ["CUR-013", "invalid cursor hook type value", "cursor", "validation", 
 - **Category**: `Cursor`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `Yes (safe)`
-- **Verified On**: `2026-04-22`
+- **Verified On**: `2026-08-01`
 
 ## Applicability
 
@@ -44,5 +44,5 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ### Valid
 
 ```json
-{"version":1,"hooks":{"sessionStart":[{"type":"prompt","command":"Summarize changes"}]}}
+{"version":1,"hooks":{"beforeShellExecution":[{"type":"prompt","prompt":"Is this command safe?"}]}}
 ```

--- a/website/docs/rules/generated/cur-014.md
+++ b/website/docs/rules/generated/cur-014.md
@@ -13,7 +13,7 @@ keywords: ["CUR-014", "invalid cursor subagent frontmatter", "cursor", "validati
 - **Category**: `Cursor`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-04-22`
+- **Verified On**: `2026-08-01`
 
 ## Applicability
 
@@ -52,7 +52,7 @@ Review staged changes.
 ---
 name: reviewer-agent
 description: Reviews code for defects
-model: fast
+model: claude-opus-5[effort=high]
 readonly: true
 is_background: false
 ---

--- a/website/docs/rules/generated/cur-016.md
+++ b/website/docs/rules/generated/cur-016.md
@@ -13,7 +13,7 @@ keywords: ["CUR-016", "invalid cursor environment schema", "cursor", "validation
 - **Category**: `Cursor`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-07-31`
+- **Verified On**: `2026-08-01`
 
 ## Applicability
 

--- a/website/docs/rules/generated/cur-016.md
+++ b/website/docs/rules/generated/cur-016.md
@@ -45,5 +45,5 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ### Valid
 
 ```json
-{"build":{"dockerfile":"Dockerfile","context":".."},"install":"npm ci","start":"npm run dev","terminals":[{"name":"app","command":"npm run dev"}]}
+{"$schema":"https://cursor.com/schemas/environment.schema.json","build":{"dockerfile":"Dockerfile","context":".."},"install":"npm ci","start":"npm run dev","terminals":[{"name":"app","command":"npm run dev"}]}
 ```

--- a/website/docs/rules/generated/cur-017.md
+++ b/website/docs/rules/generated/cur-017.md
@@ -13,7 +13,7 @@ keywords: ["CUR-017", "invalid hook entry field types", "cursor", "validation", 
 - **Category**: `Cursor`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-04-22`
+- **Verified On**: `2026-08-01`
 
 ## Applicability
 
@@ -40,7 +40,7 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ```json
 {
   "hooks": {
-    "save-file": [{ "command": 42, "events": "file_saved" }]
+    "beforeShellExecution": [{ "type": "command", "command": "npm run lint", "timeout": "slow", "failClosed": "yes" }]
   }
 }
 ```
@@ -50,7 +50,7 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ```json
 {
   "hooks": {
-    "save-file": [{ "command": "npm run lint", "events": ["file_saved"] }]
+    "beforeShellExecution": [{ "type": "command", "command": "npm run lint", "timeout": 30, "failClosed": true }]
   }
 }
 ```

--- a/website/docs/rules/generated/cur-018.md
+++ b/website/docs/rules/generated/cur-018.md
@@ -1,9 +1,9 @@
 ---
 id: cur-018
-title: "CUR-018: Prompt Hook Missing Prompt Field - Cursor"
+title: "CUR-018: Invalid or Missing Prompt Hook Field - Cursor"
 sidebar_label: "CUR-018"
-description: "agnix rule CUR-018 checks for prompt hook missing prompt field in cursor files. Severity: MEDIUM. See examples and fix guidance."
-keywords: ["CUR-018", "prompt hook missing prompt field", "cursor", "validation", "agnix", "linter"]
+description: "agnix rule CUR-018 checks for invalid or missing prompt hook field in cursor files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CUR-018", "invalid or missing prompt hook field", "cursor", "validation", "agnix", "linter"]
 ---
 
 ## Summary
@@ -13,7 +13,7 @@ keywords: ["CUR-018", "prompt hook missing prompt field", "cursor", "validation"
 - **Category**: `Cursor`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-04-22`
+- **Verified On**: `2026-08-01`
 
 ## Applicability
 
@@ -40,7 +40,7 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ```json
 {
   "hooks": {
-    "ai-review": [{ "type": "prompt" }]
+    "beforeShellExecution": [{ "type": "prompt", "prompt": null }]
   }
 }
 ```
@@ -50,7 +50,7 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ```json
 {
   "hooks": {
-    "ai-review": [{ "type": "prompt", "prompt": "Review this change" }]
+    "beforeShellExecution": [{ "type": "prompt", "prompt": "Review this command" }]
   }
 }
 ```

--- a/website/docs/rules/generated/cur-020.md
+++ b/website/docs/rules/generated/cur-020.md
@@ -1,0 +1,48 @@
+---
+id: cur-020
+title: "CUR-020: Ignored Plain Markdown Cursor Rule - Cursor"
+sidebar_label: "CUR-020"
+description: "agnix rule CUR-020 checks for ignored plain markdown cursor rule in cursor files. Severity: HIGH. See examples and fix guidance."
+keywords: ["CUR-020", "ignored plain markdown cursor rule", "cursor", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CUR-020`
+- **Severity**: `HIGH`
+- **Category**: `Cursor`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-08-01`
+
+## Applicability
+
+- **Tool**: `cursor`
+- **Version Range**: `unspecified`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://cursor.com/docs/rules
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```markdown
+.cursor/rules/typescript.md
+```
+
+### Valid
+
+```markdown
+.cursor/rules/typescript.mdc
+```

--- a/website/docs/rules/generated/mcp-009.md
+++ b/website/docs/rules/generated/mcp-009.md
@@ -13,7 +13,7 @@ keywords: ["MCP-009", "missing command for stdio server", "mcp", "validation", "
 - **Category**: `MCP`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-02-13`
+- **Verified On**: `2026-08-01`
 
 ## Applicability
 
@@ -24,6 +24,7 @@ keywords: ["MCP-009", "missing command for stdio server", "mcp", "validation", "
 ## Evidence Sources
 
 - https://modelcontextprotocol.io/specification
+- https://cursor.com/docs/mcp
 
 ## Test Coverage Metadata
 

--- a/website/docs/rules/generated/mcp-010.md
+++ b/website/docs/rules/generated/mcp-010.md
@@ -13,7 +13,7 @@ keywords: ["MCP-010", "missing url for http/sse server", "mcp", "validation", "a
 - **Category**: `MCP`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-02-13`
+- **Verified On**: `2026-08-01`
 
 ## Applicability
 
@@ -24,6 +24,7 @@ keywords: ["MCP-010", "missing url for http/sse server", "mcp", "validation", "a
 ## Evidence Sources
 
 - https://modelcontextprotocol.io/specification
+- https://cursor.com/docs/mcp
 
 ## Test Coverage Metadata
 

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `443` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `444` validation rules generated from `knowledge-base/rules.json`.
 `124` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -268,8 +268,9 @@ This section contains all `443` validation rules generated from `knowledge-base/
 | [CUR-015](./generated/cur-015.md) | Empty Cursor Subagent Body | MEDIUM | Cursor | No |
 | [CUR-016](./generated/cur-016.md) | Invalid Cursor Environment Schema | HIGH | Cursor | No |
 | [CUR-017](./generated/cur-017.md) | Invalid Hook Entry Field Types | MEDIUM | Cursor | No |
-| [CUR-018](./generated/cur-018.md) | Prompt Hook Missing Prompt Field | MEDIUM | Cursor | No |
+| [CUR-018](./generated/cur-018.md) | Invalid or Missing Prompt Hook Field | MEDIUM | Cursor | No |
 | [CUR-019](./generated/cur-019.md) | Invalid Prompt Hook Model Type | LOW | Cursor | No |
+| [CUR-020](./generated/cur-020.md) | Ignored Plain Markdown Cursor Rule | HIGH | Cursor | No |
 | [CX-SK-001](./generated/cx-sk-001.md) | Codex Skill Uses Unsupported Field | MEDIUM | Codex Skills | Yes (safe/unsafe) |
 | [GM-001](./generated/gm-001.md) | Invalid Markdown Structure in GEMINI.md | HIGH | Gemini CLI | Yes (safe) |
 | [GM-002](./generated/gm-002.md) | Missing Section Headers in GEMINI.md | MEDIUM | Gemini CLI | No |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 443,
+  "totalRules": 444,
   "categoryCount": 40,
   "autofixCount": 124,
   "uniqueTools": [


### PR DESCRIPTION
## Summary

- add CUR-020 for plain `.md` files that Cursor ignores under `.cursor/rules/`
- align Cursor subagent models, prompt hooks, `environment.json`, and URL-only MCP servers with current Cursor documentation
- switch spec monitoring to canonical content, expand MCP coverage, and harden release/fetch failure handling
- triage and advance Cursor 3.14.7, Gemini CLI 0.53.1, Kiro CLI 2.16.0, and MCP 2026-07-28 baselines

Follow-up for #1305, #1306, #1307, and #1308.

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- rule bookkeeping check
- workflow YAML and embedded shell syntax checks
- live re-fetch of all 23 canonical spec sources with zero hash mismatches
- independent validation and workflow reviews, including a clean second pass after fixes

## Release

Rule count increases from 443 to 444, so this will be followed by a `v0.45.0` feature release after merge.