### PR TITLE
Align Claude schemas with current documentation

### DIFF
--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Baseline hashes for canonical specification content. Human-facing URLs are kept separately from machine-readable content URLs.",
-  "last_updated": "2026-08-05T00:00:00Z",
+  "last_updated": "2026-08-09T09:41:00Z",
   "sources": {
     "s-tier": {
       "agent-skills-spec": {
@@ -117,7 +117,7 @@
       "claude-code-memory": {
         "url": "https://code.claude.com/docs/en/memory",
         "content_url": "https://code.claude.com/docs/en/memory.md",
-        "hash": "eea3a7b7d4da9409c6a627e26142373f52171526fcfe901070ac77d20cf15513",
+        "hash": "a4559956d8451c7133362cc3230c16712f8d5c68fcd1a2122bd5a2600181af56",
         "rules": [
           "CC-MEM-001",
           "CC-MEM-002",
@@ -128,7 +128,7 @@
       "claude-code-hooks": {
         "url": "https://code.claude.com/docs/en/hooks",
         "content_url": "https://code.claude.com/docs/en/hooks.md",
-        "hash": "b318b60616297d4a5a8c83d628a2061bf2c65dc0d05a17b5579482b971165ebb",
+        "hash": "7a561d9a32dc7a42fbb83bfc137b9c0f21cad45e1e9a25a81f3622bca118adc6",
         "rules": [
           "CC-HK-001",
           "CC-HK-002",
@@ -146,18 +146,20 @@
       "claude-code-skills": {
         "url": "https://code.claude.com/docs/en/skills",
         "content_url": "https://code.claude.com/docs/en/skills.md",
-        "hash": "1f08c689cea03dc2d12ff6646c33b740a3219ba0c2bec960ac05fcd7a4a4c308",
+        "hash": "b52706dee098407fad34e0162b6799b971a29738e25ce0e0eccbe13c69c95b4c",
         "rules": [
           "CC-SK-001",
           "CC-SK-002",
           "CC-SK-004",
-          "CC-SK-006"
+          "CC-SK-006",
+          "CC-SK-008",
+          "CC-SK-017"
         ]
       },
       "claude-code-plugins": {
         "url": "https://code.claude.com/docs/en/plugins-reference",
         "content_url": "https://code.claude.com/docs/en/plugins-reference.md",
-        "hash": "a07104858eefd300ed179c1e8727d5d92d1611140f0e524e82f68ae010e13cf7",
+        "hash": "59d788845be508a182bae5cde6dba663e4eb8d3e77b43bf8c6088cce40ec6027",
         "rules": [
           "CC-PL-002",
           "CC-PL-003",
@@ -169,7 +171,7 @@
       "claude-code-subagents": {
         "url": "https://code.claude.com/docs/en/sub-agents",
         "content_url": "https://code.claude.com/docs/en/sub-agents.md",
-        "hash": "5b209909ee8304b3af61709d9a5fe7bacaf87feeec9b1dc8f8c48b3f4136d4cb",
+        "hash": "a9a788cd9bc21cb95e860c4ab6e63efe6b1c406e8f0aa1aee8e66ce5e128037e",
         "rules": [
           "CC-AG-001",
           "CC-AG-002",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Claude Code skill and hook schema compatibility**. Accept skills without
+  explicit `name` or `description`, validate the documented `disallowed-tools`
+  field with the existing Claude tool vocabulary, and parse prompt-hook
+  `continueOnBlock` as a boolean.
+- **Claude Code specification baselines**. Advance the reviewed hooks, memory,
+  plugins, skills, and subagent documentation hashes after auditing the current
+  validation contracts.
+
 ## [0.47.0] - 2026-08-08
 
 ### Added

--- a/crates/agnix-core/src/rules/hooks/tests.rs
+++ b/crates/agnix-core/src/rules/hooks/tests.rs
@@ -2620,6 +2620,48 @@ fn test_cc_hk_012_valid_json_no_error() {
 }
 
 #[test]
+fn test_cc_hk_012_prompt_continue_on_block_boolean_is_valid() {
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [{
+                "hooks": [{
+                    "type": "prompt",
+                    "prompt": "Check the request: $ARGUMENTS",
+                    "continueOnBlock": true
+                }]
+            }]
+        }
+    }"#;
+
+    let diagnostics = validate(content);
+    assert!(
+        diagnostics.iter().all(|d| d.rule != "CC-HK-012"),
+        "documented continueOnBlock boolean must parse: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn test_cc_hk_012_prompt_continue_on_block_rejects_non_boolean() {
+    let content = r#"{
+        "hooks": {
+            "PreToolUse": [{
+                "hooks": [{
+                    "type": "prompt",
+                    "prompt": "Check the request: $ARGUMENTS",
+                    "continueOnBlock": "yes"
+                }]
+            }]
+        }
+    }"#;
+
+    let diagnostics = validate(content);
+    assert_eq!(
+        diagnostics.iter().filter(|d| d.rule == "CC-HK-012").count(),
+        1
+    );
+}
+
+#[test]
 fn test_cc_hk_012_disabled() {
     let mut config = LintConfig::default();
     config.rules_mut().disabled_rules = vec!["CC-HK-012".to_string()];

--- a/crates/agnix-core/src/rules/per_client_skill.rs
+++ b/crates/agnix-core/src/rules/per_client_skill.rs
@@ -188,8 +188,13 @@ fn is_claude_plugin_skill(path: &Path, config: &LintConfig) -> bool {
         };
 
         if declared_paths.into_iter().any(|declared| {
-            safe_plugin_relative_path(declared)
-                .is_some_and(|relative| path.starts_with(plugin_root.join(relative)))
+            safe_plugin_relative_path(declared).is_some_and(|relative| {
+                if relative.as_os_str().is_empty() {
+                    path.parent() == Some(plugin_root)
+                } else {
+                    path.starts_with(plugin_root.join(relative))
+                }
+            })
         }) {
             return true;
         }
@@ -661,6 +666,11 @@ mod tests {
         assert_eq!(
             resolve_skill_client(&plugin_root.join("SKILL.md"), &LintConfig::default()),
             SkillClient::ClaudeCode
+        );
+        assert_eq!(
+            resolve_skill_client(&plugin_root.join("docs/SKILL.md"), &LintConfig::default()),
+            SkillClient::Unknown,
+            "skills: \".\" must not claim nested SKILL.md files"
         );
     }
 

--- a/crates/agnix-core/src/rules/per_client_skill.rs
+++ b/crates/agnix-core/src/rules/per_client_skill.rs
@@ -9,7 +9,7 @@ use crate::diagnostics::{Diagnostic, Fix};
 use crate::parsers::frontmatter::split_frontmatter;
 use crate::rules::{Validator, ValidatorMetadata};
 use rust_i18n::t;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 /// Known clients that host SKILL.md files.
 ///
@@ -119,29 +119,79 @@ pub(crate) fn detect_client(path: &Path) -> SkillClient {
     SkillClient::Unknown
 }
 
+/// Normalize a plugin component path without allowing it to escape the plugin
+/// root. Claude accepts both `/` and `\` separators in manifest paths.
+fn safe_plugin_relative_path(raw: &str) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let normalized = trimmed.replace('\\', "/");
+    let bytes = normalized.as_bytes();
+    if bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':' {
+        return None;
+    }
+
+    let mut relative = PathBuf::new();
+    for component in Path::new(&normalized).components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => relative.push(part),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    Some(relative)
+}
+
 /// Return whether `path` is a skill owned by a Claude Code plugin.
 ///
-/// Claude plugins may expose either a root `SKILL.md` or skills below the
-/// plugin's `skills/` directory. Require the documented sibling manifest so a
-/// generic `skills/foo/SKILL.md` tree is not misclassified as Claude-owned.
+/// Claude always scans the plugin root's `skills/` directory and loads any
+/// additional string or array paths declared by the manifest's `skills` field.
+/// Require the documented sibling manifest so a generic `skills/foo/SKILL.md`
+/// tree is not misclassified as Claude-owned.
 fn is_claude_plugin_skill(path: &Path, config: &LintConfig) -> bool {
+    if path.file_name().and_then(|name| name.to_str()) != Some("SKILL.md") {
+        return false;
+    }
+
     let Some(parent) = path.parent() else {
         return false;
     };
 
-    let has_manifest = |root: &Path| {
-        config
-            .fs()
-            .is_file(&root.join(".claude-plugin").join("plugin.json"))
-    };
+    for plugin_root in parent.ancestors() {
+        let manifest_path = plugin_root.join(".claude-plugin").join("plugin.json");
+        if !config.fs().is_file(&manifest_path) {
+            continue;
+        }
 
-    if path.file_name().and_then(|name| name.to_str()) == Some("SKILL.md") && has_manifest(parent) {
-        return true;
-    }
+        if path.starts_with(plugin_root.join("skills")) {
+            return true;
+        }
 
-    for ancestor in parent.ancestors() {
-        if ancestor.file_name().and_then(|name| name.to_str()) == Some("skills") {
-            return ancestor.parent().is_some_and(has_manifest);
+        let Ok(manifest_content) = config.fs().read_to_string(&manifest_path) else {
+            continue;
+        };
+        let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&manifest_content) else {
+            continue;
+        };
+        let Some(declared_skills) = manifest.get("skills") else {
+            continue;
+        };
+
+        let declared_paths: Vec<&str> = match declared_skills {
+            serde_json::Value::String(path) => vec![path],
+            serde_json::Value::Array(paths) => {
+                paths.iter().filter_map(serde_json::Value::as_str).collect()
+            }
+            _ => Vec::new(),
+        };
+
+        if declared_paths.into_iter().any(|declared| {
+            safe_plugin_relative_path(declared)
+                .is_some_and(|relative| path.starts_with(plugin_root.join(relative)))
+        }) {
+            return true;
         }
     }
 
@@ -335,7 +385,7 @@ impl Validator for PerClientSkillValidator {
             return diagnostics;
         }
 
-        let client = detect_client(path);
+        let client = resolve_skill_client(path, config);
 
         let per_client_rule = rule_id_for_client(client);
         let has_per_client = per_client_rule
@@ -600,9 +650,66 @@ mod tests {
             ),
             SkillClient::ClaudeCode
         );
+
+        assert_eq!(
+            resolve_skill_client(&plugin_root.join("SKILL.md"), &LintConfig::default()),
+            SkillClient::Unknown,
+            "a root skill must be declared with skills: \".\""
+        );
+
+        fs::write(&manifest, r#"{"skills":"."}"#).unwrap();
         assert_eq!(
             resolve_skill_client(&plugin_root.join("SKILL.md"), &LintConfig::default()),
             SkillClient::ClaudeCode
+        );
+    }
+
+    #[test]
+    fn test_resolve_skill_client_claude_plugin_custom_skill_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let plugin_root = temp.path().join("my-plugin");
+        let manifest = plugin_root.join(".claude-plugin").join("plugin.json");
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::write(
+            &manifest,
+            r#"{"skills":["./custom-skills",".\\more-skills"]}"#,
+        )
+        .unwrap();
+
+        for relative in [
+            "custom-skills/review/SKILL.md",
+            "more-skills/deploy/SKILL.md",
+        ] {
+            assert_eq!(
+                resolve_skill_client(&plugin_root.join(relative), &LintConfig::default()),
+                SkillClient::ClaudeCode
+            );
+        }
+    }
+
+    #[test]
+    fn test_resolve_skill_client_rejects_escaping_plugin_skill_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let plugin_root = temp.path().join("my-plugin");
+        let manifest = plugin_root.join(".claude-plugin").join("plugin.json");
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::write(&manifest, r#"{"skills":"../external-skills"}"#).unwrap();
+
+        assert_eq!(
+            resolve_skill_client(
+                &temp.path().join("external-skills/review/SKILL.md"),
+                &LintConfig::default()
+            ),
+            SkillClient::Unknown
+        );
+
+        fs::write(&manifest, r#"{"skills":"C:\\external-skills"}"#).unwrap();
+        assert_eq!(
+            resolve_skill_client(
+                &plugin_root.join("C:/external-skills/review/SKILL.md"),
+                &LintConfig::default()
+            ),
+            SkillClient::Unknown
         );
     }
 
@@ -661,6 +768,28 @@ mod tests {
             per_client.is_empty(),
             "Claude Code should have no per-client or XP-SK-001 warnings, got {:?}",
             per_client
+        );
+    }
+
+    #[test]
+    fn test_claude_plugin_custom_skill_skips_cross_platform_warning() {
+        let temp = tempfile::tempdir().unwrap();
+        let plugin_root = temp.path().join("my-plugin");
+        let manifest = plugin_root.join(".claude-plugin").join("plugin.json");
+        let skill_path = plugin_root.join("custom-skills/review/SKILL.md");
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::write(&manifest, r#"{"skills":"./custom-skills"}"#).unwrap();
+
+        let content = make_skill(
+            "description: Review changes\ndisallowed-tools: Bash",
+            "Body",
+        );
+        let diagnostics =
+            PerClientSkillValidator.validate(&skill_path, &content, &LintConfig::default());
+
+        assert!(
+            !diagnostics.iter().any(|d| d.rule == "XP-SK-001"),
+            "Claude-only fields in manifest-owned skills are not portability issues: {diagnostics:?}"
         );
     }
 

--- a/crates/agnix-core/src/rules/per_client_skill.rs
+++ b/crates/agnix-core/src/rules/per_client_skill.rs
@@ -119,6 +119,35 @@ pub(crate) fn detect_client(path: &Path) -> SkillClient {
     SkillClient::Unknown
 }
 
+/// Return whether `path` is a skill owned by a Claude Code plugin.
+///
+/// Claude plugins may expose either a root `SKILL.md` or skills below the
+/// plugin's `skills/` directory. Require the documented sibling manifest so a
+/// generic `skills/foo/SKILL.md` tree is not misclassified as Claude-owned.
+fn is_claude_plugin_skill(path: &Path, config: &LintConfig) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+
+    let has_manifest = |root: &Path| {
+        config
+            .fs()
+            .is_file(&root.join(".claude-plugin").join("plugin.json"))
+    };
+
+    if path.file_name().and_then(|name| name.to_str()) == Some("SKILL.md") && has_manifest(parent) {
+        return true;
+    }
+
+    for ancestor in parent.ancestors() {
+        if ancestor.file_name().and_then(|name| name.to_str()) == Some("skills") {
+            return ancestor.parent().is_some_and(has_manifest);
+        }
+    }
+
+    false
+}
+
 /// Map a `tools = [...]` entry (or `--tools` value) to a [`SkillClient`].
 /// Matching is case-insensitive to tolerate configs that use different casing.
 fn skill_client_from_tool_str(tool: &str) -> Option<SkillClient> {
@@ -150,6 +179,9 @@ pub(crate) fn resolve_skill_client(path: &Path, config: &LintConfig) -> SkillCli
     let by_path = detect_client(path);
     if by_path != SkillClient::Unknown {
         return by_path;
+    }
+    if is_claude_plugin_skill(path, config) {
+        return SkillClient::ClaudeCode;
     }
 
     let mut from_tools = config
@@ -437,6 +469,7 @@ mod tests {
     use super::*;
     use crate::config::LintConfig;
     use crate::rules::Validator;
+    use std::fs;
 
     fn make_skill(frontmatter: &str, body: &str) -> String {
         format!("---\n{}\n---\n{}", frontmatter, body)
@@ -549,6 +582,39 @@ mod tests {
         assert_eq!(
             detect_client(Path::new("projects/foo/.cursor/skills/review/SKILL.md")),
             SkillClient::Cursor
+        );
+    }
+
+    #[test]
+    fn test_resolve_skill_client_claude_plugin_layouts() {
+        let temp = tempfile::tempdir().unwrap();
+        let plugin_root = temp.path().join("my-plugin");
+        let manifest = plugin_root.join(".claude-plugin").join("plugin.json");
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::write(&manifest, "{}").unwrap();
+
+        assert_eq!(
+            resolve_skill_client(
+                &plugin_root.join("skills/review/SKILL.md"),
+                &LintConfig::default()
+            ),
+            SkillClient::ClaudeCode
+        );
+        assert_eq!(
+            resolve_skill_client(&plugin_root.join("SKILL.md"), &LintConfig::default()),
+            SkillClient::ClaudeCode
+        );
+    }
+
+    #[test]
+    fn test_resolve_skill_client_generic_skills_without_plugin_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_skill_client(
+                &temp.path().join("skills/review/SKILL.md"),
+                &LintConfig::default()
+            ),
+            SkillClient::Unknown
         );
     }
 

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -1930,6 +1930,26 @@ fn is_valid_skill_tool_name(tool: &str) -> bool {
     is_valid_mcp_tool_format(tool, KNOWN_TOOLS)
 }
 
+/// Derive Claude Code's command name when frontmatter omits `name`.
+///
+/// Directory-based skills use the directory name, including plugin-root
+/// `SKILL.md` files. Legacy command files use their Markdown file stem.
+fn derived_claude_skill_name(path: &Path) -> String {
+    if path.file_name().and_then(|name| name.to_str()) == Some("SKILL.md") {
+        return path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_string();
+    }
+
+    path.file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
 impl Validator for SkillValidator {
     fn metadata(&self) -> ValidatorMetadata {
         ValidatorMetadata {
@@ -2016,9 +2036,10 @@ impl Validator for SkillValidator {
                 name: frontmatter
                     .name
                     .as_deref()
-                    .unwrap_or_default()
-                    .trim()
-                    .to_string(),
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| derived_claude_skill_name(path)),
                 description: frontmatter
                     .description
                     .as_deref()

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -85,6 +85,12 @@ struct SkillFrontmatter {
         deserialize_with = "de_string_or_space_seq"
     )]
     allowed_tools: Option<String>,
+    #[serde(
+        rename = "disallowed-tools",
+        default,
+        deserialize_with = "de_string_or_space_seq"
+    )]
+    disallowed_tools: Option<String>,
     #[serde(rename = "argument-hint")]
     argument_hint: Option<String>,
     // Named positional arguments for `$name` substitution. "Accepts a
@@ -308,7 +314,7 @@ const KNOWN_FRONTMATTER_FIELDS: &[&str] = &[
     "name",
     "description",
     // Documented Claude Code skill fields (code.claude.com/docs/en/skills,
-    // verified 2026-05-24): `when_to_use` and `arguments` were missing.
+    // verified 2026-08-09): keep this list aligned with the documented table.
     "when_to_use",
     "arguments",
     // Claude Code v2.1.186 accepts kebab-case, snake_case, and camelCase for
@@ -324,6 +330,7 @@ const KNOWN_FRONTMATTER_FIELDS: &[&str] = &[
     "compatibility",
     "metadata",
     "allowed-tools",
+    "disallowed-tools",
     "argument-hint",
     "disable-model-invocation",
     "user-invocable",
@@ -622,6 +629,14 @@ impl<'a> ValidationContext<'a> {
 
     /// AS-002, AS-003: Validate required name and description fields
     fn validate_required_fields(&mut self, frontmatter: &SkillFrontmatter) {
+        // Claude Code treats every frontmatter field as optional: `name`
+        // defaults from the skill location, and `description` falls back to
+        // the first paragraph. AS-002/003 encode the stricter Agent Skills
+        // baseline and remain applicable to generic and other-client skills.
+        if self.client == SkillClient::ClaudeCode {
+            return;
+        }
+
         let (name_line, name_col) = self.frontmatter_key_line_col("name");
         let (description_line, description_col) = self.frontmatter_key_line_col("description");
 
@@ -1171,18 +1186,24 @@ impl<'a> ValidationContext<'a> {
     fn validate_cc_tools(&mut self, schema: &SkillSchema) {
         let (allowed_tools_line, allowed_tools_col) =
             self.frontmatter_key_line_col("allowed-tools");
+        let (disallowed_tools_line, disallowed_tools_col) =
+            self.frontmatter_key_line_col("disallowed-tools");
 
-        // Parse allowed_tools once for CC-SK-007 and CC-SK-008. Claude Code
-        // accepts comma- or space-separated entries, and scoped matchers can
-        // contain spaces inside parentheses like `Bash(git add *)`.
-        let tool_list: Option<Vec<&str>> = schema
+        // Claude Code accepts comma- or space-separated entries in both tool
+        // fields, and scoped matchers can contain spaces inside parentheses
+        // like `Bash(git add *)`.
+        let allowed_tool_list: Option<Vec<&str>> = schema
             .allowed_tools
+            .as_ref()
+            .map(|tools| split_tool_list(tools));
+        let disallowed_tool_list: Option<Vec<&str>> = schema
+            .disallowed_tools
             .as_ref()
             .map(|tools| split_tool_list(tools));
 
         // CC-SK-007: Unrestricted Bash warning
         if self.config.is_rule_enabled("CC-SK-007") {
-            if let Some(ref tools) = tool_list {
+            if let Some(ref tools) = allowed_tool_list {
                 // Find all plain Bash occurrences in the allowed-tools line only
                 // to avoid matching "Bash" in other fields like description
                 let search_start = frontmatter_key_offset(&self.parts.frontmatter, "allowed-tools")
@@ -1226,19 +1247,33 @@ impl<'a> ValidationContext<'a> {
         // CC-SK-008: Unknown tool name. KNOWN_TOOLS is Claude Code's tool set;
         // the whole CC-SK family is gated to Claude Code skills at the dispatch.
         if self.config.is_rule_enabled("CC-SK-008") {
-            if let Some(ref tools) = tool_list {
-                // Compute known tools list once outside loop
-                static KNOWN_TOOLS_LIST: OnceLock<String> = OnceLock::new();
-                let known_tools_str = KNOWN_TOOLS_LIST.get_or_init(|| KNOWN_TOOLS.join(", "));
+            // Compute known tools list once outside both loops.
+            static KNOWN_TOOLS_LIST: OnceLock<String> = OnceLock::new();
+            let known_tools_str = KNOWN_TOOLS_LIST.get_or_init(|| KNOWN_TOOLS.join(", "));
 
+            for (tools, line, col) in [
+                (
+                    allowed_tool_list.as_ref(),
+                    allowed_tools_line,
+                    allowed_tools_col,
+                ),
+                (
+                    disallowed_tool_list.as_ref(),
+                    disallowed_tools_line,
+                    disallowed_tools_col,
+                ),
+            ] {
+                let Some(tools) = tools else {
+                    continue;
+                };
                 for &tool in tools {
                     let base_name = tool.split('(').next().unwrap_or(tool);
                     if !is_valid_skill_tool_name(base_name) {
                         self.diagnostics.push(
                             Diagnostic::error(
                                 self.path.to_path_buf(),
-                                allowed_tools_line,
-                                allowed_tools_col,
+                                line,
+                                col,
                                 "CC-SK-008",
                                 t!(
                                     "rules.cc_sk_008.message",
@@ -1974,50 +2009,53 @@ impl Validator for SkillValidator {
             // Phase 11: CC-SK-017 (unknown frontmatter fields)
             ctx.validate_cc_unknown_frontmatter_fields();
 
-            // Phase 12-15: Claude Code rules (CC-SK-001-009)
-            // These require both name and description to be non-empty
-            if let (Some(name), Some(description)) = (
-                frontmatter.name.as_deref(),
-                frontmatter.description.as_deref(),
-            ) {
-                let name_trimmed = name.trim();
-                let description_trimmed = description.trim();
-                if !name_trimmed.is_empty() && !description_trimmed.is_empty() {
-                    let schema = SkillSchema {
-                        name: name_trimmed.to_string(),
-                        description: description_trimmed.to_string(),
-                        license: frontmatter.license.clone(),
-                        compatibility: frontmatter.compatibility.clone(),
-                        metadata: frontmatter.metadata.clone(),
-                        allowed_tools: frontmatter.allowed_tools.clone(),
-                        argument_hint: frontmatter.argument_hint.clone(),
-                        disable_model_invocation: frontmatter.disable_model_invocation,
-                        user_invocable: frontmatter.user_invocable,
-                        model: frontmatter.model.clone(),
-                        context: frontmatter.context.clone(),
-                        background: frontmatter.background,
-                        agent: frontmatter.agent.clone(),
-                        effort: frontmatter.effort.clone(),
-                        paths: frontmatter.paths.clone(),
-                        shell: frontmatter.shell.clone(),
-                    };
+            // Phase 12-15: Claude Code rules (CC-SK-001-009). Claude Code
+            // allows name and description to be omitted, but the remaining
+            // frontmatter fields still need validation.
+            let schema = SkillSchema {
+                name: frontmatter
+                    .name
+                    .as_deref()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+                description: frontmatter
+                    .description
+                    .as_deref()
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string(),
+                license: frontmatter.license.clone(),
+                compatibility: frontmatter.compatibility.clone(),
+                metadata: frontmatter.metadata.clone(),
+                allowed_tools: frontmatter.allowed_tools.clone(),
+                disallowed_tools: frontmatter.disallowed_tools.clone(),
+                argument_hint: frontmatter.argument_hint.clone(),
+                disable_model_invocation: frontmatter.disable_model_invocation,
+                user_invocable: frontmatter.user_invocable,
+                model: frontmatter.model.clone(),
+                context: frontmatter.context.clone(),
+                background: frontmatter.background,
+                agent: frontmatter.agent.clone(),
+                effort: frontmatter.effort.clone(),
+                paths: frontmatter.paths.clone(),
+                shell: frontmatter.shell.clone(),
+            };
 
-                    // CC-SK-006 (dangerous auto-invocation) and CC-SK-009 (too many injections)
-                    ctx.validate_cc_safety(&schema, &frontmatter);
+            // CC-SK-006 (dangerous auto-invocation) and CC-SK-009 (too many injections)
+            ctx.validate_cc_safety(&schema, &frontmatter);
 
-                    // CC-SK-007 (unrestricted Bash) and CC-SK-008 (unknown tools)
-                    ctx.validate_cc_tools(&schema);
+            // CC-SK-007 (unrestricted Bash) and CC-SK-008 (unknown tools)
+            ctx.validate_cc_tools(&schema);
 
-                    // CC-SK-001-004 (model/context validation)
-                    ctx.validate_cc_model_context(&schema);
+            // CC-SK-001-004 (model/context validation)
+            ctx.validate_cc_model_context(&schema);
 
-                    // CC-SK-005 (agent type)
-                    ctx.validate_cc_agent(&schema);
+            // CC-SK-005 (agent type)
+            ctx.validate_cc_agent(&schema);
 
-                    // CC-SK-018 (effort), CC-SK-019 (paths), CC-SK-020 (shell)
-                    ctx.validate_cc_effort_paths_shell(&schema);
-                }
-            }
+            // CC-SK-018 (effort), CC-SK-019 (paths), CC-SK-020 (shell)
+            ctx.validate_cc_effort_paths_shell(&schema);
         } // end Claude Code skill rules (CC-SK-*)
 
         // Phase 16: Body validation (AS-012, AS-013)

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -73,6 +73,32 @@ Body"#;
 }
 
 #[test]
+fn test_claude_skill_allows_missing_name_and_description() {
+    let content = r#"---
+disallowed-tools: ImaginaryTool
+---
+Use the directory name as the command and this paragraph as the description."#;
+
+    let diagnostics = SkillValidator.validate(
+        Path::new(".claude/skills/review/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| d.rule != "AS-002" && d.rule != "AS-003"),
+        "Claude Code documents every skill frontmatter field as optional: {diagnostics:?}"
+    );
+    assert_eq!(
+        diagnostics.iter().filter(|d| d.rule == "CC-SK-008").count(),
+        1,
+        "optional name and description must not suppress validation of other fields"
+    );
+}
+
+#[test]
 fn test_as_004_invalid_name_format() {
     let content = r#"---
 name: bad_name
@@ -1296,6 +1322,55 @@ Body"#;
         .collect();
 
     assert_eq!(cc_sk_008.len(), 0);
+}
+
+#[test]
+fn test_cc_sk_008_disallowed_tools_accepts_documented_shapes() {
+    let validator = SkillValidator;
+    for disallowed_tools in [
+        "disallowed-tools: AskUserQuestion, Write",
+        "disallowed-tools:\n  - AskUserQuestion\n  - Write",
+    ] {
+        let content = format!(
+            "---\nname: autonomous-review\ndescription: Use when reviewing autonomously\n{disallowed_tools}\n---\nReview the code."
+        );
+        let diagnostics = validator.validate(
+            Path::new(".claude/skills/autonomous-review/SKILL.md"),
+            &content,
+            &LintConfig::default(),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| d.rule != "CC-SK-008" && d.rule != "CC-SK-017"),
+            "documented disallowed-tools shape must validate: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn test_cc_sk_008_rejects_unknown_disallowed_tool() {
+    let content = r#"---
+name: autonomous-review
+description: Use when reviewing autonomously
+disallowed-tools: AskUserQuestion, ImaginaryTool
+---
+Review the code."#;
+
+    let diagnostics = SkillValidator.validate(
+        Path::new(".claude/skills/autonomous-review/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-008")
+        .collect();
+
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].message.contains("ImaginaryTool"));
+    assert_eq!(hits[0].line, 4);
 }
 
 #[test]

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -123,6 +123,35 @@ fn test_claude_plugin_skill_allows_missing_name_and_description() {
 }
 
 #[test]
+fn test_claude_plugin_custom_skill_path_uses_claude_contract() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = temp.path().join("my-plugin");
+    let manifest = plugin_root.join(".claude-plugin").join("plugin.json");
+    let skill_path = plugin_root.join("custom-skills/review/SKILL.md");
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+    fs::write(&manifest, r#"{"skills":"./custom-skills"}"#).unwrap();
+
+    let diagnostics = SkillValidator.validate(
+        &skill_path,
+        "---\ndisallowed-tools: ImaginaryTool\n---\nReview the current changes.",
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| d.rule != "AS-002" && d.rule != "AS-003"),
+        "custom plugin skill roots use Claude's optional-field contract: {diagnostics:?}"
+    );
+    assert_eq!(
+        diagnostics.iter().filter(|d| d.rule == "CC-SK-008").count(),
+        1,
+        "custom plugin skill roots still run Claude field validation"
+    );
+}
+
+#[test]
 fn test_as_004_invalid_name_format() {
     let content = r#"---
 name: bad_name

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -99,6 +99,30 @@ Use the directory name as the command and this paragraph as the description."#;
 }
 
 #[test]
+fn test_claude_plugin_skill_allows_missing_name_and_description() {
+    let temp = tempfile::tempdir().unwrap();
+    let plugin_root = temp.path().join("my-plugin");
+    let manifest = plugin_root.join(".claude-plugin").join("plugin.json");
+    let skill_path = plugin_root.join("skills/review/SKILL.md");
+    fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+    fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+    fs::write(&manifest, "{}").unwrap();
+
+    let diagnostics = SkillValidator.validate(
+        &skill_path,
+        "---\n---\nReview the current changes.",
+        &LintConfig::default(),
+    );
+
+    assert!(
+        diagnostics
+            .iter()
+            .all(|d| d.rule != "AS-002" && d.rule != "AS-003"),
+        "manifest-owned plugin skills use Claude's optional-field contract: {diagnostics:?}"
+    );
+}
+
+#[test]
 fn test_as_004_invalid_name_format() {
     let content = r#"---
 name: bad_name
@@ -506,6 +530,28 @@ Body"#;
         cc_sk_006_errors[0].level,
         crate::diagnostics::DiagnosticLevel::Error
     );
+}
+
+#[test]
+fn test_cc_sk_006_uses_directory_name_when_frontmatter_omits_name() {
+    let content = r#"---
+description: Deploys to production
+---
+Body"#;
+
+    let diagnostics = SkillValidator.validate(
+        Path::new(".claude/skills/deploy-prod/SKILL.md"),
+        content,
+        &LintConfig::default(),
+    );
+
+    let hits: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.rule == "CC-SK-006")
+        .collect();
+    assert_eq!(hits.len(), 1);
+    assert!(hits[0].message.contains("deploy-prod"));
+    assert!(!diagnostics.iter().any(|d| d.rule == "AS-002"));
 }
 
 #[test]

--- a/crates/agnix-core/src/schemas/hooks.rs
+++ b/crates/agnix-core/src/schemas/hooks.rs
@@ -68,6 +68,9 @@ pub enum Hook {
         timeout: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         model: Option<String>,
+        /// Continue the turn after a prompt hook blocks instead of stopping it.
+        #[serde(rename = "continueOnBlock", skip_serializing_if = "Option::is_none")]
+        continue_on_block: Option<bool>,
     },
     #[serde(rename = "agent")]
     Agent {
@@ -446,6 +449,7 @@ mod tests {
             prompt: Some("summarize".to_string()),
             timeout: None,
             model: None,
+            continue_on_block: None,
         };
         assert_eq!(prompt.type_name(), "prompt");
         assert!(prompt.is_prompt());

--- a/crates/agnix-core/src/schemas/skill.rs
+++ b/crates/agnix-core/src/schemas/skill.rs
@@ -28,6 +28,10 @@ pub struct SkillSchema {
     #[serde(skip_serializing_if = "Option::is_none", rename = "allowed-tools")]
     pub allowed_tools: Option<String>,
 
+    /// Optional: tools removed from the active skill's available pool
+    #[serde(skip_serializing_if = "Option::is_none", rename = "disallowed-tools")]
+    pub disallowed_tools: Option<String>,
+
     // Claude Code extensions
     /// Optional: argument hint for autocomplete
     #[serde(skip_serializing_if = "Option::is_none", rename = "argument-hint")]
@@ -167,6 +171,9 @@ pub const KNOWN_SKILL_FRONTMATTER_FIELDS: &[&str] = &[
     "compatibility",
     "metadata",
     "allowed-tools",
+    "disallowed-tools",
+    "when_to_use",
+    "arguments",
     "argument-hint",
     "disable-model-invocation",
     "user-invocable",
@@ -385,6 +392,7 @@ mod tests {
             compatibility: None,
             metadata: None,
             allowed_tools: None,
+            disallowed_tools: None,
             argument_hint: None,
             disable_model_invocation: None,
             user_invocable: None,
@@ -414,6 +422,7 @@ mod tests {
             compatibility: None,
             metadata: None,
             allowed_tools: None,
+            disallowed_tools: None,
             argument_hint: None,
             disable_model_invocation: None,
             user_invocable: None,
@@ -443,6 +452,7 @@ mod tests {
             compatibility: None,
             metadata: None,
             allowed_tools: None,
+            disallowed_tools: None,
             argument_hint: None,
             disable_model_invocation: None,
             user_invocable: None,
@@ -465,6 +475,7 @@ mod tests {
             compatibility: None,
             metadata: None,
             allowed_tools: None,
+            disallowed_tools: None,
             argument_hint: None,
             disable_model_invocation: None,
             user_invocable: None,
@@ -705,6 +716,9 @@ mod tests {
             "agent",
             "hooks",
             "allowed-tools",
+            "disallowed-tools",
+            "when_to_use",
+            "arguments",
         ] {
             assert!(
                 KNOWN_SKILL_FRONTMATTER_FIELDS.contains(field),

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1405,7 +1405,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/hooks"
         ],
-        "verified_on": "2026-04-23",
+        "verified_on": "2026-08-09",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -1624,7 +1624,7 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\n  \"hooks\": {\n    \"Stop\": [\n      {\n        \"hooks\": [\n          { \"type\": \"command\", \"command\": \"echo bye\", \"timeout\": 30 }\n        ]\n      }\n    ]\n  }\n}",
+      "good_example": "{\n  \"hooks\": {\n    \"PreToolUse\": [\n      {\n        \"hooks\": [\n          { \"type\": \"prompt\", \"prompt\": \"Review: $ARGUMENTS\", \"continueOnBlock\": true }\n        ]\n      }\n    ]\n  }\n}",
       "bad_example": "{\n  \"hooks\": {\n    \"Stop\": [\n      {\n        hooks: [\n          { type: command }\n        ]\n      }\n    ]\n  }\n}"
     },
     {
@@ -3244,11 +3244,12 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
+          "https://code.claude.com/docs/en/skills",
           "https://code.claude.com/docs/en/settings",
           "https://code.claude.com/docs/en/tools",
           "https://code.claude.com/docs/en/permissions"
         ],
-        "verified_on": "2026-07-31",
+        "verified_on": "2026-08-09",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3262,8 +3263,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "---\nname: find-files\ndescription: Use when finding files by pattern\nallowed-tools: Glob, Grep, Read\n---\nSearch for files matching the pattern.",
-      "bad_example": "---\nname: find-files\ndescription: Use when finding files by pattern\nallowed-tools: Glob, Grep, FooBar\n---\nSearch for files matching the pattern."
+      "good_example": "---\nname: find-files\ndescription: Use when finding files by pattern\nallowed-tools: Glob, Grep, Read\ndisallowed-tools: Write\n---\nSearch for files matching the pattern.",
+      "bad_example": "---\nname: find-files\ndescription: Use when finding files by pattern\ndisallowed-tools: FooBar\n---\nSearch for files matching the pattern."
     },
     {
       "id": "CC-SK-009",
@@ -3497,7 +3498,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-08-09",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3511,7 +3512,7 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "---\nname: lint-config\ndescription: Use when validating configuration files\ndisplay-name: Lint Config\ndefault-enabled: true\nfallback: lint-config\nallowed-tools: Read, Grep\n---\nLint project configuration files.",
+      "good_example": "---\nname: lint-config\ndescription: Use when validating configuration files\ndisplay-name: Lint Config\ndefault-enabled: true\nfallback: lint-config\nallowed-tools: Read, Grep\ndisallowed-tools: Write\n---\nLint project configuration files.",
       "bad_example": "---\nname: lint-config\ndescription: Use when validating configuration files\nallowed_tools: Read, Grep\n---\nLint project configuration files."
     },
     {

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -118,15 +118,15 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="as-002"></a>
 ### AS-002 [HIGH] Missing Required Field: name
-**Requirement**: `name` field REQUIRED in frontmatter
-**Detection**: Parse YAML, check for `name` key
+**Requirement**: `name` field REQUIRED in Agent Skills frontmatter; Claude Code skills may omit it and derive the name from the skill location
+**Detection**: For non-Claude skills, parse YAML and check for `name` key
 **Fix**: [AUTO-FIX] Add `name: directory-name`
 **Source**: agentskills.io/specification
 
 <a id="as-003"></a>
 ### AS-003 [HIGH] Missing Required Field: description
-**Requirement**: `description` field REQUIRED in frontmatter
-**Detection**: Parse YAML, check for `description` key
+**Requirement**: `description` field REQUIRED in Agent Skills frontmatter; Claude Code skills may omit it and use the first body paragraph
+**Detection**: For non-Claude skills, parse YAML and check for `description` key
 **Fix**: [AUTO-FIX] Add `description: "Use when..."`
 **Source**: agentskills.io/specification
 
@@ -261,7 +261,7 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 ### CC-SK-008 [HIGH] Unknown Tool Name
 **Requirement**: Tool names MUST match Claude Code tools. **Claude Code skills only** - other clients (Codex/OpenCode/…) have their own tool vocabularies, so this is scoped to the owning client.
 **Known Tools**: the current built-in set (code.claude.com/docs/en/tools, verified 2026-07-31) incl. `PowerShell`, `Agent`, `Workflow`, `Artifact`, `ReportFindings`, `SendUserFile`, `EndConversation`, `Cron*`, `Team*`, `EnterWorktree`/`ExitWorktree`, `ScheduleWakeup`, `ListMcpResourcesTool`/`ReadMcpResourceTool`, `WaitForMcpServers`, plus legacy names kept for tolerance
-**Detection**: skill client is Claude Code AND tool not in the set; MCP tools are accepted in both documented forms - server-only `mcp__<server>` and fully qualified `mcp__<server>__<tool>` (case-sensitive lowercase prefix). The tool segment may glob (`mcp__github__get_*`); the server segment may not, since a rule must name one configured server
+**Detection**: skill client is Claude Code AND a tool in `allowed-tools` or `disallowed-tools` is not in the set; MCP tools are accepted in both documented forms - server-only `mcp__<server>` and fully qualified `mcp__<server>__<tool>` (case-sensitive lowercase prefix). The tool segment may glob (`mcp__github__get_*`); the server segment may not, since a rule must name one configured server
 **Fix**: Suggest closest match
 **Source**: code.claude.com/docs/en/tools
 
@@ -323,7 +323,7 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 
 <a id="cc-sk-017"></a>
 ### CC-SK-017 [MEDIUM] Unknown Frontmatter Field
-**Requirement**: Skill frontmatter SHOULD only use recognized Claude Code fields. **Claude Code skills only** - other clients' field support is checked by the per-client skill validator (CL-SK/CX-SK/OC-SK/WS-SK). Known fields include the documented `when_to_use` and `arguments` (added 2026-05-24).
+**Requirement**: Skill frontmatter SHOULD only use recognized Claude Code fields. **Claude Code skills only** - other clients' field support is checked by the per-client skill validator (CL-SK/CX-SK/OC-SK/WS-SK). Known fields include the documented `when_to_use`, `arguments`, and `disallowed-tools`.
 **Detection**: skill client is Claude Code AND frontmatter contains a field not in the Claude Code skill schema
 **Fix**: Manual fix required - remove unknown field or correct typo
 **Source**: code.claude.com/docs/en/skills

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1405,7 +1405,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/hooks"
         ],
-        "verified_on": "2026-04-23",
+        "verified_on": "2026-08-09",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -1624,7 +1624,7 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "{\n  \"hooks\": {\n    \"Stop\": [\n      {\n        \"hooks\": [\n          { \"type\": \"command\", \"command\": \"echo bye\", \"timeout\": 30 }\n        ]\n      }\n    ]\n  }\n}",
+      "good_example": "{\n  \"hooks\": {\n    \"PreToolUse\": [\n      {\n        \"hooks\": [\n          { \"type\": \"prompt\", \"prompt\": \"Review: $ARGUMENTS\", \"continueOnBlock\": true }\n        ]\n      }\n    ]\n  }\n}",
       "bad_example": "{\n  \"hooks\": {\n    \"Stop\": [\n      {\n        hooks: [\n          { type: command }\n        ]\n      }\n    ]\n  }\n}"
     },
     {
@@ -3244,11 +3244,12 @@
       "evidence": {
         "source_type": "vendor_docs",
         "source_urls": [
+          "https://code.claude.com/docs/en/skills",
           "https://code.claude.com/docs/en/settings",
           "https://code.claude.com/docs/en/tools",
           "https://code.claude.com/docs/en/permissions"
         ],
-        "verified_on": "2026-07-31",
+        "verified_on": "2026-08-09",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3262,8 +3263,8 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "---\nname: find-files\ndescription: Use when finding files by pattern\nallowed-tools: Glob, Grep, Read\n---\nSearch for files matching the pattern.",
-      "bad_example": "---\nname: find-files\ndescription: Use when finding files by pattern\nallowed-tools: Glob, Grep, FooBar\n---\nSearch for files matching the pattern."
+      "good_example": "---\nname: find-files\ndescription: Use when finding files by pattern\nallowed-tools: Glob, Grep, Read\ndisallowed-tools: Write\n---\nSearch for files matching the pattern.",
+      "bad_example": "---\nname: find-files\ndescription: Use when finding files by pattern\ndisallowed-tools: FooBar\n---\nSearch for files matching the pattern."
     },
     {
       "id": "CC-SK-009",
@@ -3497,7 +3498,7 @@
         "source_urls": [
           "https://code.claude.com/docs/en/skills"
         ],
-        "verified_on": "2026-02-14",
+        "verified_on": "2026-08-09",
         "applies_to": {
           "tool": "claude-code"
         },
@@ -3511,7 +3512,7 @@
       "fix": {
         "autofix": false
       },
-      "good_example": "---\nname: lint-config\ndescription: Use when validating configuration files\ndisplay-name: Lint Config\ndefault-enabled: true\nfallback: lint-config\nallowed-tools: Read, Grep\n---\nLint project configuration files.",
+      "good_example": "---\nname: lint-config\ndescription: Use when validating configuration files\ndisplay-name: Lint Config\ndefault-enabled: true\nfallback: lint-config\nallowed-tools: Read, Grep\ndisallowed-tools: Write\n---\nLint project configuration files.",
       "bad_example": "---\nname: lint-config\ndescription: Use when validating configuration files\nallowed_tools: Read, Grep\n---\nLint project configuration files."
     },
     {

--- a/website/docs/rules/generated/cc-hk-005.md
+++ b/website/docs/rules/generated/cc-hk-005.md
@@ -13,7 +13,7 @@ keywords: ["CC-HK-005", "missing type field", "claude hooks", "validation", "agn
 - **Category**: `Claude Hooks`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `Yes (safe)`
-- **Verified On**: `2026-04-23`
+- **Verified On**: `2026-08-09`
 
 ## Applicability
 

--- a/website/docs/rules/generated/cc-hk-012.md
+++ b/website/docs/rules/generated/cc-hk-012.md
@@ -56,10 +56,10 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ```json
 {
   "hooks": {
-    "Stop": [
+    "PreToolUse": [
       {
         "hooks": [
-          { "type": "command", "command": "echo bye", "timeout": 30 }
+          { "type": "prompt", "prompt": "Review: $ARGUMENTS", "continueOnBlock": true }
         ]
       }
     ]

--- a/website/docs/rules/generated/cc-sk-008.md
+++ b/website/docs/rules/generated/cc-sk-008.md
@@ -13,7 +13,7 @@ keywords: ["CC-SK-008", "unknown tool name", "claude skills", "validation", "agn
 - **Category**: `Claude Skills`
 - **Normative Level**: `MUST`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-07-31`
+- **Verified On**: `2026-08-09`
 
 ## Applicability
 
@@ -23,6 +23,7 @@ keywords: ["CC-SK-008", "unknown tool name", "claude skills", "validation", "agn
 
 ## Evidence Sources
 
+- https://code.claude.com/docs/en/skills
 - https://code.claude.com/docs/en/settings
 - https://code.claude.com/docs/en/tools
 - https://code.claude.com/docs/en/permissions
@@ -43,7 +44,7 @@ The following examples demonstrate what triggers this rule and how to fix it.
 ---
 name: find-files
 description: Use when finding files by pattern
-allowed-tools: Glob, Grep, FooBar
+disallowed-tools: FooBar
 ---
 Search for files matching the pattern.
 ```
@@ -55,6 +56,7 @@ Search for files matching the pattern.
 name: find-files
 description: Use when finding files by pattern
 allowed-tools: Glob, Grep, Read
+disallowed-tools: Write
 ---
 Search for files matching the pattern.
 ```

--- a/website/docs/rules/generated/cc-sk-017.md
+++ b/website/docs/rules/generated/cc-sk-017.md
@@ -13,7 +13,7 @@ keywords: ["CC-SK-017", "unknown frontmatter field", "claude skills", "validatio
 - **Category**: `Claude Skills`
 - **Normative Level**: `SHOULD`
 - **Auto-Fix**: `No`
-- **Verified On**: `2026-02-14`
+- **Verified On**: `2026-08-09`
 
 ## Applicability
 
@@ -56,6 +56,7 @@ display-name: Lint Config
 default-enabled: true
 fallback: lint-config
 allowed-tools: Read, Grep
+disallowed-tools: Write
 ---
 Lint project configuration files.
 ```


### PR DESCRIPTION
## Summary
- accept current Claude Code skill frontmatter, including optional `name`/`description` and `disallowed-tools`
- parse prompt-hook `continueOnBlock` as a boolean
- advance the five reviewed Claude documentation baselines and generated evidence

## Validation
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo run -p agnix-cli --bin agnix -- eval tests/eval.yaml` (61/61)
- rule, locale, schema, docs, and live hash parity checks
- `cargo deny check`

Closes #1342