### PR TITLE
fix(release): keep the Linux x86_64 gnu binary loadable on older glibc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,15 @@ jobs:
         # it.
         run: bash scripts/check-locale-sync.sh
 
+      - name: Release install path tests
+        if: matrix.os == 'ubuntu-latest'
+        # Covers the glibc floor gate the release build runs and the npm
+        # installer's static-build fallback. Neither ships inside the Rust
+        # workspace, so nothing else exercises them (see #1371).
+        run: |
+          bash scripts/check-glibc-floor.test.sh
+          node npm/test/install-helpers.test.js
+
       - name: Schema sync check
         if: matrix.os == 'ubuntu-latest'
         # Fails if the committed .agnix.toml schema differs from the current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Both gnu targets build through cross so the glibc floor comes from
+          # cross's old sysroot instead of the runner image. Building natively
+          # on ubuntu-latest pinned x86_64 to GLIBC_2.39 and made the binary
+          # unloadable on bookworm, RHEL 9, and Ubuntu 22.04 (issue #1371).
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: agnix
+            cross: true
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             artifact: agnix
@@ -73,6 +78,16 @@ jobs:
       - name: Build release binary (cross)
         if: matrix.cross
         run: cross build --release --target ${{ matrix.target }} -p agnix-cli -p agnix-lsp -p agnix-mcp
+
+      # Fails the release before any asset is published if a build picks up a
+      # glibc newer than the declared floor.
+      - name: Verify glibc floor
+        if: endsWith(matrix.target, '-unknown-linux-gnu')
+        run: |
+          bash scripts/check-glibc-floor.sh \
+            target/${{ matrix.target }}/release/agnix \
+            target/${{ matrix.target }}/release/agnix-lsp \
+            target/${{ matrix.target }}/release/agnix-mcp
 
       - name: Create CLI archive (Unix)
         if: runner.os != 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the deepest common ancestor of every path, walked up to the nearest `.git` or
   `.agnix.toml` marker, so results no longer depend on argument order or on
   which files a commit happens to touch.
