### PR TITLE
fix(cli): resolve batch root independent of argument order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Skill directory size exclusions** (#1360). AS-015 now omits paths matched
   by top-level `exclude` or `[files].exclude` when calculating the 8 MB skill
   directory total, while continuing to validate the rest of the skill.
+- **CC-MEM-001 false positive when several paths are passed on the command
+  line** ([#1368](https://github.com/agent-sh/agnix/issues/1368)). The
+  workspace root came from the parent of the first path, so a file in a
+  subdirectory listed first became the root and `CLAUDE.md`'s root-relative
+  `@imports` were reported as escaping the project. Since pre-commit passes
+  matched files in sorted order, `.claude/...` sorted ahead of `CLAUDE.md` and
+  the same tree passed or failed depending on argument order. The root is now
+  the deepest common ancestor of every path, walked up to the nearest `.git` or
+  `.agnix.toml` marker, so results no longer depend on argument order or on
+  which files a commit happens to touch.
 
 ### Security
 - **Dependency lockfile bumps (website + VS Code extension)**: js-yaml

--- a/crates/agnix-cli/src/main.rs
+++ b/crates/agnix-cli/src/main.rs
@@ -408,11 +408,12 @@ fn load_config_or_default(path: Option<&PathBuf>) -> anyhow::Result<LintConfig> 
 /// `agnix --strict AGENTS.md CLAUDE.md` check only the changed files instead
 /// of rescanning the entire repo.
 ///
-/// Before iterating we resolve a workspace root and set it on a cloned
-/// `LintConfig` so per-file validators see the same `[files]` include/exclude
-/// semantics they'd see during a full project walk. The aggregate
-/// `files_checked` count is also bounded by `max_files_to_validate` so a large
-/// file list from pre-commit can't bypass the DoS guard.
+/// Before iterating we resolve a workspace root (see [`resolve_batch_root`])
+/// and set it on a cloned `LintConfig` so per-file validators see the same
+/// `[files]` include/exclude semantics they'd see during a full project walk.
+/// The aggregate `files_checked` count is also bounded by
+/// `max_files_to_validate` so a large file list from pre-commit can't bypass
+/// the DoS guard.
 fn run_validation(
     paths: &[PathBuf],
     config: &LintConfig,
@@ -434,24 +435,9 @@ fn run_validation(
     }
 
     // Resolve a workspace root so per-file validators can apply relative
-    // `[files]` patterns and so diagnostics use a stable base path. Use the
-    // parent of the first file path, or the first directory path, or cwd.
-    let root_dir = paths
-        .first()
-        .map(|p| {
-            if p.is_dir() {
-                p.clone()
-            } else {
-                p.parent()
-                    .map(Path::to_path_buf)
-                    .unwrap_or_else(|| PathBuf::from("."))
-            }
-        })
-        .and_then(|p| std::fs::canonicalize(&p).ok())
-        .unwrap_or_else(|| std::fs::canonicalize(".").unwrap_or_else(|_| PathBuf::from(".")));
-
+    // `[files]` patterns and so diagnostics use a stable base path.
     let mut config = config.clone();
-    config.set_root_dir(root_dir);
+    config.set_root_dir(resolve_batch_root(paths));
 
     let mut registry = ValidatorRegistry::with_defaults();
     for name in &config.rules().disabled_validators {
@@ -492,6 +478,76 @@ fn run_validation(
         }
     }
     Ok(ValidationResult::new(diagnostics, files_checked))
+}
+
+/// Markers that identify a workspace root. `.git` is matched as a directory or
+/// a file so git worktrees and submodules resolve to their own root, matching
+/// how `agnix-core` walks for a repo root when no root is configured.
+const PROJECT_ROOT_MARKERS: [&str; 2] = [".git", ".agnix.toml"];
+
+/// Resolve the workspace root for an explicit list of paths.
+///
+/// The root must not depend on argument order. Deriving it from the first path
+/// made `CLAUDE.md`'s root-relative `@imports` look like they escaped the
+/// project whenever a file in a subdirectory came first, and pre-commit passes
+/// the staged files as positional args in sorted order, so `.claude/...` sorted
+/// ahead of `CLAUDE.md` and became the root (#1368).
+///
+/// The deepest common ancestor of every path is order-independent. Walking up
+/// from there to the nearest project marker keeps a partial file list on the
+/// same root a full project walk would use, so the result also doesn't depend
+/// on which files a given commit happens to touch. With no marker anywhere
+/// above the paths, the common ancestor is used as-is.
+fn resolve_batch_root(paths: &[PathBuf]) -> PathBuf {
+    let mut common: Option<PathBuf> = None;
+    for path in paths {
+        let dir = if path.is_dir() {
+            path.clone()
+        } else {
+            match path.parent() {
+                // A bare filename has an empty parent, which means cwd.
+                Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+                _ => PathBuf::from("."),
+            }
+        };
+        let dir = std::fs::canonicalize(&dir).unwrap_or(dir);
+        common = Some(match common {
+            Some(current) => common_ancestor(&current, &dir),
+            None => dir,
+        });
+    }
+
+    // No paths, or paths with nothing in common (separate mounts, different
+    // Windows drives): fall back to cwd rather than to the filesystem root.
+    let common = common
+        .filter(|dir| dir.components().next().is_some())
+        .unwrap_or_else(|| std::fs::canonicalize(".").unwrap_or_else(|_| PathBuf::from(".")));
+
+    find_project_root(&common).unwrap_or(common)
+}
+
+/// Deepest directory that is an ancestor of, or equal to, both paths.
+fn common_ancestor(left: &Path, right: &Path) -> PathBuf {
+    let mut shared = PathBuf::new();
+    for (left_component, right_component) in left.components().zip(right.components()) {
+        if left_component != right_component {
+            break;
+        }
+        shared.push(left_component);
+    }
+    shared
+}
+
+/// Nearest ancestor of `dir`, including `dir` itself, holding a project marker.
+fn find_project_root(dir: &Path) -> Option<PathBuf> {
+    dir.ancestors()
+        .filter(|ancestor| !ancestor.as_os_str().is_empty())
+        .find(|ancestor| {
+            PROJECT_ROOT_MARKERS
+                .iter()
+                .any(|marker| ancestor.join(marker).exists())
+        })
+        .map(Path::to_path_buf)
 }
 
 fn count_errors_warnings(diagnostics: &[Diagnostic]) -> (usize, usize) {
@@ -1665,5 +1721,91 @@ mod resolve_fix_mode_tests {
 
         assert!(frame.contains("abc"));
         assert!(frame.contains("^"));
+    }
+}
+
+/// Regression tests for #1368: the workspace root for an explicit path list
+/// must not depend on the order the paths are passed in.
+#[cfg(test)]
+mod resolve_batch_root_tests {
+    use super::*;
+
+    /// `CLAUDE.md` plus a skill file in a subdirectory, the shape pre-commit
+    /// produces. Returns the temp dir and the two paths.
+    fn batch_fixture(marker: bool) -> (tempfile::TempDir, PathBuf, PathBuf) {
+        let temp = tempfile::TempDir::new().unwrap();
+        let skill_dir = temp.path().join(".claude/skills/demo");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        if marker {
+            std::fs::create_dir_all(temp.path().join(".git")).unwrap();
+        }
+
+        let claude_md = temp.path().join("CLAUDE.md");
+        std::fs::write(&claude_md, "# Project\n\n@docs/guide.md\n").unwrap();
+        let skill_md = skill_dir.join("SKILL.md");
+        std::fs::write(&skill_md, "---\nname: demo\n---\n\n# Demo\n").unwrap();
+
+        (temp, claude_md, skill_md)
+    }
+
+    #[test]
+    fn root_is_the_same_in_both_argument_orders() {
+        let (temp, claude_md, skill_md) = batch_fixture(true);
+        let expected = std::fs::canonicalize(temp.path()).unwrap();
+
+        assert_eq!(
+            resolve_batch_root(&[claude_md.clone(), skill_md.clone()]),
+            expected
+        );
+        assert_eq!(resolve_batch_root(&[skill_md, claude_md]), expected);
+    }
+
+    #[test]
+    fn root_is_order_independent_without_any_marker() {
+        let (_temp, claude_md, skill_md) = batch_fixture(false);
+
+        assert_eq!(
+            resolve_batch_root(&[claude_md.clone(), skill_md.clone()]),
+            resolve_batch_root(&[skill_md, claude_md])
+        );
+    }
+
+    #[test]
+    fn root_walks_up_to_marker_when_every_path_is_in_a_subdirectory() {
+        let (temp, _claude_md, skill_md) = batch_fixture(true);
+        let expected = std::fs::canonicalize(temp.path()).unwrap();
+
+        assert_eq!(resolve_batch_root(&[skill_md]), expected);
+    }
+
+    #[test]
+    fn root_without_marker_is_the_common_ancestor() {
+        let (temp, claude_md, skill_md) = batch_fixture(false);
+        // Only meaningful when nothing above the temp dir carries a marker.
+        let temp_root = std::fs::canonicalize(temp.path()).unwrap();
+        if find_project_root(&temp_root).is_some() {
+            return;
+        }
+
+        assert_eq!(resolve_batch_root(&[claude_md, skill_md]), temp_root);
+    }
+
+    // Unix-only: the expected values are spelled with `/`, which does not
+    // round-trip through `PathBuf::push` on Windows.
+    #[cfg(unix)]
+    #[test]
+    fn common_ancestor_stops_at_the_first_differing_component() {
+        assert_eq!(
+            common_ancestor(Path::new("/a/b/c"), Path::new("/a/b/d/e")),
+            PathBuf::from("/a/b")
+        );
+        assert_eq!(
+            common_ancestor(Path::new("/a/b"), Path::new("/a/b")),
+            PathBuf::from("/a/b")
+        );
+        assert_eq!(
+            common_ancestor(Path::new("/a/b"), Path::new("/x/y")),
+            PathBuf::from("/")
+        );
     }
 }

--- a/crates/agnix-cli/tests/cli_integration.rs
+++ b/crates/agnix-cli/tests/cli_integration.rs
@@ -3633,6 +3633,66 @@ fn test_cli_multiple_paths_scope_to_listed_files() {
     );
 }
 
+// Regression test for #1368: the workspace root was taken from the parent of
+// the first path, so `CLAUDE.md`'s root-relative `@imports` were reported as
+// CC-MEM-001 "escapes project root" whenever a file in a subdirectory was
+// listed first. pre-commit passes matched files in sorted order, which puts
+// `.claude/...` ahead of `CLAUDE.md`, so the same tree passed or failed
+// depending on argument order.
+#[test]
+fn test_cli_multiple_paths_root_is_argument_order_independent() {
+    let temp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(temp.path().join("docs")).unwrap();
+    std::fs::create_dir_all(temp.path().join(".claude/skills/demo")).unwrap();
+    std::fs::write(
+        temp.path().join("CLAUDE.md"),
+        "# Project\n\n@docs/guide.md\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("docs/guide.md"), "# Guide\n").unwrap();
+    std::fs::write(
+        temp.path().join(".claude/skills/demo/SKILL.md"),
+        "---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n",
+    )
+    .unwrap();
+
+    let run = |first: &str, second: &str| -> serde_json::Value {
+        let mut cmd = assert_cmd::cargo::cargo_bin_cmd!("agnix");
+        let output = cmd
+            .current_dir(temp.path())
+            .arg(first)
+            .arg(second)
+            .arg("--format")
+            .arg("json")
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        serde_json::from_str(&stdout)
+            .unwrap_or_else(|_| panic!("expected JSON output, got: {stdout}"))
+    };
+
+    let claude_first = run("CLAUDE.md", ".claude/skills/demo/SKILL.md");
+    let skill_first = run(".claude/skills/demo/SKILL.md", "CLAUDE.md");
+
+    for (label, json) in [
+        ("CLAUDE.md first", &claude_first),
+        ("SKILL.md first", &skill_first),
+    ] {
+        let diagnostics = json["diagnostics"].as_array().unwrap();
+        assert!(
+            !diagnostics
+                .iter()
+                .any(|d| d["rule"].as_str() == Some("CC-MEM-001")),
+            "@docs/guide.md exists inside the project, so CC-MEM-001 must not fire ({label}): {json}"
+        );
+    }
+
+    assert_eq!(
+        claude_first["diagnostics"], skill_first["diagnostics"],
+        "diagnostics must not depend on the order the paths are passed in"
+    );
+}
+
 // --watch with more than one path should be rejected with the localized error,
 // not silently pick one. Ensures we don't regress the ergonomics when someone
 // combines --watch with a pre-commit style invocation.


### PR DESCRIPTION
## Summary

CC-MEM-001 reported `Import path escapes project root` for imports that plainly exist inside the project, depending on the order the paths were passed on the command line.

`run_validation` derived one workspace root from `paths.first()` (a file's parent, or the directory itself) and applied it to every file in the batch. `resolve_project_root` in `rules/imports.rs` returns a configured root verbatim, so `find_repo_root` never ran, and the escape check compared `<project>/docs/guide.md` against `<project>/.claude/skills/demo`. pre-commit passes matched files in sorted order, so `.claude/...` sorted ahead of `CLAUDE.md` and became the root.

The root is now the deepest common ancestor of every supplied path, walked up to the nearest `.git` or `.agnix.toml` marker (`.git` accepted as a file or a directory, so worktrees resolve to their own root). The common ancestor removes the argument-order dependence; the marker walk-up also removes the dependence on which files a commit happens to touch, so staging only `sub/CLAUDE.md` no longer roots at `sub/`. Directory arguments still re-resolve their own root inside `validate_project_with_registry`, so `agnix .` is unchanged. With no marker anywhere above the paths, the common ancestor is used as-is.

## Type of Change

- [x] Bug fix

## Checklist

- [x] Tests added/updated
- [x] CHANGELOG.md updated
- [ ] Documentation updated (if applicable) - no documented behavior changes
- [x] `cargo fmt && cargo clippy` passes

## Related Issues

Closes #1368

## Test Plan

The reporter's tree, no git repo, no config file, no CLI flags:

```bash
mkdir -p repro/docs repro/.claude/skills/demo && cd repro
printf '# Project\n\n@docs/guide.md\n' > CLAUDE.md
printf '# Guide\n' > docs/guide.md
printf -- '---\nname: demo\ndescription: Demo skill\n---\n\n# Demo\n' > .claude/skills/demo/SKILL.md
```

Before:

```
$ agnix CLAUDE.md .claude/skills/demo/SKILL.md      -> No issues found            (exit 0)
$ agnix .claude/skills/demo/SKILL.md CLAUDE.md      -> CLAUDE.md:3:1 error: Import path escapes project root: @docs/guide.md
                                                       Found 1 error, 0 warnings  (exit 1)
$ printf '%s\n' .claude/skills/demo/SKILL.md CLAUDE.md | sort | xargs agnix   -> same error (exit 1)
```

After: all three report `No issues found`, and `agnix .` is unchanged (0 errors, 0 warnings, 1 info version-pin notice). Same result in a git-initialized copy, and `agnix sub/CLAUDE.md` alone - a nested memory file with root-relative imports - is now clean too.

Regression coverage:

- `test_cli_multiple_paths_root_is_argument_order_independent` runs the reporter's two-file tree in both orders, asserts CC-MEM-001 does not fire and that the two diagnostic sets are identical. It fails on the pre-fix binary with the exact reported message.
- `resolve_batch_root_tests`: order independence with and without a marker, marker walk-up for a batch entirely inside a subdirectory, and the common-ancestor helper.

Local gates, all green: `cargo fmt --check --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, `cargo test -p agnix-cli --test kiro_ci_gate -- --include-ignored`, `agnix eval tests/eval.yaml` (61/61), rule bookkeeping and rule count checks, locale sync, schema sync, and self-lint `agnix . --config .agnix.toml` (No issues found). A multi-path run against this repo in reversed argument orders produces identical diagnostics and `files_checked`.