### PR TITLE
release: v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.0] - 2026-08-09
+
 ### Fixed
 - **Claude Code skill and hook schema compatibility**. Accept skills without
   explicit `name` or `description`, validate the documented `disallowed-tools`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -99,14 +99,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.47.0"
+version = "0.48.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -33,8 +33,8 @@ categories = ["development-tools", "command-line-utilities"]
 [workspace.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.47.0" }
-agnix-core = { path = "crates/agnix-core", version = "0.47.0" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.48.0" }
+agnix-core = { path = "crates/agnix-core", version = "0.48.0" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.agnix
 pluginName = agnix
 pluginRepositoryUrl = https://github.com/agent-sh/agnix
 # SemVer format -> https://semver.org
-pluginVersion = 0.47.0
+pluginVersion = 0.48.0
 
 # Supported build number ranges and IntelliJ Platform Versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.47.0"
+version = "0.48.0"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Lint agent configurations before they break your workflow. 447 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",


### PR DESCRIPTION
## Summary
- release current Claude Code skill and prompt-hook schema compatibility
- publish plugin-owned custom skill path resolution fixes
- synchronize Cargo, npm, VS Code, JetBrains, Zed, and Claude plugin versions to 0.48.0

## Validation
- cargo test --workspace --locked
- cargo test --doc --workspace --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo fmt --all -- --check
- efficacy: 61/61, 100% precision/recall/F1
- agnix self-lint
- cargo audit and cargo deny advisories
- release builds for CLI, LSP, and MCP
- CLI/LSP version checks and MCP initialize handshake at 0.48.0
- rule bookkeeping parity: 447 rules