### PR TITLE
release: v0.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.48.1] - 2026-08-15
+
 ### Fixed
 - **Skill directory size exclusions** (#1360). AS-015 now omits paths matched
   by top-level `exclude` or `[files].exclude` when calculating the 8 MB skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.48.1] - 2026-08-15
 
+### Changed
+- **Tool release and spec baselines** (#1354). Advanced the tracked releases for
+  Claude Code (`v2.1.226` to `v2.1.229`), OpenCode (`v1.18.15` to `v1.18.17`),
+  Kiro CLI (`2.16.0` to `2.17.0`), Cline (`v4.1.6` to `v4.1.8`), Cursor
+  (`3.15.6` to `3.15.19`), Gemini CLI (`v0.54.4` to `v0.55.1`), and amp (news
+  marker `size-the-orbs-of-production` to `global-plugins-and-skills`), plus the
+  `cursor-environment` spec hash. Registered the `output_style`, `gemini_agent`,
+  and per-client skill validators in the tool inventory and filled in the
+  matching config surfaces and rule prefixes (`CC-OS`, `MCP`, `OC-SK`, `CR-SK`,
+  `GM-AG`) in `knowledge-base/RESEARCH-TRACKING.md`. Watcher bookkeeping only -
+  no validation behaviour changes.
+
 ### Fixed
 - **Skill directory size exclusions** (#1360). AS-015 now omits paths matched
   by top-level `exclude` or `[files].exclude` when calculating the 8 MB skill

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -99,14 +99,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.48.0"
+version = "0.48.1"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -33,8 +33,8 @@ categories = ["development-tools", "command-line-utilities"]
 [workspace.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.48.0" }
-agnix-core = { path = "crates/agnix-core", version = "0.48.0" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.48.1" }
+agnix-core = { path = "crates/agnix-core", version = "0.48.1" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.agnix
 pluginName = agnix
 pluginRepositoryUrl = https://github.com/agent-sh/agnix
 # SemVer format -> https://semver.org
-pluginVersion = 0.48.0
+pluginVersion = 0.48.1
 
 # Supported build number ranges and IntelliJ Platform Versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.48.0"
+version = "0.48.1"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "Lint agent configurations before they break your workflow. 447 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",


### PR DESCRIPTION
Patch release. No API changes.

## Fixed

- **Skill directory size exclusions** (#1360) - AS-015 now honours `exclude` patterns when totalling the 8 MB skill directory size.
- **CC-MEM-001 false positive with multiple CLI paths** (#1368, #1370) - the batch root is the deepest common ancestor walked up to the nearest `.git`/`.agnix.toml` marker, so results no longer depend on argument order.
- **Linux x86_64 binary unloadable below glibc 2.39** (#1371, #1372) - both gnu targets build through `cross` (now `GLIBC_2.18`), a release gate fails the build above `GLIBC_2.31`, and both install paths fall back to the static musl archive when the gnu binary cannot run.

## Security

- Lockfile bumps for js-yaml GHSA-5p4m-2wfm-xmqj and nanoid GHSA-2v37-7h3g-55p8 (website + VS Code extension). Lockfile-only.

## Pre-release checks

`cargo fmt --check --all`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, `agnix eval tests/eval.yaml` (61/61), self-lint, `cargo audit` (only the two allowlisted warnings), `cargo deny check advisories` - all clean. `agnix --version` reports `0.48.1`.

Version synced across all manifests via `scripts/sync-versions.sh`.