+- **Linux x86_64 release binary unusable on glibc older than 2.39**
+  ([#1371](https://github.com/agent-sh/agnix/issues/1371)). The x86_64 gnu
+  build ran natively on `ubuntu-latest`, so it linked the runner's glibc and
+  failed at load time with `version 'GLIBC_2.39' not found` on Debian bookworm,
+  RHEL/Rocky 9, and Ubuntu 22.04. Both gnu targets now build through `cross`
+  against an old sysroot (currently `GLIBC_2.18`), a release gate fails the
+  build if any binary needs newer than `GLIBC_2.31`, and `npm install -g agnix`
+  plus `scripts/download.sh` probe the downloaded binary and retry with the
+  static musl archive when the host cannot load it.
 
 ### Security
 - **Dependency lockfile bumps (website + VS Code extension)**: js-yaml

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -73,6 +73,22 @@ cargo deny check advisories
 
 3. Verify the release at https://github.com/agent-sh/agnix/releases
 
+### glibc floor
+
+Both `*-unknown-linux-gnu` targets build through `cross`, whose sysroot is much
+older than the runner image, and the `Verify glibc floor` step fails the build
+if any of the three binaries references a glibc newer than `GLIBC_FLOOR` in
+`scripts/check-glibc-floor.sh`. Building natively on `ubuntu-latest` instead
+pinned the x86_64 binary to `GLIBC_2.39`, which made it unloadable on Debian
+bookworm, RHEL 9, and Ubuntu 22.04 (#1371).
+
+Do not switch a gnu target back to a native build to shave build time. To check
+a binary by hand:
+
+```bash
+bash scripts/check-glibc-floor.sh target/x86_64-unknown-linux-gnu/release/agnix
+```
+
 ## Post-release Verification
 
 After the release workflow completes, verify all install targets work. This should be automated via a post-release CI workflow.

--- a/npm/install.js
+++ b/npm/install.js
@@ -3,7 +3,7 @@
 const https = require('https');
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 const os = require('os');
 const crypto = require('crypto');
 
@@ -35,12 +35,10 @@ function restoreWrapperBackup(wrapperPath, wrapperBackup, installCompleted) {
 }
 
 /**
- * Get platform-specific asset name and binary name.
+ * Get platform-specific asset name and binary name. Platform and arch are
+ * parameters so tests can cover mappings other than the host's.
  */
-function getPlatformInfo() {
-  const platform = os.platform();
-  const arch = os.arch();
-
+function getPlatformInfo(platform = os.platform(), arch = os.arch()) {
   const mapping = {
     'darwin-arm64': {
       asset: 'agnix-aarch64-apple-darwin.tar.gz',
@@ -55,6 +53,9 @@ function getPlatformInfo() {
     },
     'linux-x64': {
       asset: 'agnix-x86_64-unknown-linux-gnu.tar.gz',
+      // Statically linked, so it runs on hosts whose glibc is older than the
+      // one the gnu build was linked against (issue #1371).
+      fallbackAsset: 'agnix-x86_64-unknown-linux-musl.tar.gz',
       extractedName: 'agnix',
       binary: 'agnix-binary',
     },
@@ -229,11 +230,58 @@ async function verifyChecksum(archivePath, checksumUrl, deps = { downloadFile })
   }
 }
 
+/**
+ * Whether the installed binary can actually execute on this host. A binary
+ * built against a newer glibc than the host provides fails in the dynamic
+ * loader, which npm otherwise only surfaces on the user's first real run.
+ */
+function binaryRuns(binaryPath, deps = { spawnSync }) {
+  try {
+    const result = deps.spawnSync(binaryPath, ['--version'], { stdio: 'ignore' });
+    return !result.error && result.status === 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Download one release asset, verify it, and place the extracted binary at
+ * `binaryPath`. Removes the archive whether or not the download succeeded.
+ */
+async function fetchBinary({ asset, extractedName, binDir, binaryPath }) {
+  const downloadUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${VERSION}/${asset}`;
+  const archivePath = path.join(binDir, asset);
+  const extractedPath = path.join(binDir, extractedName);
+
+  try {
+    await downloadFile(downloadUrl, archivePath);
+    await verifyChecksum(archivePath, `${downloadUrl}.sha256`);
+    console.log('Extracting...');
+    extractArchive(archivePath, binDir);
+
+    // Rename extracted binary to avoid conflict with wrapper script
+    if (fs.existsSync(extractedPath) && extractedPath !== binaryPath) {
+      fs.renameSync(extractedPath, binaryPath);
+    }
+
+    // Make binary executable on Unix
+    if (os.platform() !== 'win32') {
+      fs.chmodSync(binaryPath, 0o755);
+    }
+
+    if (!fs.existsSync(binaryPath)) {
+      throw new Error('Binary not found after extraction');
+    }
+  } finally {
+    // Best-effort cleanup so a failed install leaves no stale archive.
+    removeIfExists(archivePath);
+  }
+}
+
 async function main() {
   const platformInfo = getPlatformInfo();
   const binDir = path.join(__dirname, 'bin');
   const binaryPath = path.join(binDir, platformInfo.binary);
-  const extractedPath = path.join(binDir, platformInfo.extractedName);
   const wrapperPath = path.join(binDir, 'agnix');
   const wrapperBackup = path.join(binDir, 'agnix.backup');
   let installCompleted = false;
@@ -249,9 +297,6 @@ async function main() {
     fs.mkdirSync(binDir, { recursive: true });
   }
 
-  const downloadUrl = `https://github.com/${GITHUB_REPO}/releases/download/v${VERSION}/${platformInfo.asset}`;
-  const archivePath = path.join(binDir, platformInfo.asset);
-
   console.log(`Downloading agnix v${VERSION} for ${os.platform()}-${os.arch()}...`);
 
   try {
@@ -260,14 +305,30 @@ async function main() {
       fs.copyFileSync(wrapperPath, wrapperBackup);
     }
 
-    await downloadFile(downloadUrl, archivePath);
-    await verifyChecksum(archivePath, `${downloadUrl}.sha256`);
-    console.log('Extracting...');
-    extractArchive(archivePath, binDir);
+    await fetchBinary({
+      asset: platformInfo.asset,
+      extractedName: platformInfo.extractedName,
+      binDir,
+      binaryPath,
+    });
 
-    // Rename extracted binary to avoid conflict with wrapper script
-    if (fs.existsSync(extractedPath) && extractedPath !== binaryPath) {
-      fs.renameSync(extractedPath, binaryPath);
+    let runs = binaryRuns(binaryPath);
+
+    // The default Linux asset is glibc-linked, so on a host older than the
+    // build's glibc floor it cannot load at all. Retry with the static build
+    // rather than leaving behind a binary that dies in the dynamic loader.
+    if (!runs && platformInfo.fallbackAsset) {
+      console.log(
+        `Downloaded binary cannot run on this host, retrying with ${platformInfo.fallbackAsset}...`
+      );
+      removeIfExists(binaryPath);
+      await fetchBinary({
+        asset: platformInfo.fallbackAsset,
+        extractedName: platformInfo.extractedName,
+        binDir,
+        binaryPath,
+      });
+      runs = binaryRuns(binaryPath);
     }
 
     // Restore wrapper script if it was backed up
@@ -275,14 +336,11 @@ async function main() {
       fs.renameSync(wrapperBackup, wrapperPath);
     }
 
-    // Make binary executable on Unix
-    if (os.platform() !== 'win32') {
-      fs.chmodSync(binaryPath, 0o755);
-    }
-
-    // Verify binary exists
-    if (!fs.existsSync(binaryPath)) {
-      throw new Error('Binary not found after extraction');
+    if (!runs) {
+      // Keep the install itself successful: some sandboxes forbid spawning
+      // during postinstall, and the binary is on disk either way.
+      console.warn('Warning: the installed agnix binary did not run on this host.');
+      console.warn('If `agnix --version` fails, build from source with: cargo install agnix-cli');
     }
 
     installCompleted = true;
@@ -294,8 +352,8 @@ async function main() {
     console.error('  cargo install agnix-cli');
     process.exitCode = 1;
   } finally {
-    // Best-effort cleanup so a failed install leaves no stale archive or backup.
-    removeIfExists(archivePath);
+    // Best-effort cleanup so a failed install leaves no stale backup. Archives
+    // are removed by fetchBinary itself.
     try {
       restoreWrapperBackup(wrapperPath, wrapperBackup, installCompleted);
     } catch (_) {
@@ -309,8 +367,10 @@ if (require.main === module) {
 }
 
 module.exports = {
+  binaryRuns,
   downloadFile,
   extractArchive,
+  fetchBinary,
   getPlatformInfo,
   main,
   parseSha256Sidecar,

--- a/npm/test/install-helpers.test.js
+++ b/npm/test/install-helpers.test.js
@@ -11,6 +11,8 @@ const os = require('os');
 const path = require('path');
 
 const {
+  binaryRuns,
+  getPlatformInfo,
   parseSha256Sidecar,
   restoreWrapperBackup,
   sha256File,
@@ -155,6 +157,62 @@ async function withTempDir(fn) {
       assert.strictEqual(fs.readFileSync(wrapperPath, 'utf8'), 'installed wrapper');
       assert.ok(!fs.existsSync(wrapperBackup), 'stale backup should be removed');
     });
+  });
+
+  await test('binaryRuns reports success only on a clean exit', () => {
+    assert.strictEqual(
+      binaryRuns('/does/not/matter', { spawnSync: () => ({ status: 0 }) }),
+      true
+    );
+    assert.strictEqual(
+      binaryRuns('/does/not/matter', { spawnSync: () => ({ status: 127 }) }),
+      false
+    );
+  });
+
+  await test('binaryRuns treats a loader failure as not runnable', () => {
+    // What a glibc-too-old host produces: the process never starts.
+    assert.strictEqual(
+      binaryRuns('/does/not/matter', {
+        spawnSync: () => ({ error: new Error('ENOEXEC'), status: null }),
+      }),
+      false
+    );
+    assert.strictEqual(
+      binaryRuns('/does/not/matter', {
+        spawnSync: () => {
+          throw new Error('spawn blocked');
+        },
+      }),
+      false
+    );
+  });
+
+  await test('binaryRuns detects a real executable', () => {
+    assert.strictEqual(binaryRuns(process.execPath), true);
+  });
+
+  await test('linux-x64 carries the static musl fallback asset', () => {
+    // Guard for #1371: the gnu asset cannot load on hosts whose glibc is older
+    // than the build's floor, so the installer needs a static alternative.
+    const info = getPlatformInfo('linux', 'x64');
+
+    assert.strictEqual(info.asset, 'agnix-x86_64-unknown-linux-gnu.tar.gz');
+    assert.strictEqual(info.fallbackAsset, 'agnix-x86_64-unknown-linux-musl.tar.gz');
+  });
+
+  await test('platforms without a static build declare no fallback', () => {
+    for (const [platform, arch] of [
+      ['darwin', 'arm64'],
+      ['linux', 'arm64'],
+      ['win32', 'x64'],
+    ]) {
+      assert.strictEqual(
+        getPlatformInfo(platform, arch).fallbackAsset,
+        undefined,
+        `${platform}-${arch} must not claim a fallback asset that is not published`
+      );
+    }
   });
 
   console.log(`\nResults: ${passed} passed, ${failed} failed`);

--- a/scripts/check-glibc-floor.sh
+++ b/scripts/check-glibc-floor.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Fail if a released glibc-linked binary requires a newer glibc than the
+# declared floor.
+#
+# Usage:
+#   bash scripts/check-glibc-floor.sh <binary> [binary...]
+#   GLIBC_FLOOR=2.28 bash scripts/check-glibc-floor.sh <binary>
+#
+# The floor exists because release binaries are consumed on distros far older
+# than the GitHub runner image: Debian bookworm ships glibc 2.36, RHEL 9 and
+# Amazon Linux 2023 ship 2.34, Ubuntu 22.04 ships 2.35. Building natively on
+# ubuntu-latest pinned the floor to the runner's glibc and broke all of them
+# (issue #1371), so the gnu targets build through `cross` and this check keeps
+# a runner-image bump from silently raising the floor again.
+#
+# Only ELF binaries linked against glibc are meaningful here. Static musl
+# builds have no version references at all and pass trivially.
+
+set -euo pipefail
+
+# Debian bullseye / Ubuntu 20.04. The cross 0.2.5 gnu images are older still
+# (Ubuntu 16.04, glibc 2.23), so this leaves headroom for an image bump without
+# giving up any distro the project supports.
+GLIBC_FLOOR="${GLIBC_FLOOR:-2.31}"
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 <binary> [binary...]" >&2
+    exit 2
+fi
+
+# Without readelf every binary would report zero version references and pass,
+# turning the release gate into a no-op.
+if [ -z "${AGNIX_GLIBC_REFS:-}" ] && ! command -v readelf >/dev/null 2>&1; then
+    echo "Error: readelf is required (install binutils)" >&2
+    exit 2
+fi
+
+# Highest glibc version referenced by a binary, empty when none are.
+# AGNIX_GLIBC_REFS overrides the extraction for the unit tests, which need to
+# exercise the comparison without producing binaries for each glibc version.
+glibc_refs() {
+    local binary="$1"
+
+    if [ -n "${AGNIX_GLIBC_REFS:-}" ]; then
+        # Word splitting is the point: the override is a space-separated list.
+        # shellcheck disable=SC2086
+        printf '%s\n' ${AGNIX_GLIBC_REFS}
+        return 0
+    fi
+
+    if [ ! -f "$binary" ]; then
+        echo "Error: no such binary: $binary" >&2
+        return 1
+    fi
+
+    # A non-ELF file also yields zero references, so reject it instead of
+    # reporting it as a clean static build.
+    if ! readelf -h "$binary" >/dev/null 2>&1; then
+        echo "Error: not an ELF binary: $binary" >&2
+        return 1
+    fi
+
+    readelf -V "$binary" 2>/dev/null | grep -o 'GLIBC_[0-9][0-9.]*' | sed 's/^GLIBC_//' || true
+}
+
+# 0 when $1 is newer than $2. sort -V orders 2.9 before 2.10, which a plain
+# string or float comparison gets wrong.
+version_gt() {
+    [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]
+}
+
+status=0
+
+for binary in "$@"; do
+    # Release archives skip binaries a target does not produce, so a missing
+    # path is only an error when it was named explicitly and cannot be read.
+    refs="$(glibc_refs "$binary")" || {
+        status=1
+        continue
+    }
+
+    if [ -z "$refs" ]; then
+        echo "ok   $binary: no glibc version references (static or non-glibc)"
+        continue
+    fi
+
+    highest="$(printf '%s\n' "$refs" | sort -uV | tail -1)"
+
+    if version_gt "$highest" "$GLIBC_FLOOR"; then
+        echo "FAIL $binary: requires GLIBC_$highest, floor is GLIBC_$GLIBC_FLOOR" >&2
+        echo "     symbols above the floor:" >&2
+        readelf --dyn-syms -W "$binary" 2>/dev/null |
+            grep -oE '[A-Za-z_0-9]+@GLIBC_[0-9][0-9.]*' |
+            sort -u |
+            while IFS= read -r symbol; do
+                version="${symbol##*@GLIBC_}"
+                if version_gt "$version" "$GLIBC_FLOOR"; then
+                    echo "       $symbol" >&2
+                fi
+            done
+        status=1
+    else
+        echo "ok   $binary: requires GLIBC_$highest, floor is GLIBC_$GLIBC_FLOOR"
+    fi
+done
+
+exit "$status"

--- a/scripts/check-glibc-floor.test.sh
+++ b/scripts/check-glibc-floor.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/check-glibc-floor.sh.
+#
+# Run:
+#   bash scripts/check-glibc-floor.test.sh
+#
+# Drives the checker through AGNIX_GLIBC_REFS so every glibc floor scenario is
+# covered without needing a binary built against that glibc. Guards the two
+# things that would make the release gate useless: version-aware comparison
+# (2.9 is older than 2.10, 2.4 is older than 2.39) and a non-zero exit when a
+# binary sits above the floor.
+
+set -uo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+checker="$script_dir/check-glibc-floor.sh"
+
+pass=0
+fail=0
+
+# assert_check <expected: ok|fail> <name> <floor> <refs>
+assert_check() {
+    local expected="$1" name="$2" floor="$3" refs="$4" actual output
+
+    if output=$(AGNIX_GLIBC_REFS="$refs" GLIBC_FLOOR="$floor" bash "$checker" /dev/null 2>&1); then
+        actual="ok"
+    else
+        actual="fail"
+    fi
+
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  ok   - $name (expected $expected)"
+        pass=$((pass + 1))
+    else
+        echo "  FAIL - $name (expected $expected, got $actual)"
+        echo "         output: $output"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "check-glibc-floor.sh:"
+
+assert_check ok "all references below the floor" 2.31 "2.2.5 2.14 2.17 2.23"
+assert_check ok "reference equal to the floor" 2.31 "2.17 2.31"
+assert_check fail "reference above the floor" 2.31 "2.17 2.34"
+assert_check fail "the v0.48.0 x86_64 reference set" 2.31 "2.2.5 2.17 2.34 2.39"
+assert_check ok "the v0.48.0 aarch64 reference set" 2.31 "2.17 2.18"
+assert_check fail "2.4 must not read as newer than 2.39" 2.4 "2.39"
+assert_check ok "2.10 must read as newer than 2.9" 2.31 "2.9 2.10"
+assert_check fail "2.9 must not read as newer than 2.10" 2.9 "2.10"
+assert_check ok "no references at all (static musl)" 2.31 " "
+
+# A named binary that cannot be read has to fail rather than pass silently, or
+# a renamed release artifact would slip through the gate.
+if bash "$checker" "$script_dir/does-not-exist" >/dev/null 2>&1; then
+    echo "  FAIL - missing binary (expected fail, got ok)"
+    fail=$((fail + 1))
+else
+    echo "  ok   - missing binary (expected fail)"
+    pass=$((pass + 1))
+fi
+
+# No arguments is a usage error, not a vacuous pass.
+bash "$checker" >/dev/null 2>&1
+if [[ "$?" -eq 2 ]]; then
+    echo "  ok   - no arguments exits 2 (expected fail)"
+    pass=$((pass + 1))
+else
+    echo "  FAIL - no arguments must exit 2 with a usage message"
+    fail=$((fail + 1))
+fi
+
+# A file that is not an ELF binary reports zero glibc references, which would
+# otherwise look identical to a clean static build.
+non_elf=$(mktemp)
+printf '#!/bin/sh\necho not an elf\n' > "$non_elf"
+if bash "$checker" "$non_elf" >/dev/null 2>&1; then
+    echo "  FAIL - non-ELF file (expected fail, got ok)"
+    fail=$((fail + 1))
+else
+    echo "  ok   - non-ELF file (expected fail)"
+    pass=$((pass + 1))
+fi
+rm -f "$non_elf"
+
+# Without readelf every binary would report zero references and pass, so the
+# checker must refuse to run instead of green-lighting the release.
+empty_path_dir=$(mktemp -d)
+env -i "PATH=$empty_path_dir" /bin/bash "$checker" "$checker" >/dev/null 2>&1
+if [[ "$?" -eq 2 ]]; then
+    echo "  ok   - missing readelf exits 2 (expected fail)"
+    pass=$((pass + 1))
+else
+    echo "  FAIL - missing readelf must exit 2 instead of passing"
+    fail=$((fail + 1))
+fi
+rmdir "$empty_path_dir"
+
+echo
+echo "passed: $pass  failed: $fail"
+[[ "$fail" -eq 0 ]]

--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -66,6 +66,9 @@ case "${OS}" in
             x86_64)
                 TARGET="x86_64-unknown-linux-gnu"
                 EXT="tar.gz"
+                # Statically linked, so it still runs when the host glibc is
+                # older than the one the gnu build was linked against (#1371).
+                FALLBACK_TARGET="x86_64-unknown-linux-musl"
                 ;;
             *)
                 echo "Error: Unsupported Linux architecture: ${ARCH}" >&2
@@ -103,6 +106,7 @@ esac
 # Set binary name (Windows uses .exe extension)
 BINARY_NAME="${BINARY_NAME:-agnix}"
 ARTIFACT_NAME="agnix-${TARGET}.${EXT}"
+FALLBACK_TARGET="${FALLBACK_TARGET:-}"
 
 # Resolve version
 if [ "${VERSION}" = "latest" ]; then
@@ -122,94 +126,120 @@ if [ "${VERSION}" = "latest" ]; then
     fi
 fi
 
-echo "Downloading agnix ${VERSION} for ${TARGET}..."
-
-# Download URL
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT_NAME}"
-
 # Download and extract
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "${TEMP_DIR}"' EXIT
 
-echo "Downloading from ${DOWNLOAD_URL}..."
-HTTP_CODE=$(curl -sL -w "%{http_code}" "${DOWNLOAD_URL}" -o "${TEMP_DIR}/${ARTIFACT_NAME}")
+# install_artifact <artifact-name>
+# Downloads one release artifact, verifies it against its checksum sidecar, and
+# extracts it into BIN_DIR. Integrity failures exit non-zero: never install an
+# artifact that failed verification.
+install_artifact() {
+    ARTIFACT_NAME="$1"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARTIFACT_NAME}"
 
-if [ "${HTTP_CODE}" != "200" ]; then
-    echo "Error: Failed to download release (HTTP ${HTTP_CODE})" >&2
-    echo "URL: ${DOWNLOAD_URL}" >&2
-    exit 1
-fi
+    echo "Downloading from ${DOWNLOAD_URL}..."
+    HTTP_CODE=$(curl -sL -w "%{http_code}" "${DOWNLOAD_URL}" -o "${TEMP_DIR}/${ARTIFACT_NAME}")
 
-CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
-CHECKSUM_FILE="${TEMP_DIR}/${ARTIFACT_NAME}.sha256"
+    if [ "${HTTP_CODE}" != "200" ]; then
+        echo "Error: Failed to download release (HTTP ${HTTP_CODE})" >&2
+        echo "URL: ${DOWNLOAD_URL}" >&2
+        exit 1
+    fi
 
-echo "Downloading checksum from ${CHECKSUM_URL}..."
-HTTP_CODE=$(curl -sL -w "%{http_code}" "${CHECKSUM_URL}" -o "${CHECKSUM_FILE}")
+    CHECKSUM_URL="${DOWNLOAD_URL}.sha256"
+    CHECKSUM_FILE="${TEMP_DIR}/${ARTIFACT_NAME}.sha256"
 
-if [ "${HTTP_CODE}" != "200" ]; then
-    echo "Error: Failed to download release checksum (HTTP ${HTTP_CODE})" >&2
-    echo "URL: ${CHECKSUM_URL}" >&2
-    exit 1
-fi
+    echo "Downloading checksum from ${CHECKSUM_URL}..."
+    HTTP_CODE=$(curl -sL -w "%{http_code}" "${CHECKSUM_URL}" -o "${CHECKSUM_FILE}")
 
-EXPECTED_SHA="$(awk -v expected="${ARTIFACT_NAME}" '
-NF {
-    hash = tolower($1)
-    file = $2
-    sub(/^\*/, "", file)
-    sub(/\r$/, "", file)
-    n = split(file, parts, /[\\\/]/)
-    base = parts[n]
-    if (base == expected) {
-        print hash
-        found = 1
-        exit
+    if [ "${HTTP_CODE}" != "200" ]; then
+        echo "Error: Failed to download release checksum (HTTP ${HTTP_CODE})" >&2
+        echo "URL: ${CHECKSUM_URL}" >&2
+        exit 1
+    fi
+
+    EXPECTED_SHA="$(awk -v expected="${ARTIFACT_NAME}" '
+    NF {
+        hash = tolower($1)
+        file = $2
+        sub(/^\*/, "", file)
+        sub(/\r$/, "", file)
+        n = split(file, parts, /[\\\/]/)
+        base = parts[n]
+        if (base == expected) {
+            print hash
+            found = 1
+            exit
+        }
     }
-}
-END {
-    if (!found) {
+    END {
+        if (!found) {
+            exit 1
+        }
+    }
+    ' "${CHECKSUM_FILE}")" || {
+        echo "Error: Checksum file does not contain an entry for ${ARTIFACT_NAME}" >&2
         exit 1
     }
+    if ! printf '%s\n' "${EXPECTED_SHA}" | grep -Eq '^[0-9a-f]{64}$'; then
+        echo "Error: Invalid checksum file for ${ARTIFACT_NAME}" >&2
+        exit 1
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        ACTUAL_SHA="$(sha256sum "${TEMP_DIR}/${ARTIFACT_NAME}" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')"
+    elif command -v shasum >/dev/null 2>&1; then
+        ACTUAL_SHA="$(shasum -a 256 "${TEMP_DIR}/${ARTIFACT_NAME}" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')"
+    else
+        echo "Error: sha256sum or shasum is required to verify downloads" >&2
+        exit 1
+    fi
+
+    if [ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]; then
+        echo "Error: Checksum mismatch for ${ARTIFACT_NAME}" >&2
+        echo "Expected: ${EXPECTED_SHA}" >&2
+        echo "Actual:   ${ACTUAL_SHA}" >&2
+        exit 1
+    fi
+
+    echo "Checksum verified."
+
+    echo "Extracting..."
+    case "${ARTIFACT_NAME}" in
+        *.tar.gz)
+            tar -xzf "${TEMP_DIR}/${ARTIFACT_NAME}" -C "${BIN_DIR}"
+            ;;
+        *.zip)
+            unzip -q -o "${TEMP_DIR}/${ARTIFACT_NAME}" -d "${BIN_DIR}"
+            ;;
+    esac
+
+    # Make executable (use correct binary name for platform)
+    chmod +x "${BIN_DIR}/${BINARY_NAME}" 2>/dev/null || true
 }
-' "${CHECKSUM_FILE}")" || {
-    echo "Error: Checksum file does not contain an entry for ${ARTIFACT_NAME}" >&2
-    exit 1
-}
-if ! printf '%s\n' "${EXPECTED_SHA}" | grep -Eq '^[0-9a-f]{64}$'; then
-    echo "Error: Invalid checksum file for ${ARTIFACT_NAME}" >&2
-    exit 1
+
+echo "Downloading agnix ${VERSION} for ${TARGET}..."
+install_artifact "agnix-${TARGET}.${EXT}"
+
+# A binary built against a newer glibc than this host provides dies in the
+# dynamic loader, so probe it and retry with the static build when one exists
+# rather than leaving an unusable binary on PATH (#1371).
+if ! "${BIN_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
+    if [ -n "${FALLBACK_TARGET}" ]; then
+        echo "Downloaded binary cannot run on this host, retrying with ${FALLBACK_TARGET}..."
+        install_artifact "agnix-${FALLBACK_TARGET}.tar.gz"
+        if ! "${BIN_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then
+            echo "Error: neither ${TARGET} nor ${FALLBACK_TARGET} runs on this host" >&2
+            echo "Set BUILD_FROM_SOURCE=true to build from source instead." >&2
+            exit 1
+        fi
+    else
+        echo "Error: the downloaded ${TARGET} binary does not run on this host" >&2
+        echo "Set BUILD_FROM_SOURCE=true to build from source instead." >&2
+        exit 1
+    fi
 fi
-
-if command -v sha256sum >/dev/null 2>&1; then
-    ACTUAL_SHA="$(sha256sum "${TEMP_DIR}/${ARTIFACT_NAME}" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')"
-elif command -v shasum >/dev/null 2>&1; then
-    ACTUAL_SHA="$(shasum -a 256 "${TEMP_DIR}/${ARTIFACT_NAME}" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')"
-else
-    echo "Error: sha256sum or shasum is required to verify downloads" >&2
-    exit 1
-fi
-
-if [ "${ACTUAL_SHA}" != "${EXPECTED_SHA}" ]; then
-    echo "Error: Checksum mismatch for ${ARTIFACT_NAME}" >&2
-    echo "Expected: ${EXPECTED_SHA}" >&2
-    echo "Actual:   ${ACTUAL_SHA}" >&2
-    exit 1
-fi
-
-echo "Checksum verified."
-
-echo "Extracting..."
-case "${EXT}" in
-    tar.gz)
-        tar -xzf "${TEMP_DIR}/${ARTIFACT_NAME}" -C "${BIN_DIR}"
-        ;;
-    zip)
-        unzip -q -o "${TEMP_DIR}/${ARTIFACT_NAME}" -d "${BIN_DIR}"
-        ;;
-esac
-
-# Make executable (use correct binary name for platform)
-chmod +x "${BIN_DIR}/${BINARY_NAME}" 2>/dev/null || true
 
 # Add to PATH for subsequent steps
 echo "${BIN_DIR}" >> "${GITHUB_PATH:-/dev/null}"

--- a/tests/release_workflow.rs
+++ b/tests/release_workflow.rs
@@ -173,6 +173,101 @@ fn release_workflow_pins_latest_versioned_docs_to_the_release_tag() {
 }
 
 #[test]
+fn release_workflow_builds_gnu_linux_targets_below_the_glibc_floor() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let workflow = fs::read_to_string(format!("{root}/.github/workflows/release.yml"))
+        .expect("failed to read release workflow")
+        .replace("\r\n", "\n");
+
+    // Building x86_64 natively on ubuntu-latest pinned the binary to the
+    // runner's glibc (GLIBC_2.39), which made it unloadable on bookworm,
+    // RHEL 9, and Ubuntu 22.04. cross builds against an old sysroot instead.
+    for target in ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"] {
+        let entry = format!(
+            "            target: {target}\n            artifact: agnix\n            cross: true"
+        );
+        assert!(
+            workflow.contains(&entry),
+            "{target} must build through cross so the glibc floor comes from the cross sysroot"
+        );
+    }
+
+    assert!(
+        workflow.contains(
+            "- name: Verify glibc floor\n        if: endsWith(matrix.target, '-unknown-linux-gnu')"
+        ),
+        "release workflow must check the glibc floor of every gnu Linux build"
+    );
+    assert!(
+        workflow.contains("bash scripts/check-glibc-floor.sh"),
+        "the glibc floor step must run the checker script"
+    );
+    for binary in ["release/agnix", "release/agnix-lsp", "release/agnix-mcp"] {
+        assert!(
+            workflow.contains(&format!("target/${{{{ matrix.target }}}}/{binary}")),
+            "the glibc floor check must cover {binary}"
+        );
+    }
+}
+
+#[test]
+fn ci_runs_the_release_install_path_tests() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let workflow = fs::read_to_string(format!("{root}/.github/workflows/ci.yml"))
+        .expect("failed to read CI workflow")
+        .replace("\r\n", "\n");
+
+    assert!(
+        workflow.contains(
+            "- name: Release install path tests\n        if: matrix.os == 'ubuntu-latest'"
+        ),
+        "CI must run the release install path tests on Ubuntu"
+    );
+    assert!(
+        workflow.contains("bash scripts/check-glibc-floor.test.sh"),
+        "CI must run the glibc floor checker's own tests"
+    );
+    assert!(
+        workflow.contains("node npm/test/install-helpers.test.js"),
+        "CI must run the npm installer helper tests"
+    );
+}
+
+#[test]
+fn install_paths_fall_back_to_the_static_linux_build() {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let script = fs::read_to_string(format!("{root}/scripts/download.sh"))
+        .expect("failed to read download script");
+    let installer =
+        fs::read_to_string(format!("{root}/npm/install.js")).expect("failed to read npm installer");
+
+    // A glibc-linked binary that the host cannot load leaves both install
+    // paths with a binary that dies in the dynamic loader, so each has to probe
+    // the download and retry with the static musl artifact.
+    assert!(
+        script.contains(r#"FALLBACK_TARGET="x86_64-unknown-linux-musl""#),
+        "download script must know the static Linux fallback target"
+    );
+    assert!(
+        script.contains(r#"install_artifact "agnix-${FALLBACK_TARGET}.tar.gz""#),
+        "download script must install the fallback artifact when the primary cannot run"
+    );
+    assert!(
+        script.contains(r#"if ! "${BIN_DIR}/${BINARY_NAME}" --version >/dev/null 2>&1; then"#),
+        "download script must probe the downloaded binary before trusting it"
+    );
+
+    assert!(
+        installer.contains("fallbackAsset: 'agnix-x86_64-unknown-linux-musl.tar.gz'"),
+        "npm installer must map linux-x64 to a static fallback asset"
+    );
+    assert!(
+        installer.contains("if (!runs && platformInfo.fallbackAsset) {"),
+        "npm installer must retry with the fallback asset when the binary cannot run"
+    );
+}
+
+#[test]
 fn action_download_script_verifies_release_checksum() {
     let root = env!("CARGO_MANIFEST_DIR");
     let script = fs::read_to_string(format!("{root}/scripts/download.sh"))

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -35,6 +35,16 @@ cargo install agnix-cli
 
 Download from [GitHub Releases](https://github.com/agent-sh/agnix/releases) for your platform.
 
+Two Linux x86_64 archives are published:
+
+| Archive | Use it when |
+|---------|-------------|
+| `agnix-x86_64-unknown-linux-gnu.tar.gz` | Default. Releases are gated to require no more than glibc 2.31; current builds need only 2.18. |
+| `agnix-x86_64-unknown-linux-musl.tar.gz` | Statically linked, no glibc dependency. Use it on musl distros such as Alpine, or on any host where the gnu build reports a missing `GLIBC_...` version. |
+
+The npm installer and the GitHub Action pick the gnu build and switch to the
+static musl build automatically if it cannot run on the host.
+
 ## Verify installation
 
 ```bash


### PR DESCRIPTION
Fixes #1371.

## Cause

`x86_64-unknown-linux-gnu` was the only Linux gnu target built natively on `ubuntu-latest`, so it linked against the runner image's glibc. The published v0.48.0 binary carries a non-weak `GLIBC_2.39` verneed entry:

```
$ readelf -V agnix | grep -A2 'GLIBC_2.39'
  0x0080: Name: GLIBC_2.39  Flags: none  Version: 12
```

The symbols are `pidfd_spawnp` / `pidfd_getpid`, pulled in by Rust std's process-spawn path and new in glibc 2.39. Because the verneed entry is not weak, the dynamic loader refuses to start the process at all:

```
$ ./agnix --version
./agnix: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./agnix)
```

That is fatal on every distro older than Ubuntu 24.04: Debian bookworm (2.36), Ubuntu 22.04 (2.35), RHEL/Rocky 9 and Amazon Linux 2023 (2.34). `aarch64-unknown-linux-gnu` was never affected - it already built through `cross`, and tops out at `GLIBC_2.18`.

## Fix

1. **Both gnu targets build through `cross`** (`.github/workflows/release.yml`). The cross 0.2.5 gnu image is Ubuntu 16.04 / glibc 2.23. Measured on the release profile locally, all three binaries now top out at `GLIBC_2.18`:

   ```
   ok   target/x86_64-unknown-linux-gnu/release/agnix: requires GLIBC_2.18, floor is GLIBC_2.31
   ok   target/x86_64-unknown-linux-gnu/release/agnix-lsp: requires GLIBC_2.18, floor is GLIBC_2.31
   ok   target/x86_64-unknown-linux-gnu/release/agnix-mcp: requires GLIBC_2.18, floor is GLIBC_2.31
   ```

2. **A release-time floor gate** (`scripts/check-glibc-floor.sh`, run in the build job for every gnu target). Fails the release before any asset is published if a binary needs newer than `GLIBC_FLOOR` (default 2.31). A runner-image or toolchain bump cannot silently raise the floor again. The script exits 2 rather than passing when `readelf` is missing, and rejects non-ELF inputs, so neither situation can produce a vacuous green.

3. **Static-build fallback in both install paths** (`npm/install.js`, `scripts/download.sh`). Each now runs `--version` on what it downloaded and, on Linux x86_64, retries with `agnix-x86_64-unknown-linux-musl.tar.gz` when the binary cannot start. Users on hosts below the floor get a working install rather than a binary that dies in the loader. Platforms with no published static build declare no fallback and fail with an actionable message instead of installing something unusable.

## Verification

End-to-end in Docker against the **real published v0.48.0 assets**.

Debian bookworm (glibc 2.36), before:

```
./agnix: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by ./agnix)
exit 1
```

Debian bookworm, after - `npm install -g agnix`:

```
Downloading agnix v0.48.0 for linux-x64...
Checksum verified.
Downloaded binary cannot run on this host, retrying with agnix-x86_64-unknown-linux-musl.tar.gz...
Checksum verified.
agnix 0.48.0
exit 0
```

Debian bookworm, after - `scripts/download.sh`: same fallback line, then `agnix 0.48.0`, script exit 0.

Debian trixie (glibc 2.41), after: no fallback triggered, works directly.

Local gates:

- `cargo fmt --check --all` - clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` - clean
- `cargo test --workspace` - 0 failed (includes 3 new `tests/release_workflow.rs` tests)
- `bash scripts/check-glibc-floor.test.sh` - 13 passed, 0 failed
- `node npm/test/install-helpers.test.js` - 14 passed, 0 failed
- `shellcheck scripts/check-glibc-floor.sh scripts/check-glibc-floor.test.sh scripts/download.sh` - clean
- `agnix -- eval tests/eval.yaml` - all 61 cases passed
- self-lint, locale sync, rule bookkeeping, rule counts - all green

## Tests

Nothing here ships inside the Rust workspace, so CI gains a `Release install path tests` step (ubuntu-only) running the two new suites:

- `scripts/check-glibc-floor.test.sh` - 13 assertions covering version-aware comparison (2.9 < 2.10, 2.4 < 2.39), the actual v0.48.0 x86_64 reference set (must fail) and aarch64 set (must pass), static musl with no references, missing binary, non-ELF input, missing `readelf`, and no arguments.
- `npm/test/install-helpers.test.js` - 5 new assertions on `binaryRuns` (clean exit only, loader failure and throw both treated as not runnable, real executable) and the platform-to-fallback-asset mapping.
- `tests/release_workflow.rs` - 3 new tests asserting both gnu targets carry `cross: true`, the floor step exists with its target guard and covers all three binaries, CI runs the install-path suites, and both installers keep their fallback wiring.