### PR TITLE
fix: address automated release and spec drift queue

### DIFF
--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Baseline hashes for canonical specification content. Human-facing URLs are kept separately from machine-readable content URLs.",
-  "last_updated": "2026-08-01T00:00:00Z",
+  "last_updated": "2026-08-05T00:00:00Z",
   "sources": {
     "s-tier": {
       "agent-skills-spec": {
         "url": "https://agentskills.io/specification",
         "content_url": "https://raw.githubusercontent.com/agentskills/agentskills/main/docs/specification.mdx",
-        "hash": "4e758a27be17f5bd9af8d6506890895a412f774a4c09f08ee1cc7565391d16ef",
+        "hash": "dcbdef1ca13e15bb4430a1ecf8da7e185e4202f35ddf0d788cdec88659256b4a",
         "rules": [
           "AS-001",
           "AS-002",
@@ -268,7 +268,7 @@
       "cursor-environment": {
         "url": "https://cursor.com/docs/cloud-agent/setup",
         "content_url": "https://cursor.com/docs/cloud-agent/setup.md",
-        "hash": "058418e383b5bf20786c8a858f37856aa73719759774874b73bf7fb86f18fcd0",
+        "hash": "6565db8120f64cb59b1b4de7c1a0d6dc3c9194f9565c310b06adac3bc1cf161d",
         "rules": [
           "CUR-016"
         ]

--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-08-04",
+  "last_updated": "2026-08-05",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -16,7 +16,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.221",
+      "last_known_version": "v2.1.222",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -204,7 +204,7 @@
       ],
       "github_repo": "cline/cline",
       "release_tag_regex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
-      "last_known_version": "v4.1.3",
+      "last_known_version": "v4.1.4",
       "tracked": true,
       "notes": "Tracks only the core Cline vX.Y.Z release train. The repository also publishes desktop-v*, cli-v*, sdk/*, and other interleaved releases that do not correspond to the validator surfaces.",
       "changes_of_interest": {
@@ -239,7 +239,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.14.7",
+      "last_known_version": "3.14.27",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {
@@ -404,7 +404,7 @@
       ],
       "commit_repo": "agentskills/agentskills",
       "commit_path": "docs/specification.mdx",
-      "last_known_version": "6868401b64f7",
+      "last_known_version": "217be548739f",
       "tracked": true,
       "notes": "The agentskills.io Skill specification (the generic cross-tool SKILL.md standard) - the source for agnix's AS-* rules. It publishes NO releases or tags, so it is tracked by the latest commit SHA touching docs/specification.mdx in the agentskills/agentskills repo (commit_repo + commit_path source). Any change opens an issue to diff the spec against the AS-* rules. Complements the weekly spec-drift.yml check. last_known_version is the short commit SHA.",
       "changes_of_interest": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 444 rules, 75+ sources, rules.json
+knowledge-base/     # 445 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-444 rules defined in `knowledge-base/rules.json` (source of truth)
+445 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 444 validation rules across 40 validators
+- 445 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SET-021: Ineffective Project Remote Control Auto-start**. Claude Code 2.1.222 no longer honors `remoteControlAtStartup: true` in project settings; agnix now warns on the ignored value while allowing project-level `false` and managed settings. Rule count 444 -> 445.
+
 ### Changed
-- **Tool release baselines**. Advanced Claude Code to `v2.1.221`, OpenCode to `v1.18.13`, Cline to `v4.1.3`, and Amp's release marker to `attach-anything` after reviewing their current release notes and validated configuration surfaces (closes #1311, #1312, and #1313).
+- **Tool release baselines**. Advanced Claude Code to `v2.1.222`, OpenCode to `v1.18.13`, Cline to `v4.1.4`, Cursor to `3.14.27`, the Agent Skills specification to `217be548739f`, and Amp's release marker to `attach-anything` after reviewing their current release notes and validated configuration surfaces (closes #1311, #1312, #1313, #1316, #1317, #1318, and #1319).
 
 ### Fixed
 - **Claude Code credential protection compatibility**. Extend CC-SET-012 for environment-variable masking added in 2.1.199 and file masking added in 2.1.221, including ECMAScript extraction validation, structured file controls, injection host lists, environment variable names, and `allowPlaintextInject`; accept mask-only fields that Claude Code ignores on `deny` entries; accept the newly documented `skills: "."` plugin-root path under CC-PL-007.
+- **Agent Skills metadata type enforcement**. Reject non-map `metadata` and metadata entries with non-string keys or values, matching the clarified Agent Skills specification instead of silently coercing YAML scalars.
 
 ### Security
 - **Undici 7.29.0**. Refresh both npm lockfiles for the upstream cache-control, request-header, retry-response, and cookie validation security fixes from Dependabot PR #1314.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 444 rules, 75+ sources, rules.json
+knowledge-base/     # 445 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-444 rules defined in `knowledge-base/rules.json` (source of truth)
+445 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 444 validation rules across 40 validators
+- 445 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>444 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>445 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 444 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 445 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -14,7 +14,7 @@
 | Agents | agents/*.md | 18 |
 | Plugins | plugin.json | 15 |
 | Claude Output Styles | .claude/output-styles/*.md | 6 |
-| Claude Settings | .claude/settings.json | 20 |
+| Claude Settings | .claude/settings.json | 21 |
 | Prompt Engineering | CLAUDE.md, AGENTS.md | 6 |
 | Cross-Platform | AGENTS.md | 10 |
 | MCP | tool definitions | 26 |

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -1313,6 +1313,11 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline must be unrestricted, small, medium, or large (got %{actual})
     suggestion: Set workflowSizeGuideline to one of unrestricted, small, medium, or large.
+  cc_set_021:
+    message: 'remoteControlAtStartup: true cannot enable Remote Control from project settings in Claude Code 2.1.222+;
+      this value is ignored'
+    suggestion: Enable Remote Control in user settings with /config, or set this field to false to disable it for the
+      project.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -826,6 +826,11 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline debe ser unrestricted, small, medium o large (se obtuvo %{actual})
     suggestion: Establece workflowSizeGuideline en unrestricted, small, medium o large.
+  cc_set_021:
+    message: 'remoteControlAtStartup: true no puede habilitar Remote Control desde la configuracion del proyecto en Claude
+      Code 2.1.222+; este valor se ignora'
+    suggestion: Habilita Remote Control en la configuracion de usuario con /config, o establece este campo en false para
+      deshabilitarlo en el proyecto.
 
 
 # ===========================================================================

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -779,6 +779,9 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline 必须是 unrestricted、small、medium 或 large（实际为 %{actual}）
     suggestion: 将 workflowSizeGuideline 设置为 unrestricted、small、medium 或 large。
+  cc_set_021:
+    message: 'Claude Code 2.1.222+ 无法通过项目设置中的 remoteControlAtStartup: true 启用远程控制；该值会被忽略'
+    suggestion: 使用 /config 在用户设置中启用远程控制，或在此处将该字段设置为 false 以针对项目禁用。
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -1313,6 +1313,11 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline must be unrestricted, small, medium, or large (got %{actual})
     suggestion: Set workflowSizeGuideline to one of unrestricted, small, medium, or large.
+  cc_set_021:
+    message: 'remoteControlAtStartup: true cannot enable Remote Control from project settings in Claude Code 2.1.222+;
+      this value is ignored'
+    suggestion: Enable Remote Control in user settings with /config, or set this field to false to disable it for the
+      project.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -826,6 +826,11 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline debe ser unrestricted, small, medium o large (se obtuvo %{actual})
     suggestion: Establece workflowSizeGuideline en unrestricted, small, medium o large.
+  cc_set_021:
+    message: 'remoteControlAtStartup: true no puede habilitar Remote Control desde la configuracion del proyecto en Claude
+      Code 2.1.222+; este valor se ignora'
+    suggestion: Habilita Remote Control en la configuracion de usuario con /config, o establece este campo en false para
+      deshabilitarlo en el proyecto.
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -779,6 +779,9 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline 必须是 unrestricted、small、medium 或 large（实际为 %{actual}）
     suggestion: 将 workflowSizeGuideline 设置为 unrestricted、small、medium 或 large。
+  cc_set_021:
+    message: 'Claude Code 2.1.222+ 无法通过项目设置中的 remoteControlAtStartup: true 启用远程控制；该值会被忽略'
+    suggestion: 使用 /config 在用户设置中启用远程控制，或在此处将该字段设置为 false 以针对项目禁用。
 
 
 # ===========================================================================

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -25,6 +25,7 @@
 //! - `emojiCompletionEnabled` boolean check (CC-SET-018, added in Claude Code v2.1.217).
 //! - `sandbox.network.strictAllowlist` boolean check (CC-SET-019, added in Claude Code v2.1.219).
 //! - `workflowSizeGuideline` enum check (CC-SET-020, added in Claude Code v2.1.219).
+//! - ineffective project-level `remoteControlAtStartup: true` (CC-SET-021, changed in Claude Code v2.1.222).
 //!
 //! Runs on FileType::Hooks (which covers `.claude/settings.json` -
 //! see `file_types/detection.rs`). Skips non-Claude Code settings paths
@@ -59,6 +60,7 @@ const RULE_IDS: &[&str] = &[
     "CC-SET-018",
     "CC-SET-019",
     "CC-SET-020",
+    "CC-SET-021",
 ];
 
 /// Allowed values for `worktree.baseRef` per Claude Code v2.1.133 release notes.
@@ -187,6 +189,10 @@ impl Validator for ClaudeSettingsValidator {
 
         if config.is_rule_enabled("CC-SET-020") {
             validate_workflow_size_guideline(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-021") {
+            validate_remote_control_at_startup_scope(path, content, &value, &mut diagnostics);
         }
 
         diagnostics
@@ -1796,6 +1802,39 @@ fn validate_workflow_size_guideline(
             t!("rules.cc_set_020.message", actual = actual),
         )
         .with_suggestion(t!("rules.cc_set_020.suggestion")),
+    );
+}
+
+/// CC-SET-021: Warn when project settings try to enable Remote Control.
+///
+/// Claude Code 2.1.222 stopped honoring `remoteControlAtStartup: true` in
+/// repo-local settings. A project may still set it to `false` to disable
+/// Remote Control, while enabling it must happen at user scope via `/config`.
+/// Managed settings remain an honored policy tier and are excluded.
+fn validate_remote_control_at_startup_scope(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let is_managed = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "managed-settings.json");
+    if is_managed || value.get("remoteControlAtStartup") != Some(&serde_json::Value::Bool(true)) {
+        return;
+    }
+
+    let line = find_key_line(content, "remoteControlAtStartup").unwrap_or(1);
+    diagnostics.push(
+        Diagnostic::warning(
+            path.to_path_buf(),
+            line,
+            0,
+            "CC-SET-021",
+            t!("rules.cc_set_021.message"),
+        )
+        .with_suggestion(t!("rules.cc_set_021.suggestion")),
     );
 }
 
@@ -3998,5 +4037,75 @@ mod tests {
                 "expected one hit for {invalid}"
             );
         }
+    }
+
+    // ===== CC-SET-021: project-level Remote Control auto-start =====
+
+    #[test]
+    fn test_remote_control_at_startup_true_flags_project_settings() {
+        let content = r#"{"remoteControlAtStartup": true}"#;
+        for path in [".claude/settings.json", ".claude/settings.local.json"] {
+            let diagnostics = validate_at(path, content);
+            assert_eq!(
+                diagnostics
+                    .iter()
+                    .filter(|diagnostic| diagnostic.rule == "CC-SET-021")
+                    .count(),
+                1,
+                "expected one hit in {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_remote_control_at_startup_false_null_and_absent_are_valid() {
+        for content in [
+            r#"{"remoteControlAtStartup": false}"#,
+            r#"{"remoteControlAtStartup": null}"#,
+            r#"{"model": "sonnet"}"#,
+        ] {
+            assert!(
+                validate(content)
+                    .iter()
+                    .all(|diagnostic| diagnostic.rule != "CC-SET-021"),
+                "unexpected CC-SET-021 for {content}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_remote_control_at_startup_true_is_allowed_in_managed_settings() {
+        let diagnostics = validate_at(
+            ".claude/managed-settings.json",
+            r#"{"remoteControlAtStartup": true}"#,
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.rule != "CC-SET-021")
+        );
+    }
+
+    #[test]
+    fn test_remote_control_at_startup_diagnostic_points_to_key_and_can_be_disabled() {
+        let content = "{\n  \"model\": \"sonnet\",\n  \"remoteControlAtStartup\": true\n}";
+        let diagnostics = validate(content);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.rule == "CC-SET-021")
+            .expect("CC-SET-021 diagnostic");
+        assert_eq!(diagnostic.line, 3);
+
+        let mut builder = LintConfig::builder();
+        builder.disable_rule("CC-SET-021");
+        let config = builder.build().expect("valid config");
+        let path = PathBuf::from(".claude/settings.json");
+        let per_file = config.for_path(&path);
+        assert!(
+            ClaudeSettingsValidator
+                .validate(&path, content, &per_file)
+                .iter()
+                .all(|diagnostic| diagnostic.rule != "CC-SET-021")
+        );
     }
 }

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use regex::Regex;
 use rust_i18n::t;
-use serde::Deserialize;
+use serde::{Deserialize, de::Error as _};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -43,12 +43,37 @@ where
     }))
 }
 
+fn de_string_map<'de, D>(deserializer: D) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_yaml::Value::deserialize(deserializer)?;
+    let serde_yaml::Value::Mapping(entries) = value else {
+        return Err(D::Error::custom(
+            "metadata must be a map from string keys to string values",
+        ));
+    };
+
+    let mut metadata = HashMap::with_capacity(entries.len());
+    for (key, value) in entries {
+        let (serde_yaml::Value::String(key), serde_yaml::Value::String(value)) = (key, value)
+        else {
+            return Err(D::Error::custom(
+                "metadata must be a map from string keys to string values",
+            ));
+        };
+        metadata.insert(key, value);
+    }
+    Ok(Some(metadata))
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct SkillFrontmatter {
     name: Option<String>,
     description: Option<String>,
     license: Option<String>,
     compatibility: Option<String>,
+    #[serde(default, deserialize_with = "de_string_map")]
     metadata: Option<HashMap<String, String>>,
     // Claude Code accepts `allowed-tools` as a space-separated string OR a YAML
     // list; agentskills.io documents a space-separated string. Deserialize both

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -2498,6 +2498,73 @@ Body content"#;
 }
 
 #[test]
+fn test_as_016_metadata_requires_string_keys_and_values() {
+    let validator = SkillValidator;
+    let valid = r#"---
+name: test-skill
+description: Use when validating Agent Skills metadata
+metadata:
+  owner: platform
+---
+Body"#;
+    let valid_diagnostics = validator.validate(
+        Path::new("skills/test-skill/SKILL.md"),
+        valid,
+        &LintConfig::default(),
+    );
+    assert!(
+        valid_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule != "AS-016")
+    );
+
+    for invalid in [
+        r#"---
+name: test-skill
+description: Use when validating Agent Skills metadata
+metadata:
+  priority: 1
+---
+Body"#,
+        r#"---
+name: test-skill
+description: Use when validating Agent Skills metadata
+metadata:
+  owner:
+    team: platform
+---
+Body"#,
+        r#"---
+name: test-skill
+description: Use when validating Agent Skills metadata
+metadata:
+  1: platform
+---
+Body"#,
+        r#"---
+name: test-skill
+description: Use when validating Agent Skills metadata
+metadata: platform
+---
+Body"#,
+    ] {
+        let diagnostics = validator.validate(
+            Path::new("skills/test-skill/SKILL.md"),
+            invalid,
+            &LintConfig::default(),
+        );
+        assert_eq!(
+            diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.rule == "AS-016")
+                .count(),
+            1,
+            "non-string metadata must fail frontmatter parsing"
+        );
+    }
+}
+
+#[test]
 fn test_as_016_allowed_tools_yaml_list_no_parse_error() {
     // Reproduces #957: `allowed-tools` as a YAML list previously failed to
     // deserialize (Option<String>) and tripped AS-016. Claude Code accepts a

--- a/crates/agnix-lsp/README.md
+++ b/crates/agnix-lsp/README.md
@@ -81,7 +81,7 @@ The extension automatically downloads the `agnix-lsp` binary. See `editors/zed/R
 
 - Real-time diagnostics as you type (via textDocument/didChange)
 - Real-time diagnostics on file open and save
-- Supports all agnix validation rules (444 rules)
+- Supports all agnix validation rules (445 rules)
 - Project-level validation for cross-file rules (AGM-006, XP-004/005/006, VER-001)
 
 - Maps diagnostic severity levels (Error, Warning, Info)

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -1313,6 +1313,11 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline must be unrestricted, small, medium, or large (got %{actual})
     suggestion: Set workflowSizeGuideline to one of unrestricted, small, medium, or large.
+  cc_set_021:
+    message: 'remoteControlAtStartup: true cannot enable Remote Control from project settings in Claude Code 2.1.222+;
+      this value is ignored'
+    suggestion: Enable Remote Control in user settings with /config, or set this field to false to disable it for the
+      project.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -826,6 +826,11 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline debe ser unrestricted, small, medium o large (se obtuvo %{actual})
     suggestion: Establece workflowSizeGuideline en unrestricted, small, medium o large.
+  cc_set_021:
+    message: 'remoteControlAtStartup: true no puede habilitar Remote Control desde la configuracion del proyecto en Claude
+      Code 2.1.222+; este valor se ignora'
+    suggestion: Habilita Remote Control en la configuracion de usuario con /config, o establece este campo en false para
+      deshabilitarlo en el proyecto.
 
 
 # ===========================================================================

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -779,6 +779,9 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline 必须是 unrestricted、small、medium 或 large（实际为 %{actual}）
     suggestion: 将 workflowSizeGuideline 设置为 unrestricted、small、medium 或 large。
+  cc_set_021:
+    message: 'Claude Code 2.1.222+ 无法通过项目设置中的 remoteControlAtStartup: true 启用远程控制；该值会被忽略'
+    suggestion: 使用 /config 在用户设置中启用远程控制，或在此处将该字段设置为 false 以针对项目禁用。
 
 
 # ===========================================================================

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 444,
-  "last_updated": "2026-08-01",
+  "total_rules": 445,
+  "last_updated": "2026-08-05",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -354,7 +354,7 @@
         "source_urls": [
           "https://agentskills.io/specification"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-08-05",
         "applies_to": {
           "spec_revision": "1.0"
         },
@@ -712,8 +712,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "---\nname: valid-yaml\ndescription: Use when demonstrating valid YAML frontmatter\n---\nBody content here.",
-      "bad_example": "---\nname: broken-yaml\ndescription: [unclosed bracket\n---\nBody content here."
+      "good_example": "---\nname: valid-yaml\ndescription: Use when demonstrating valid YAML frontmatter\nmetadata:\n  owner: platform\n---\nBody content here.",
+      "bad_example": "---\nname: broken-yaml\ndescription: Use when demonstrating invalid metadata\nmetadata:\n  priority: 1\n---\nBody content here."
     },
     {
       "id": "AS-017",
@@ -4200,6 +4200,36 @@
       "bad_example": "{\n  \"workflowSizeGuideline\": \"tiny\"\n}"
     },
     {
+      "id": "CC-SET-021",
+      "name": "Ineffective Project Remote Control Auto-start",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.222",
+          "https://code.claude.com/docs/en/settings",
+          "https://code.claude.com/docs/en/remote-control"
+        ],
+        "verified_on": "2026-08-05",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.222"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"remoteControlAtStartup\": false\n}",
+      "bad_example": "{\n  \"remoteControlAtStartup\": true\n}"
+    },
+    {
       "id": "CDX-000",
       "name": "TOML Parse Error",
       "severity": "HIGH",
@@ -7575,7 +7605,7 @@
           "https://cursor.com/docs/cloud-agent/setup",
           "https://cursor.com/schemas/environment.schema.json"
         ],
-        "verified_on": "2026-08-01",
+        "verified_on": "2026-08-05",
         "applies_to": {
           "tool": "cursor"
         },
@@ -13037,7 +13067,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 20,
+      "count": 21,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -300,6 +300,6 @@ cargo install agnix-lsp
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for frontmatter fields
-- 444 validation rules
+- 445 validation rules
 - Status bar indicator (VS Code)
 - Syntax highlighting for SKILL.md (VS Code)

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,7 +3,7 @@
 Real-time validation for AI agent configuration files in VS Code.
 Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix).
 
-**444 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
+**445 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
 
 
 ## Features
@@ -11,7 +11,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Real-time validation** - Diagnostics as you type
 - **Context-aware completions** - Frontmatter keys, values, and snippets
 - **JSON Schema validation and autocomplete for `.agnix.toml` config files**
-- **Validates 444 rules** - From official specs and best practices
+- **Validates 445 rules** - From official specs and best practices
 
 - **Diagnostics panel** - Sidebar tree view of all issues by file
 - **CodeLens** - Rule info shown inline above problematic lines
@@ -45,7 +45,7 @@ Access via Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | `agnix: Fix All Issues in File` | `Ctrl+Shift+.` | Apply all available fixes |
 | `agnix: Preview Fixes` | - | Browse fixes with diff preview |
 | `agnix: Fix All Safe Issues` | `Ctrl+Alt+.` | Apply only safe fixes |
-| `agnix: Show All Rules` | - | Browse 444 rules by category |
+| `agnix: Show All Rules` | - | Browse 445 rules by category |
 
 | `agnix: Show Rule Documentation` | - | Open docs for a rule (via CodeLens) |
 | `agnix: Ignore Rule in Project` | - | Add rule to `.agnix.toml` disabled list |

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 444 validation rules across 40 categories, sourced from 75+ references
+> 445 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 444 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 445 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (444 rules)
+├── VALIDATION-RULES.md             # Master validation reference (445 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **444 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **445 rules** |
 
 
 ### Validation Rules by Category
@@ -97,7 +97,7 @@ knowledge-base/
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 20 | 0 | 19 | 1 | 0 |
+| Claude Settings | 21 | 0 | 20 | 1 | 0 |
 | Claude Skills | 20 | 10 | 9 | 1 | 10 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **444** | **215** | **199** | **30** | **124** |
+| **TOTAL** | **445** | **215** | **200** | **30** | **124** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 444 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 445 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     444 rules
+Validation Rules:     445 rules
 Auto-Fixable Rules:   124 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 444 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 445 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-08-04
+**Last Updated**: 2026-08-05
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -16,7 +16,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-04 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-05 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET |
 | Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json`, Agent Plugins root `plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-07-30 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
 | OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-04 | AGM, XP, OC |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/**/*.{json,md}`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-08-01 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
@@ -26,8 +26,8 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Weekly | 2026-07-26 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-04 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-01 | CUR, MCP |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-05 | CLN, CL-SK |
+| Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-05 | CUR, MCP |
 
 ### B Tier (test on significant changes if time permits)
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -199,9 +199,9 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="as-016"></a>
 ### AS-016 [HIGH] Skill Parse Error
-**Requirement**: SKILL.md frontmatter MUST be valid YAML
-**Detection**: YAML parse error on frontmatter content
-**Fix**: Fix YAML syntax errors in frontmatter
+**Requirement**: SKILL.md frontmatter MUST be valid YAML and match the Agent Skills field types. In particular, `metadata` is a map from string keys to string values.
+**Detection**: YAML syntax or typed-frontmatter parse error, including non-string `metadata` values
+**Fix**: Fix YAML syntax errors and use string keys and values in `metadata`
 **Source**: agentskills.io/specification
 
 <a id="as-017"></a>
@@ -495,6 +495,13 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 **Detection**: Parse settings JSON and flag non-string values or strings outside the documented enum
 **Fix**: Manual - choose one of the four documented values
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.219, code.claude.com/docs/en/settings
+
+<a id="cc-set-021"></a>
+### CC-SET-021 [MEDIUM] Ineffective Project Remote Control Auto-start
+**Requirement**: Project-level `.claude/settings.json` and `.claude/settings.local.json` SHOULD NOT set `remoteControlAtStartup` to `true` in Claude Code 2.1.222+. Enabling Remote Control from repository settings is ignored; `false` remains valid for disabling it in that project.
+**Detection**: Parse project settings JSON and flag a strict `true` value for `remoteControlAtStartup`. Ignore `false`, `null`, absent values, and managed settings.
+**Fix**: Manual - enable Remote Control in user settings through `/config`, or set the project value to `false` when the project should disable it.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.222, code.claude.com/docs/en/settings, code.claude.com/docs/en/remote-control
 
 ---
 
@@ -3558,7 +3565,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 20 | 0 | 19 | 1 | 0 |
+| Claude Settings | 21 | 0 | 20 | 1 | 0 |
 | Claude Skills | 20 | 10 | 9 | 1 | 10 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -3589,7 +3596,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **444** | **215** | **199** | **30** | **124** |
+| **TOTAL** | **445** | **215** | **200** | **30** | **124** |
 
 
 ---
@@ -3619,8 +3626,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 444 validation rules across 40 categories
+**Total Coverage**: 445 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 215 HIGH, 199 MEDIUM, 30 LOW
+**Certainty**: 215 HIGH, 200 MEDIUM, 30 LOW
 **Auto-Fixable**: 124 rules (28%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 444,
-  "last_updated": "2026-08-01",
+  "total_rules": 445,
+  "last_updated": "2026-08-05",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -354,7 +354,7 @@
         "source_urls": [
           "https://agentskills.io/specification"
         ],
-        "verified_on": "2026-02-04",
+        "verified_on": "2026-08-05",
         "applies_to": {
           "spec_revision": "1.0"
         },
@@ -712,8 +712,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "---\nname: valid-yaml\ndescription: Use when demonstrating valid YAML frontmatter\n---\nBody content here.",
-      "bad_example": "---\nname: broken-yaml\ndescription: [unclosed bracket\n---\nBody content here."
+      "good_example": "---\nname: valid-yaml\ndescription: Use when demonstrating valid YAML frontmatter\nmetadata:\n  owner: platform\n---\nBody content here.",
+      "bad_example": "---\nname: broken-yaml\ndescription: Use when demonstrating invalid metadata\nmetadata:\n  priority: 1\n---\nBody content here."
     },
     {
       "id": "AS-017",
@@ -4200,6 +4200,36 @@
       "bad_example": "{\n  \"workflowSizeGuideline\": \"tiny\"\n}"
     },
     {
+      "id": "CC-SET-021",
+      "name": "Ineffective Project Remote Control Auto-start",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.222",
+          "https://code.claude.com/docs/en/settings",
+          "https://code.claude.com/docs/en/remote-control"
+        ],
+        "verified_on": "2026-08-05",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.222"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"remoteControlAtStartup\": false\n}",
+      "bad_example": "{\n  \"remoteControlAtStartup\": true\n}"
+    },
+    {
       "id": "CDX-000",
       "name": "TOML Parse Error",
       "severity": "HIGH",
@@ -7575,7 +7605,7 @@
           "https://cursor.com/docs/cloud-agent/setup",
           "https://cursor.com/schemas/environment.schema.json"
         ],
-        "verified_on": "2026-08-01",
+        "verified_on": "2026-08-05",
         "applies_to": {
           "tool": "cursor"
         },
@@ -13037,7 +13067,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 20,
+      "count": 21,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1313,6 +1313,11 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline must be unrestricted, small, medium, or large (got %{actual})
     suggestion: Set workflowSizeGuideline to one of unrestricted, small, medium, or large.
+  cc_set_021:
+    message: 'remoteControlAtStartup: true cannot enable Remote Control from project settings in Claude Code 2.1.222+;
+      this value is ignored'
+    suggestion: Enable Remote Control in user settings with /config, or set this field to false to disable it for the
+      project.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -826,6 +826,11 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline debe ser unrestricted, small, medium o large (se obtuvo %{actual})
     suggestion: Establece workflowSizeGuideline en unrestricted, small, medium o large.
+  cc_set_021:
+    message: 'remoteControlAtStartup: true no puede habilitar Remote Control desde la configuracion del proyecto en Claude
+      Code 2.1.222+; este valor se ignora'
+    suggestion: Habilita Remote Control en la configuracion de usuario con /config, o establece este campo en false para
+      deshabilitarlo en el proyecto.
 
 
 # ===========================================================================

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -779,6 +779,9 @@ rules:
   cc_set_020:
     message: workflowSizeGuideline 必须是 unrestricted、small、medium 或 large（实际为 %{actual}）
     suggestion: 将 workflowSizeGuideline 设置为 unrestricted、small、medium 或 large。
+  cc_set_021:
+    message: 'Claude Code 2.1.222+ 无法通过项目设置中的 remoteControlAtStartup: true 启用远程控制；该值会被忽略'
+    suggestion: 使用 /config 在用户设置中启用远程控制，或在此处将该字段设置为 false 以针对项目禁用。
 
 
 # ===========================================================================

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.45.0",
-  "description": "Lint agent configurations before they break your workflow. 444 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 445 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "aviarchi1994@gmail.com",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 444 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 445 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 444 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 445 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/sk/meta-skill/SKILL.md
+++ b/sk/meta-skill/SKILL.md
@@ -1,8 +1,0 @@
----
-name: meta-skill
-description: Use when checking metadata parsing of unquoted numeric values in frontmatter.
-metadata:
-  author: example-org
-  version: 1.0
----
-Body.

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 444 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 445 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 444 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 445 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -73,6 +73,6 @@ GitHub Copilot validation is enabled by default and can be targeted in config wi
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 444 rules
+- [Rules Reference](./rules/index.md) - browse all 445 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 444 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 445 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 444 rules derived from official specs and real-world testing
+- **Validates** configuration files against 445 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 444 validation rules
+- [Rules Reference](./rules/index.md) - browse all 445 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics

--- a/website/docs/rules/generated/as-001.md
+++ b/website/docs/rules/generated/as-001.md
@@ -13,7 +13,7 @@ keywords: ["AS-001", "missing frontmatter", "agent skills", "validation", "agnix
 - **Category**: `Agent Skills`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `Yes (safe)`
-- **Verified On**: `2026-02-04`
+- **Verified On**: `2026-08-05`
 
 ## Applicability
 

--- a/website/docs/rules/generated/as-016.md
+++ b/website/docs/rules/generated/as-016.md
@@ -40,7 +40,9 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ```markdown
 ---
 name: broken-yaml
-description: [unclosed bracket
+description: Use when demonstrating invalid metadata
+metadata:
+  priority: 1
 ---
 Body content here.
 ```
@@ -51,6 +53,8 @@ Body content here.
 ---
 name: valid-yaml
 description: Use when demonstrating valid YAML frontmatter
+metadata:
+  owner: platform
 ---
 Body content here.
 ```

--- a/website/docs/rules/generated/cc-set-021.md
+++ b/website/docs/rules/generated/cc-set-021.md
@@ -1,0 +1,54 @@
+---
+id: cc-set-021
+title: "CC-SET-021: Ineffective Project Remote Control Auto-start"
+sidebar_label: "CC-SET-021"
+description: "agnix rule CC-SET-021 checks for ineffective project remote control auto-start in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-021", "ineffective project remote control auto-start", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-021`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `SHOULD`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-08-05`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.222`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.222
+- https://code.claude.com/docs/en/settings
+- https://code.claude.com/docs/en/remote-control
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "remoteControlAtStartup": true
+}
+```
+
+### Valid
+
+```json
+{
+  "remoteControlAtStartup": false
+}
+```

--- a/website/docs/rules/generated/cur-016.md
+++ b/website/docs/rules/generated/cur-016.md
@@ -13,7 +13,7 @@ keywords: ["CUR-016", "invalid cursor environment schema", "cursor", "validation
 - **Category**: `Cursor`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-08-01`
+- **Verified On**: `2026-08-05`
 
 ## Applicability
 

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `444` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `445` validation rules generated from `knowledge-base/rules.json`.
 `124` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -149,6 +149,7 @@ This section contains all `444` validation rules generated from `knowledge-base/
 | [CC-SET-018](./generated/cc-set-018.md) | Non-boolean emojiCompletionEnabled Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-019](./generated/cc-set-019.md) | Non-boolean sandbox.network.strictAllowlist Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-020](./generated/cc-set-020.md) | Invalid workflowSizeGuideline Setting | MEDIUM | Claude Settings | No |
+| [CC-SET-021](./generated/cc-set-021.md) | Ineffective Project Remote Control Auto-start | MEDIUM | Claude Settings | No |
 | [CDX-000](./generated/cdx-000.md) | TOML Parse Error | HIGH | Codex CLI | No |
 | [CDX-001](./generated/cdx-001.md) | Invalid Approval Mode | HIGH | Codex CLI | Yes (unsafe) |
 | [CDX-002](./generated/cdx-002.md) | Invalid Full Auto Error Mode | HIGH | Codex CLI | Yes (unsafe) |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 444,
+  "totalRules": 445,
   "categoryCount": 40,
   "autofixCount": 124,
   "uniqueTools": [


### PR DESCRIPTION
## Summary

- enforce the Agent Skills specification's string-to-string `metadata` map and refresh the Agent Skills baseline
- add `CC-SET-021` for ignored project-level `remoteControlAtStartup: true` in Claude Code 2.1.222+
- review and refresh the Cursor environment/spec baseline and release marker
- review Cline v4.1.4 as having no changes to validated `.clinerules`, workflow, hook, or skill surfaces
- regenerate rule docs and bookkeeping for 445 rules

Addresses #1316, #1317, #1318, and #1319.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p agnix-cli --test kiro_ci_gate -- --include-ignored`
- `node scripts/sync-rule-bookkeeping.js --check`
- `git diff --check`
- live `scripts/check-tool-releases.sh` sweep: all baselines current after Cline v4.1.4 update
