### PR TITLE
fix: honor excludes in skill directory size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Skill directory size exclusions** (#1360). AS-015 now omits paths matched
+  by top-level `exclude` or `[files].exclude` when calculating the 8 MB skill
+  directory total, while continuing to validate the rest of the skill.
+
 ### Security
 - **Dependency lockfile bumps (website + VS Code extension)**: js-yaml
   GHSA-5p4m-2wfm-xmqj (quadratic `!!omap` complexity) and nanoid

--- a/crates/agnix-core/src/pipeline.rs
+++ b/crates/agnix-core/src/pipeline.rs
@@ -540,8 +540,7 @@ pub fn validate_project(path: &Path, config: &LintConfig) -> LintResult<Validati
     validate_project_with_registry(path, config, &registry)
 }
 
-#[cfg(feature = "filesystem")]
-struct ExcludePattern {
+pub(crate) struct ExcludePattern {
     pattern: glob::Pattern,
     dir_only_prefix: Option<String>,
     allow_probe: bool,
@@ -556,8 +555,7 @@ pub(crate) fn normalize_rel_path(entry_path: &Path, root: &Path) -> String {
     }
 }
 
-#[cfg(feature = "filesystem")]
-fn compile_single_exclude_pattern(pattern: &str) -> Result<ExcludePattern, String> {
+pub(crate) fn compile_single_exclude_pattern(pattern: &str) -> Result<ExcludePattern, String> {
     let normalized = pattern.replace('\\', "/");
     let (glob_str, dir_only_prefix) = if let Some(prefix) = normalized.strip_suffix('/') {
         (format!("{}/**", prefix), Some(prefix.to_string()))
@@ -604,8 +602,7 @@ fn compile_files_exclude_for_walker(excludes: &[String]) -> Vec<ExcludePattern> 
         .collect()
 }
 
-#[cfg(feature = "filesystem")]
-fn should_prune_dir(rel_dir: &str, exclude_patterns: &[ExcludePattern]) -> bool {
+pub(crate) fn should_prune_dir(rel_dir: &str, exclude_patterns: &[ExcludePattern]) -> bool {
     if rel_dir.is_empty() {
         return false;
     }
@@ -617,8 +614,7 @@ fn should_prune_dir(rel_dir: &str, exclude_patterns: &[ExcludePattern]) -> bool 
         .any(|p| p.pattern.matches(rel_dir) || (p.allow_probe && p.pattern.matches(&probe)))
 }
 
-#[cfg(feature = "filesystem")]
-fn is_excluded_file(path_str: &str, exclude_patterns: &[ExcludePattern]) -> bool {
+pub(crate) fn is_excluded_file(path_str: &str, exclude_patterns: &[ExcludePattern]) -> bool {
     exclude_patterns
         .iter()
         .any(|p| p.pattern.matches(path_str) && p.dir_only_prefix.as_deref() != Some(path_str))

--- a/crates/agnix-core/src/rules/skill/helpers.rs
+++ b/crates/agnix-core/src/rules/skill/helpers.rs
@@ -1,6 +1,10 @@
+use crate::config::LintConfig;
 use crate::fs::FileSystem;
 use crate::parsers::frontmatter::{
     FrontmatterParts, check_yaml_depth, check_yaml_duplicate_top_level_keys,
+};
+use crate::pipeline::{
+    compile_single_exclude_pattern, is_excluded_file, normalize_rel_path, should_prune_dir,
 };
 use regex::Regex;
 use std::collections::HashSet;
@@ -402,7 +406,24 @@ pub(super) fn is_script_path(path: &Path, content: &str) -> bool {
     )
 }
 
-pub(super) fn directory_size_until(path: &Path, max_bytes: u64, fs: &dyn FileSystem) -> u64 {
+pub(super) fn directory_size_until(
+    path: &Path,
+    max_bytes: u64,
+    fs: &dyn FileSystem,
+    config: &LintConfig,
+) -> u64 {
+    let exclude_patterns = config
+        .exclude()
+        .iter()
+        .chain(config.files_config().exclude.iter())
+        .filter_map(|pattern| compile_single_exclude_pattern(pattern).ok())
+        .collect::<Vec<_>>();
+    let root_dir = if exclude_patterns.is_empty() {
+        None
+    } else {
+        config.root_dir().map(|root| root.as_path())
+    };
+
     let mut total = 0u64;
     let mut stack = vec![path.to_path_buf()];
     while let Some(current) = stack.pop() {
@@ -414,11 +435,24 @@ pub(super) fn directory_size_until(path: &Path, max_bytes: u64, fs: &dyn FileSys
             if entry.metadata.is_symlink {
                 continue;
             }
+            let relative_path = root_dir.map(|root| normalize_rel_path(&entry.path, root));
             if entry.metadata.is_dir {
+                if relative_path
+                    .as_deref()
+                    .is_some_and(|path| should_prune_dir(path, &exclude_patterns))
+                {
+                    continue;
+                }
                 stack.push(entry.path.clone());
                 continue;
             }
             if entry.metadata.is_file {
+                if relative_path
+                    .as_deref()
+                    .is_some_and(|path| is_excluded_file(path, &exclude_patterns))
+                {
+                    continue;
+                }
                 total = total.saturating_add(entry.metadata.len);
                 if total > max_bytes {
                     return total;

--- a/crates/agnix-core/src/rules/skill/mod.rs
+++ b/crates/agnix-core/src/rules/skill/mod.rs
@@ -1752,7 +1752,8 @@ impl<'a> ValidationContext<'a> {
                 let (frontmatter_line, frontmatter_col) =
                     self.line_col_at(self.parts.frontmatter_start);
                 const MAX_BYTES: u64 = 8 * 1024 * 1024;
-                let size = directory_size_until(dir, MAX_BYTES, self.config.fs().as_ref());
+                let size =
+                    directory_size_until(dir, MAX_BYTES, self.config.fs().as_ref(), self.config);
                 if size > MAX_BYTES {
                     self.diagnostics.push(
                         Diagnostic::error(

--- a/crates/agnix-core/src/rules/skill/tests.rs
+++ b/crates/agnix-core/src/rules/skill/tests.rs
@@ -2439,7 +2439,12 @@ fn test_directory_size_until_short_circuits() {
     }
 
     // With a 2MB limit, should short-circuit and return > 2MB
-    let size = directory_size_until(temp_dir.path(), 2 * 1024 * 1024, &fs);
+    let size = directory_size_until(
+        temp_dir.path(),
+        2 * 1024 * 1024,
+        &fs,
+        &LintConfig::default(),
+    );
     assert!(size > 2 * 1024 * 1024, "Size should exceed 2MB limit");
     // Should not have scanned all 10MB (short-circuited after exceeding limit).
     // Upper bound is 3MB because: directory iteration order is unspecified,
@@ -2463,7 +2468,7 @@ fn test_directory_size_until_accurate_under_limit() {
     }
 
     // With a 1MB limit, should return exact size
-    let size = directory_size_until(temp_dir.path(), 1024 * 1024, &fs);
+    let size = directory_size_until(temp_dir.path(), 1024 * 1024, &fs, &LintConfig::default());
     assert_eq!(size, 2048);
 }
 
@@ -2472,7 +2477,7 @@ fn test_directory_size_until_handles_empty_directory() {
     let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
     let fs = RealFileSystem;
 
-    let size = directory_size_until(temp_dir.path(), 1024 * 1024, &fs);
+    let size = directory_size_until(temp_dir.path(), 1024 * 1024, &fs, &LintConfig::default());
     assert_eq!(size, 0);
 }
 
@@ -2491,7 +2496,12 @@ fn test_directory_size_until_nested_directories() {
     write_bytes_to_file(&sub1.join("sub1.bin"), 2048);
     write_bytes_to_file(&sub2.join("sub2.bin"), 3072);
 
-    let size = directory_size_until(temp_dir.path(), 1024 * 1024, &real_fs);
+    let size = directory_size_until(
+        temp_dir.path(),
+        1024 * 1024,
+        &real_fs,
+        &LintConfig::default(),
+    );
     assert_eq!(size, 6144, "Should sum files across all nested directories");
 }
 
@@ -2510,12 +2520,78 @@ fn test_directory_size_until_nested_short_circuits() {
     write_bytes_to_file(&sub1.join("sub1.bin"), 1024 * 1024);
     write_bytes_to_file(&sub2.join("sub2.bin"), 1024 * 1024);
 
-    let size = directory_size_until(temp_dir.path(), 2 * 1024 * 1024, &real_fs);
+    let size = directory_size_until(
+        temp_dir.path(),
+        2 * 1024 * 1024,
+        &real_fs,
+        &LintConfig::default(),
+    );
     assert!(size > 2 * 1024 * 1024, "Should exceed limit");
     assert!(
         size <= 3 * 1024 * 1024,
         "Should short-circuit before scanning all"
     );
+}
+
+#[test]
+fn test_as_015_respects_configured_excludes() {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let skill_dir = temp_dir.path().join("skills").join("big-skill");
+    let data_dir = skill_dir.join("data");
+    fs::create_dir_all(&data_dir).expect("Failed to create skill data directory");
+
+    let skill_content = "---\nname: big-skill\n---\nBody\n";
+    let metadata_content =
+        "name = \"big-skill\"\nversion = \"1.0.0\"\ntype = \"skill\"\nprompt-file = \"SKILL.md\"\n";
+    let skill_path = skill_dir.join("SKILL.md");
+    fs::write(&skill_path, skill_content).expect("Failed to write SKILL.md");
+    fs::write(skill_dir.join("metadata.toml"), metadata_content)
+        .expect("Failed to write metadata.toml");
+    fs::File::create(data_dir.join("big.json"))
+        .and_then(|file| file.set_len(10 * 1024 * 1024))
+        .expect("Failed to write large payload");
+
+    let expected_size = (skill_content.len() + metadata_content.len()) as u64;
+    let cases = [
+        ("top-level subtree", false, "skills/big-skill/data/**"),
+        (
+            "top-level exact file",
+            false,
+            "skills/big-skill/data/big.json",
+        ),
+        ("files subtree", true, "skills/big-skill/data/**"),
+    ];
+
+    for (label, use_files_config, pattern) in cases {
+        let mut config = LintConfig::default();
+        config.set_root_dir(temp_dir.path().to_path_buf());
+        config.set_exclude(Vec::new());
+        if use_files_config {
+            config.files_mut().exclude = vec![pattern.to_string()];
+        } else {
+            config.set_exclude(vec![pattern.to_string()]);
+        }
+
+        let measured = directory_size_until(&skill_dir, u64::MAX, &RealFileSystem, &config);
+        assert_eq!(
+            measured, expected_size,
+            "{label} should subtract the payload from the measured size"
+        );
+
+        let diagnostics = SkillValidator.validate(&skill_path, skill_content, &config);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.rule != "AS-015"),
+            "{label} should prevent AS-015, got: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.rule == "AS-003"),
+            "{label} should not stop SKILL.md validation, got: {diagnostics:?}"
+        );
+    }
 }
 
 #[test]

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -120,7 +120,7 @@ disabled_rules = ["CC-MEM-006", "PE-003"]
 # Validate as generic markdown (XML, imports, cross-platform rules)
 # include_as_generic = ["internal/*.md"]
 
-# Exclude from validation entirely (even built-in file types)
+# Exclude from validation entirely, including AS-015 skill size totals
 # exclude = ["vendor/**", "generated/**"]
 
 # Per-file rule suppression (see "Per-file rule overrides" below).
@@ -131,6 +131,13 @@ disabled_rules = ["CC-MEM-006", "PE-003"]
 # paths = ["CLAUDE.md", "AGENTS.md"]
 # disabled_rules = ["CC-MEM-005"]
 ```
+
+### Path Exclusions
+
+Top-level `exclude` and `[files].exclude` both remove matching paths from
+validation. This includes the AS-015 skill-directory size total. Use a
+payload-specific pattern such as `skills/catalog/data/**` to omit inert data
+while keeping `SKILL.md` and prompt-facing resources in scope.
 
 ## Schema Validation
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -193,7 +193,7 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 <a id="as-015"></a>
 ### AS-015 [HIGH] Upload Size Exceeds 8MB
 **Requirement**: Skill directory MUST be under 8MB total. **claude.ai upload-platform limit** - not in the agentskills.io spec (which uses token, not byte, budgets), so scoped to Claude Code (and unscoped) skills.
-**Detection**: skill client allows Claude rules AND `directory_size > 8 * 1024 * 1024`
+**Detection**: skill client allows Claude rules AND `directory_size > 8 * 1024 * 1024`; paths matched by top-level `exclude` or `[files].exclude` are omitted from `directory_size`
 **Fix**: Remove large assets or split skill
 **Source**: claude.ai upload limit (Claude-specific)
 


### PR DESCRIPTION
## Summary

- make AS-015 omit paths matched by top-level `exclude` or `[files].exclude`
- reuse the existing project-relative exclusion matcher for exact files and subtrees
- keep the remaining skill files in validation and document the behavior

## Root cause

Project traversal applied configured exclusions before validation, but the AS-015 helper independently walked the skill directory and summed every regular file. Excluded payloads therefore still counted toward the 8 MB limit unless the entire skill was excluded.

This change extends the existing shared "do not validate this path" contract to the AS-015 aggregate instead of adding a separate configuration surface.

## Verification

- `cargo test --workspace --quiet` - 5,172 passed, 0 failed, 8 ignored
- `cargo test -p agnix-core rules::skill::tests --lib` - 242 passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p agnix-core --no-default-features`
- `cargo fmt --all -- --check`
- `node scripts/sync-rule-bookkeeping.js --check`

The synthetic fixture measured 10,485,985 bytes before the change with or without `exclude = ["skills/bigskill/data/**"]`. After the change, the excluded 10 MiB payload is omitted, the retained total is 225 bytes, and the CLI exits successfully. Removing the exclusion still reports the original 10,485,985-byte AS-015 error.

Closes #1360
