### PR TITLE
feat(tools): sync Aug 15 tool-release baselines, add CC-SET-024

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-08-13",
+  "last_updated": "2026-08-15",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -17,7 +17,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.229",
+      "last_known_version": "v2.1.232",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -99,7 +99,7 @@
         "per_client_skill"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.18.17",
+      "last_known_version": "v1.18.18",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -136,13 +136,14 @@
         "kiro_hook",
         "kiro_mcp",
         "kiro_settings",
+        "agents_md",
         "per_client_skill"
       ],
       "github_repo": null,
       "html_url": "https://kiro.dev/changelog/cli/",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
       "notes_extractor": "glm",
-      "last_known_version": "2.17.0",
+      "last_known_version": "2.18.0",
       "tracked": true,
       "notes": "Proprietary CLI; no GH releases. Tracked via HTML scrape of kiro.dev/changelog/cli/ - the first NN.NN.NN version on the page is the latest. Release-note body is upgraded via GLM (scripts/glm-extract.js). The CLI itself exposes `kiro-cli version --changelog`. IDE has a separate changelog at https://kiro.dev/changelog/ide/ (not tracked here; could be added as a separate kiro-ide entry if needed).",
       "changes_of_interest": {
@@ -153,11 +154,13 @@
           ".kiro/settings/mcp.json",
           ".kiro/settings.json (CLI preferences)",
           ".kiro/powers/*/POWER.md",
-          ".kiro/skills/*/SKILL.md"
+          ".kiro/skills/*/SKILL.md",
+          "AGENTS.md"
         ],
         "relevant": [
           "New / renamed CLI settings keys (writable via `kiro-cli settings <k> <v>`)",
           "Steering file inclusion-mode or format changes",
+          "AGENTS.md steering discovery scope (2.18.0 loads nested AGENTS.md from anywhere in the workspace tree)",
           "Agent definition schema (tools, permissions, auth)",
           "Hook event names, payload shapes, required fields",
           "MCP server config shape (auth, env substitution, tool filtering)",
@@ -211,7 +214,7 @@
       ],
       "github_repo": "cline/cline",
       "release_tag_regex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
-      "last_known_version": "v4.1.8",
+      "last_known_version": "v4.1.9",
       "tracked": true,
       "notes": "Tracks only the core Cline vX.Y.Z release train. The repository also publishes desktop-v*, cli-v*, sdk/*, and other interleaved releases that do not correspond to the validator surfaces.",
       "changes_of_interest": {
@@ -247,7 +250,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.15.19",
+      "last_known_version": "3.16.17",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 447 rules, 75+ sources, rules.json
+knowledge-base/     # 448 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-447 rules defined in `knowledge-base/rules.json` (source of truth)
+448 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 447 validation rules across 40 validators
+- 448 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SET-024: ineffective project-level `sandbox.ripgrep`**
+  ([#1358](https://github.com/agent-sh/agnix/issues/1358)). Claude Code
+  v2.1.232 honors the sandbox ripgrep binary only from user settings, managed
+  settings, and the `--settings` flag, so a value in a repository's
+  `.claude/settings.json` or `.claude/settings.local.json` is silently ignored.
+  agnix now warns on that dead override and points at the scopes that still
+  apply. User and managed settings are unaffected.
+
+### Changed
+- **Tool release baselines** (#1356, #1357, #1358, #1359, #1375). Advanced the
+  tracked releases for Kiro CLI (`2.17.0` to `2.18.0`), OpenCode (`v1.18.17` to
+  `v1.18.18`), Claude Code (`v2.1.229` to `v2.1.232`), Cline (`v4.1.8` to
+  `v4.1.9`), and Cursor (`3.15.19` to `3.16.17`). Only the Claude Code and Kiro
+  CLI releases touched a validated surface; the OpenCode, Cline, and Cursor
+  deltas were bookkeeping only.
+- **Kiro CLI inventory covers `AGENTS.md` steering** (#1356). Kiro CLI 2.18.0
+  loads nested `AGENTS.md` files as steering context from anywhere in the
+  workspace tree, so the tool inventory and release baseline now list
+  `AGENTS.md` and the `agents_md` validator (AGM rules) for Kiro. No validation
+  behaviour change - agnix already validated those files.
+
 ## [0.48.1] - 2026-08-15
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 447 rules, 75+ sources, rules.json
+knowledge-base/     # 448 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-447 rules defined in `knowledge-base/rules.json` (source of truth)
+448 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 447 validation rules across 40 validators
+- 448 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>447 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>448 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 447 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 448 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -14,7 +14,7 @@
 | Agents | agents/*.md | 18 |
 | Plugins | plugin.json | 15 |
 | Claude Output Styles | .claude/output-styles/*.md | 6 |
-| Claude Settings | .claude/settings.json | 23 |
+| Claude Settings | .claude/settings.json | 24 |
 | Prompt Engineering | CLAUDE.md, AGENTS.md | 6 |
 | Cross-Platform | AGENTS.md | 10 |
 | MCP | tool definitions | 26 |

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -1350,6 +1350,11 @@ rules:
   cc_set_023:
     message: dialogExpiry must be 60s, 5m, 10m, or never (got %{actual})
     suggestion: Set dialogExpiry to 60s, 5m, 10m, or never.
+  cc_set_024:
+    message: sandbox.ripgrep is ignored in project settings in Claude Code 2.1.232+; only user settings, managed
+      settings, and the --settings flag can override the sandbox ripgrep binary
+    suggestion: Move the sandbox.ripgrep override to your user settings at ~/.claude/settings.json, to managed settings,
+      or to a --settings file, and remove it from the repository.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -863,6 +863,11 @@ rules:
   cc_set_023:
     message: dialogExpiry debe ser 60s, 5m, 10m o never (se obtuvo %{actual})
     suggestion: Establece dialogExpiry en 60s, 5m, 10m o never.
+  cc_set_024:
+    message: sandbox.ripgrep se ignora en la configuración del proyecto en Claude Code 2.1.232+; solo la configuración
+      de usuario, la configuración gestionada y la opción --settings pueden reemplazar el binario ripgrep del sandbox
+    suggestion: Mueve el ajuste sandbox.ripgrep a tu configuración de usuario en ~/.claude/settings.json, a la
+      configuración gestionada o a un archivo --settings, y elimínalo del repositorio.
 
 
 # ===========================================================================

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -814,6 +814,9 @@ rules:
   cc_set_023:
     message: dialogExpiry 必须是 60s、5m、10m 或 never（实际为 %{actual}）
     suggestion: 将 dialogExpiry 设置为 60s、5m、10m 或 never。
+  cc_set_024:
+    message: 在 Claude Code 2.1.232+ 中，项目设置里的 sandbox.ripgrep 会被忽略；只有用户设置、受管设置和 --settings 选项可以覆盖沙箱的 ripgrep 二进制文件
+    suggestion: 请将 sandbox.ripgrep 移到 ~/.claude/settings.json 的用户设置、受管设置或 --settings 文件中，并从仓库中删除该项。
 
 
 # ===========================================================================

--- a/crates/agnix-cli/tests/rule_parity.rs
+++ b/crates/agnix-cli/tests/rule_parity.rs
@@ -1147,6 +1147,71 @@ fn test_refreshed_release_surfaces_match_research_inventory() {
     }
 }
 
+/// Kiro CLI 2.18.0 loads nested `AGENTS.md` files as steering context from
+/// anywhere in the workspace tree, so `AGENTS.md` is a Kiro config surface.
+/// Anchored to the implementation: the file type agnix classifies `AGENTS.md`
+/// into must dispatch `AgentsMdValidator`, and the AGM rule family must exist.
+#[test]
+fn test_kiro_agents_md_steering_surface_is_registered() {
+    use agnix_core::{ValidatorRegistry, detect_file_type};
+
+    let file_type = detect_file_type(Path::new("crates/agnix-core/AGENTS.md"));
+    let registry = ValidatorRegistry::with_defaults();
+    assert!(
+        registry
+            .validators_for(file_type)
+            .iter()
+            .any(|validator| validator.name() == "AgentsMdValidator"),
+        "AgentsMdValidator must run on nested AGENTS.md files"
+    );
+
+    let rules = load_rules_json();
+    assert!(
+        rules.rules.iter().any(|rule| rule.id.starts_with("AGM-")),
+        "rules.json must carry the AGM rule family that covers AGENTS.md"
+    );
+
+    let baseline_path = workspace_root().join(".github/tool-release-baselines.json");
+    let baselines: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(&baseline_path)
+            .unwrap_or_else(|e| panic!("Failed to read {}: {}", baseline_path.display(), e)),
+    )
+    .unwrap_or_else(|e| panic!("Failed to parse {}: {}", baseline_path.display(), e));
+    let kiro = &baselines["tools"]["kiro"];
+    assert!(
+        kiro["validators"]
+            .as_array()
+            .expect("kiro validators must be an array")
+            .iter()
+            .any(|validator| validator == "agents_md"),
+        "kiro baseline must register the AGENTS.md validator"
+    );
+    assert!(
+        kiro["changes_of_interest"]["config_surfaces"]
+            .as_array()
+            .expect("kiro config_surfaces must be an array")
+            .iter()
+            .any(|surface| surface == "AGENTS.md"),
+        "kiro baseline must track the AGENTS.md steering surface"
+    );
+
+    let research_path = workspace_root().join("knowledge-base/RESEARCH-TRACKING.md");
+    let research = fs::read_to_string(&research_path)
+        .unwrap_or_else(|e| panic!("Failed to read {}: {}", research_path.display(), e));
+    let row = research
+        .lines()
+        .find(|line| line.starts_with("| Kiro CLI |"))
+        .expect("RESEARCH-TRACKING.md must contain a Kiro CLI row");
+    assert!(
+        row.contains("AGENTS.md"),
+        "Kiro CLI research inventory is missing the AGENTS.md steering surface"
+    );
+    assert!(
+        row.contains("AGM"),
+        "Kiro CLI research inventory is missing the AGM rule prefix"
+    );
+}
+
 #[test]
 fn test_is_tool_alias_case_sensitivity() {
     // Test that tool alias matching is case insensitive

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -1350,6 +1350,11 @@ rules:
   cc_set_023:
     message: dialogExpiry must be 60s, 5m, 10m, or never (got %{actual})
     suggestion: Set dialogExpiry to 60s, 5m, 10m, or never.
+  cc_set_024:
+    message: sandbox.ripgrep is ignored in project settings in Claude Code 2.1.232+; only user settings, managed
+      settings, and the --settings flag can override the sandbox ripgrep binary
+    suggestion: Move the sandbox.ripgrep override to your user settings at ~/.claude/settings.json, to managed settings,
+      or to a --settings file, and remove it from the repository.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -863,6 +863,11 @@ rules:
   cc_set_023:
     message: dialogExpiry debe ser 60s, 5m, 10m o never (se obtuvo %{actual})
     suggestion: Establece dialogExpiry en 60s, 5m, 10m o never.
+  cc_set_024:
+    message: sandbox.ripgrep se ignora en la configuración del proyecto en Claude Code 2.1.232+; solo la configuración
+      de usuario, la configuración gestionada y la opción --settings pueden reemplazar el binario ripgrep del sandbox
+    suggestion: Mueve el ajuste sandbox.ripgrep a tu configuración de usuario en ~/.claude/settings.json, a la
+      configuración gestionada o a un archivo --settings, y elimínalo del repositorio.
 
 
 # ===========================================================================

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -814,6 +814,9 @@ rules:
   cc_set_023:
     message: dialogExpiry 必须是 60s、5m、10m 或 never（实际为 %{actual}）
     suggestion: 将 dialogExpiry 设置为 60s、5m、10m 或 never。
+  cc_set_024:
+    message: 在 Claude Code 2.1.232+ 中，项目设置里的 sandbox.ripgrep 会被忽略；只有用户设置、受管设置和 --settings 选项可以覆盖沙箱的 ripgrep 二进制文件
+    suggestion: 请将 sandbox.ripgrep 移到 ~/.claude/settings.json 的用户设置、受管设置或 --settings 文件中，并从仓库中删除该项。
 
 
 # ===========================================================================

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -28,6 +28,7 @@
 //! - ineffective project-level `remoteControlAtStartup: true` (CC-SET-021, changed in Claude Code v2.1.222).
 //! - `crossSessionInbound` enum check (CC-SET-022, added in Claude Code v2.1.224).
 //! - `dialogExpiry` enum check (CC-SET-023, added in Claude Code v2.1.224).
+//! - ineffective project-level `sandbox.ripgrep` (CC-SET-024, changed in Claude Code v2.1.232).
 //!
 //! Runs on FileType::Hooks (which covers `.claude/settings.json` -
 //! see `file_types/detection.rs`). Skips non-Claude Code settings paths
@@ -66,6 +67,7 @@ const RULE_IDS: &[&str] = &[
     "CC-SET-021",
     "CC-SET-022",
     "CC-SET-023",
+    "CC-SET-024",
 ];
 
 /// Allowed values for `worktree.baseRef` per Claude Code v2.1.133 release notes.
@@ -212,6 +214,10 @@ impl Validator for ClaudeSettingsValidator {
 
         if config.is_rule_enabled("CC-SET-023") {
             validate_dialog_expiry(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-024") {
+            validate_sandbox_ripgrep_scope(path, content, &value, &mut diagnostics);
         }
 
         diagnostics
@@ -2352,6 +2358,49 @@ fn validate_dialog_expiry(
             t!("rules.cc_set_023.message", actual = actual),
         )
         .with_suggestion(t!("rules.cc_set_023.suggestion")),
+    );
+}
+
+/// CC-SET-024: Warn when project settings override the sandbox ripgrep binary.
+///
+/// Claude Code 2.1.232 restricted `sandbox.ripgrep` to user settings, managed
+/// settings, and the `--settings` flag, so a checked-out repository can no
+/// longer point the sandbox at its own ripgrep. The same scope rule already
+/// covers `sandbox.credentials` masking (CC-SET-012), so user and managed
+/// settings are excluded here for the same reason.
+///
+/// Null is treated as "field absent" by JSON convention.
+fn validate_sandbox_ripgrep_scope(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(sandbox) = value.get("sandbox").and_then(|sandbox| sandbox.as_object()) else {
+        return;
+    };
+    match sandbox.get("ripgrep") {
+        None => return,
+        Some(field_value) if field_value.is_null() => return,
+        Some(_) => {}
+    }
+
+    if is_claude_managed_settings_path(path) || is_user_settings_path(path) {
+        return;
+    }
+
+    let line = find_key_line(content, "ripgrep")
+        .or_else(|| find_key_line(content, "sandbox"))
+        .unwrap_or(1);
+    diagnostics.push(
+        Diagnostic::warning(
+            path.to_path_buf(),
+            line,
+            0,
+            "CC-SET-024",
+            t!("rules.cc_set_024.message"),
+        )
+        .with_suggestion(t!("rules.cc_set_024.suggestion")),
     );
 }
 
@@ -5127,5 +5176,84 @@ mod tests {
                 1
             );
         }
+    }
+
+    // ===== CC-SET-024: project-level sandbox.ripgrep =====
+
+    #[test]
+    fn test_sandbox_ripgrep_flags_project_settings() {
+        let content = r#"{"sandbox": {"ripgrep": "/opt/rg/bin/rg"}}"#;
+        for path in [".claude/settings.json", ".claude/settings.local.json"] {
+            assert_eq!(
+                validate_at(path, content)
+                    .iter()
+                    .filter(|diagnostic| diagnostic.rule == "CC-SET-024")
+                    .count(),
+                1,
+                "expected one hit in {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sandbox_ripgrep_absent_null_and_other_sandbox_keys_are_valid() {
+        for content in [
+            r#"{"sandbox": {"enabled": true}}"#,
+            r#"{"sandbox": {"ripgrep": null}}"#,
+            r#"{"sandbox": null}"#,
+            r#"{"model": "sonnet"}"#,
+        ] {
+            assert!(
+                validate(content)
+                    .iter()
+                    .all(|diagnostic| diagnostic.rule != "CC-SET-024"),
+                "unexpected CC-SET-024 for {content}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_sandbox_ripgrep_is_allowed_in_managed_and_user_settings() {
+        let content = r#"{"sandbox": {"ripgrep": "/opt/rg/bin/rg"}}"#;
+        assert!(
+            validate_at(".claude/managed-settings.json", content)
+                .iter()
+                .all(|diagnostic| diagnostic.rule != "CC-SET-024")
+        );
+
+        let Some(home) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))
+        else {
+            return;
+        };
+        let user_settings = PathBuf::from(home).join(".claude").join("settings.json");
+        assert!(
+            ClaudeSettingsValidator
+                .validate(&user_settings, content, &LintConfig::default())
+                .iter()
+                .all(|diagnostic| diagnostic.rule != "CC-SET-024")
+        );
+    }
+
+    #[test]
+    fn test_sandbox_ripgrep_diagnostic_points_to_key_and_can_be_disabled() {
+        let content =
+            "{\n  \"model\": \"sonnet\",\n  \"sandbox\": {\n    \"ripgrep\": \"rg\"\n  }\n}";
+        let diagnostic = validate(content)
+            .into_iter()
+            .find(|diagnostic| diagnostic.rule == "CC-SET-024")
+            .expect("CC-SET-024 diagnostic");
+        assert_eq!(diagnostic.line, 4);
+
+        let mut builder = LintConfig::builder();
+        builder.disable_rule("CC-SET-024");
+        let config = builder.build().expect("valid config");
+        let path = PathBuf::from(".claude/settings.json");
+        let per_file = config.for_path(&path);
+        assert!(
+            ClaudeSettingsValidator
+                .validate(&path, content, &per_file)
+                .iter()
+                .all(|diagnostic| diagnostic.rule != "CC-SET-024")
+        );
     }
 }

--- a/crates/agnix-lsp/README.md
+++ b/crates/agnix-lsp/README.md
@@ -81,7 +81,7 @@ The extension automatically downloads the `agnix-lsp` binary. See `editors/zed/R
 
 - Real-time diagnostics as you type (via textDocument/didChange)
 - Real-time diagnostics on file open and save
-- Supports all agnix validation rules (447 rules)
+- Supports all agnix validation rules (448 rules)
 - Project-level validation for cross-file rules (AGM-006, XP-004/005/006, VER-001)
 
 - Maps diagnostic severity levels (Error, Warning, Info)

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -1350,6 +1350,11 @@ rules:
   cc_set_023:
     message: dialogExpiry must be 60s, 5m, 10m, or never (got %{actual})
     suggestion: Set dialogExpiry to 60s, 5m, 10m, or never.
+  cc_set_024:
+    message: sandbox.ripgrep is ignored in project settings in Claude Code 2.1.232+; only user settings, managed
+      settings, and the --settings flag can override the sandbox ripgrep binary
+    suggestion: Move the sandbox.ripgrep override to your user settings at ~/.claude/settings.json, to managed settings,
+      or to a --settings file, and remove it from the repository.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -863,6 +863,11 @@ rules:
   cc_set_023:
     message: dialogExpiry debe ser 60s, 5m, 10m o never (se obtuvo %{actual})
     suggestion: Establece dialogExpiry en 60s, 5m, 10m o never.
+  cc_set_024:
+    message: sandbox.ripgrep se ignora en la configuración del proyecto en Claude Code 2.1.232+; solo la configuración
+      de usuario, la configuración gestionada y la opción --settings pueden reemplazar el binario ripgrep del sandbox
+    suggestion: Mueve el ajuste sandbox.ripgrep a tu configuración de usuario en ~/.claude/settings.json, a la
+      configuración gestionada o a un archivo --settings, y elimínalo del repositorio.
 
 
 # ===========================================================================

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -814,6 +814,9 @@ rules:
   cc_set_023:
     message: dialogExpiry 必须是 60s、5m、10m 或 never（实际为 %{actual}）
     suggestion: 将 dialogExpiry 设置为 60s、5m、10m 或 never。
+  cc_set_024:
+    message: 在 Claude Code 2.1.232+ 中，项目设置里的 sandbox.ripgrep 会被忽略；只有用户设置、受管设置和 --settings 选项可以覆盖沙箱的 ripgrep 二进制文件
+    suggestion: 请将 sandbox.ripgrep 移到 ~/.claude/settings.json 的用户设置、受管设置或 --settings 文件中，并从仓库中删除该项。
 
 
 # ===========================================================================

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 447,
-  "last_updated": "2026-08-08",
+  "total_rules": 448,
+  "last_updated": "2026-08-15",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -4289,6 +4289,35 @@
       },
       "good_example": "{\n  \"dialogExpiry\": \"10m\"\n}",
       "bad_example": "{\n  \"dialogExpiry\": \"30s\"\n}"
+    },
+    {
+      "id": "CC-SET-024",
+      "name": "Ineffective Project sandbox.ripgrep Override",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.232",
+          "https://code.claude.com/docs/en/sandboxing"
+        ],
+        "verified_on": "2026-08-15",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.232"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"sandbox\": {\"enabled\": true}\n}",
+      "bad_example": "{\n  \"sandbox\": {\"ripgrep\": \"/opt/rg/bin/rg\"}\n}"
     },
     {
       "id": "CDX-000",
@@ -13129,7 +13158,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 23,
+      "count": 24,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -300,6 +300,6 @@ cargo install agnix-lsp
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for frontmatter fields
-- 447 validation rules
+- 448 validation rules
 - Status bar indicator (VS Code)
 - Syntax highlighting for SKILL.md (VS Code)

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,7 +3,7 @@
 Real-time validation for AI agent configuration files in VS Code.
 Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix).
 
-**447 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
+**448 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
 
 
 ## Features
@@ -11,7 +11,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Real-time validation** - Diagnostics as you type
 - **Context-aware completions** - Frontmatter keys, values, and snippets
 - **JSON Schema validation and autocomplete for `.agnix.toml` config files**
-- **Validates 447 rules** - From official specs and best practices
+- **Validates 448 rules** - From official specs and best practices
 
 - **Diagnostics panel** - Sidebar tree view of all issues by file
 - **CodeLens** - Rule info shown inline above problematic lines
@@ -45,7 +45,7 @@ Access via Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | `agnix: Fix All Issues in File` | `Ctrl+Shift+.` | Apply all available fixes |
 | `agnix: Preview Fixes` | - | Browse fixes with diff preview |
 | `agnix: Fix All Safe Issues` | `Ctrl+Alt+.` | Apply only safe fixes |
-| `agnix: Show All Rules` | - | Browse 447 rules by category |
+| `agnix: Show All Rules` | - | Browse 448 rules by category |
 
 | `agnix: Show Rule Documentation` | - | Open docs for a rule (via CodeLens) |
 | `agnix: Ignore Rule in Project` | - | Add rule to `.agnix.toml` disabled list |

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 447 validation rules across 40 categories, sourced from 75+ references
+> 448 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 447 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 448 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (447 rules)
+├── VALIDATION-RULES.md             # Master validation reference (448 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **447 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **448 rules** |
 
 
 ### Validation Rules by Category
@@ -97,7 +97,7 @@ knowledge-base/
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 23 | 0 | 22 | 1 | 0 |
+| Claude Settings | 24 | 0 | 23 | 1 | 0 |
 | Claude Skills | 20 | 10 | 9 | 1 | 10 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **447** | **215** | **202** | **30** | **124** |
+| **TOTAL** | **448** | **215** | **203** | **30** | **124** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 447 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 448 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     447 rules
+Validation Rules:     448 rules
 Auto-Fixable Rules:   124 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 447 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 448 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-08-13
+**Last Updated**: 2026-08-15
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -16,18 +16,18 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json`, `.claude/settings.local.json`, `.claude/managed-settings.json`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `.claude/hooks configuration`, `.mcp.json`, `.claude-plugin/plugin.json`, `.claude/rules/**/*.md`, `.claude/output-styles/*.md` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-13 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET, CC-OS, MCP |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json`, `.claude/settings.local.json`, `.claude/managed-settings.json`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `.claude/hooks configuration`, `.mcp.json`, `.claude-plugin/plugin.json`, `.claude/rules/**/*.md`, `.claude/output-styles/*.md` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-15 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET, CC-OS, MCP |
 | Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex-plugin/plugin.json`, Agent Plugins root `plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-08 | AGM, XP, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ |
-| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json`, `.opencode/skills/*/SKILL.md` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-13 | AGM, XP, OC, OC-SK |
-| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/**/*.{json,md}`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md` | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-08-13 | KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
+| OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json`, `.opencode/skills/*/SKILL.md` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-15 | AGM, XP, OC, OC-SK |
+| Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/**/*.{json,md}`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md`, `AGENTS.md` (nested, loaded as steering since 2.18.0) | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-08-15 | AGM, KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 
 ### A Tier (test on major changes)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Weekly | 2026-07-26 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-13 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json`, `.cursor/skills/*/SKILL.md` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-13 | CUR, MCP, CR-SK |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-15 | CLN, CL-SK |
+| Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json`, `.cursor/skills/*/SKILL.md` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-15 | CUR, MCP, CR-SK |
 
 ### B Tier (test on significant changes if time permits)
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -517,6 +517,13 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 **Fix**: Manual - choose one of the four documented values
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.224, code.claude.com/docs/en/settings
 
+<a id="cc-set-024"></a>
+### CC-SET-024 [MEDIUM] Ineffective Project sandbox.ripgrep Override
+**Requirement**: Project-level `.claude/settings.json` and `.claude/settings.local.json` SHOULD NOT set `sandbox.ripgrep` in Claude Code 2.1.232+. The sandbox ripgrep binary is honored only from user settings, managed settings, and the `--settings` flag, so a repository-local value is ignored.
+**Detection**: Parse settings JSON and flag a present `sandbox.ripgrep` key in project settings. Ignore user settings (`~/.claude/settings.json`) and managed settings.
+**Fix**: Manual - move the override to user settings, managed settings, or a `--settings` file, or drop it from the repository.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.232, code.claude.com/docs/en/sandboxing
+
 ---
 
 ## PER-CLIENT SKILL RULES
@@ -3579,7 +3586,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
 | Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 23 | 0 | 22 | 1 | 0 |
+| Claude Settings | 24 | 0 | 23 | 1 | 0 |
 | Claude Skills | 20 | 10 | 9 | 1 | 10 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -3610,7 +3617,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **447** | **215** | **202** | **30** | **124** |
+| **TOTAL** | **448** | **215** | **203** | **30** | **124** |
 
 
 ---
@@ -3640,8 +3647,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 447 validation rules across 40 categories
+**Total Coverage**: 448 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 215 HIGH, 202 MEDIUM, 30 LOW
+**Certainty**: 215 HIGH, 203 MEDIUM, 30 LOW
 **Auto-Fixable**: 124 rules (28%)

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 447,
-  "last_updated": "2026-08-08",
+  "total_rules": 448,
+  "last_updated": "2026-08-15",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -4289,6 +4289,35 @@
       },
       "good_example": "{\n  \"dialogExpiry\": \"10m\"\n}",
       "bad_example": "{\n  \"dialogExpiry\": \"30s\"\n}"
+    },
+    {
+      "id": "CC-SET-024",
+      "name": "Ineffective Project sandbox.ripgrep Override",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.232",
+          "https://code.claude.com/docs/en/sandboxing"
+        ],
+        "verified_on": "2026-08-15",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.232"
+        },
+        "normative_level": "SHOULD",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"sandbox\": {\"enabled\": true}\n}",
+      "bad_example": "{\n  \"sandbox\": {\"ripgrep\": \"/opt/rg/bin/rg\"}\n}"
     },
     {
       "id": "CDX-000",
@@ -13129,7 +13158,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 23,
+      "count": 24,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1350,6 +1350,11 @@ rules:
   cc_set_023:
     message: dialogExpiry must be 60s, 5m, 10m, or never (got %{actual})
     suggestion: Set dialogExpiry to 60s, 5m, 10m, or never.
+  cc_set_024:
+    message: sandbox.ripgrep is ignored in project settings in Claude Code 2.1.232+; only user settings, managed
+      settings, and the --settings flag can override the sandbox ripgrep binary
+    suggestion: Move the sandbox.ripgrep override to your user settings at ~/.claude/settings.json, to managed settings,
+      or to a --settings file, and remove it from the repository.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -863,6 +863,11 @@ rules:
   cc_set_023:
     message: dialogExpiry debe ser 60s, 5m, 10m o never (se obtuvo %{actual})
     suggestion: Establece dialogExpiry en 60s, 5m, 10m o never.
+  cc_set_024:
+    message: sandbox.ripgrep se ignora en la configuración del proyecto en Claude Code 2.1.232+; solo la configuración
+      de usuario, la configuración gestionada y la opción --settings pueden reemplazar el binario ripgrep del sandbox
+    suggestion: Mueve el ajuste sandbox.ripgrep a tu configuración de usuario en ~/.claude/settings.json, a la
+      configuración gestionada o a un archivo --settings, y elimínalo del repositorio.
 
 
 # ===========================================================================

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -814,6 +814,9 @@ rules:
   cc_set_023:
     message: dialogExpiry 必须是 60s、5m、10m 或 never（实际为 %{actual}）
     suggestion: 将 dialogExpiry 设置为 60s、5m、10m 或 never。
+  cc_set_024:
+    message: 在 Claude Code 2.1.232+ 中，项目设置里的 sandbox.ripgrep 会被忽略；只有用户设置、受管设置和 --settings 选项可以覆盖沙箱的 ripgrep 二进制文件
+    suggestion: 请将 sandbox.ripgrep 移到 ~/.claude/settings.json 的用户设置、受管设置或 --settings 文件中，并从仓库中删除该项。
 
 
 # ===========================================================================

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.48.1",
-  "description": "Lint agent configurations before they break your workflow. 447 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 448 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "aviarchi1994@gmail.com",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 447 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 448 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 447 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 448 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 447 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 448 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 447 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 448 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -73,6 +73,6 @@ GitHub Copilot validation is enabled by default and can be targeted in config wi
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 447 rules
+- [Rules Reference](./rules/index.md) - browse all 448 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 447 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 448 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 447 rules derived from official specs and real-world testing
+- **Validates** configuration files against 448 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 447 validation rules
+- [Rules Reference](./rules/index.md) - browse all 448 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics

--- a/website/docs/rules/generated/cc-set-024.md
+++ b/website/docs/rules/generated/cc-set-024.md
@@ -1,0 +1,53 @@
+---
+id: cc-set-024
+title: "CC-SET-024: Ineffective Project sandbox.ripgrep Override"
+sidebar_label: "CC-SET-024"
+description: "agnix rule CC-SET-024 checks for ineffective project sandbox.ripgrep override in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-024", "ineffective project sandbox.ripgrep override", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-024`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `SHOULD`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-08-15`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.232`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.232
+- https://code.claude.com/docs/en/sandboxing
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "sandbox": {"ripgrep": "/opt/rg/bin/rg"}
+}
+```
+
+### Valid
+
+```json
+{
+  "sandbox": {"enabled": true}
+}
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `447` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `448` validation rules generated from `knowledge-base/rules.json`.
 `124` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -152,6 +152,7 @@ This section contains all `447` validation rules generated from `knowledge-base/
 | [CC-SET-021](./generated/cc-set-021.md) | Ineffective Project Remote Control Auto-start | MEDIUM | Claude Settings | No |
 | [CC-SET-022](./generated/cc-set-022.md) | Invalid crossSessionInbound Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-023](./generated/cc-set-023.md) | Invalid dialogExpiry Setting | MEDIUM | Claude Settings | No |
+| [CC-SET-024](./generated/cc-set-024.md) | Ineffective Project sandbox.ripgrep Override | MEDIUM | Claude Settings | No |
 | [CDX-000](./generated/cdx-000.md) | TOML Parse Error | HIGH | Codex CLI | No |
 | [CDX-001](./generated/cdx-001.md) | Invalid Approval Mode | HIGH | Codex CLI | Yes (unsafe) |
 | [CDX-002](./generated/cdx-002.md) | Invalid Full Auto Error Mode | HIGH | Codex CLI | Yes (unsafe) |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 447,
+  "totalRules": 448,
   "categoryCount": 40,
   "autofixCount": 124,
   "uniqueTools": [


### PR DESCRIPTION
## Summary

Clears the open tool-release tracking queue for 2026-08-15.

- **Claude Code v2.1.232** restricted the sandbox ripgrep binary to user settings, managed settings and the `--settings` flag, so a project-level `sandbox.ripgrep` in `.claude/settings.json` / `.claude/settings.local.json` is now silently ignored. New rule **CC-SET-024** (MEDIUM, manual fix) flags it, scoped exactly like CC-SET-012's `sandbox.credentials` check. v2.1.230 was never published as a release and v2.1.231 is an MCP OAuth fix with no config surface.
- **Kiro CLI 2.18.0** loads nested `AGENTS.md` from anywhere in the workspace tree as steering context. agnix already validates that surface (`AgentsMdValidator` on `FileType::ClaudeMd`, rules AGM-001..006 including the AGM-006 nested-hierarchy project check), so no new rule was needed - the gap was the hand-maintained inventory contract. Kiro's release baseline now lists `agents_md` / `per_client_skill` under `validators` and `AGENTS.md` under `config_surfaces`, RESEARCH-TRACKING records the surface and the AGM prefix, and a new parity test anchors the claim to the registry instead of to prose.
- **OpenCode v1.18.18**, **Cline v4.1.9**, **Cursor 3.16.17** touch no validated config surface. Baseline bumps and RESEARCH-TRACKING review dates only. The Cursor changelog carries no version numbers and `/changelog/3-16` 404s, so the 3.15.19 -> 3.16.17 window was reviewed by date from the Jul 22 - Aug 13 posts (Cursor Router, Cursor Start, iPad, Google Workspace Plugins, Builds), the same way #1319 was closed; none of them touch `.cursor/rules/**/*.mdc`, `.cursor/hooks.json`, `.cursor/agents/**`, `.cursor/environment.json`, `.cursor/mcp.json` or `.cursor/skills`, and the hook event names in `cursor.rs` are already the current set.

Rule count 447 -> 448.

## Type of Change

- [x] New feature (new validation rule CC-SET-024)
- [x] Other: tool release baseline sync

## Checklist

- [x] Tests added/updated
- [x] CHANGELOG.md updated
- [x] Documentation updated (if applicable)
- [x] `cargo fmt && cargo clippy` passes

## Related Issues

Closes #1356
Closes #1357
Closes #1358
Closes #1359
Closes #1375

## Test Plan

New tests:

- `crates/agnix-core/src/rules/claude_settings.rs` - 4 unit tests for CC-SET-024: flags project `settings.json` and `settings.local.json`; absent / `null` / unrelated `sandbox` keys stay clean; managed settings and `~/.claude/settings.json` are exempt; diagnostic points at the `ripgrep` key line and `disable_rule("CC-SET-024")` suppresses it.
- `crates/agnix-cli/tests/rule_parity.rs` - `test_kiro_agents_md_steering_surface_is_registered` asserts the registry dispatches `AgentsMdValidator` for the file type `AGENTS.md` detects as, that the AGM rule family exists in rules.json, and that the Kiro baseline plus the RESEARCH-TRACKING row agree.

Full local gate run, all green:

```
cargo fmt --check --all                                              -> clean
cargo clippy --workspace --all-targets --all-features -- -D warnings -> 0 warnings
cargo test --workspace                                               -> 5186 passed, 0 failed
cargo run -p agnix-cli --bin agnix -- eval tests/eval.yaml            -> All 61 cases passed
cargo test -p agnix-cli --test kiro_ci_gate -- --include-ignored      -> 5 passed, 0 failed
node scripts/sync-rule-bookkeeping.js --check --skip-docs             -> in sync
python3 scripts/check-rule-counts.py                                  -> pass
bash scripts/check-locale-sync.sh                                     -> in sync
bash scripts/check-glibc-floor.test.sh                                -> 13 passed, 0 failed
node npm/test/install-helpers.test.js                                 -> 14 passed, 0 failed
agnix schema --fix + cmp + git diff --exit-code                       -> no drift
cargo build --release --workspace                                     -> agnix 0.48.1 + lsp + mcp
```

End-to-end with the release binary against a fixture project:

```
/tmp/ccset024-smoke/.claude/settings.json:4:0 warning: sandbox.ripgrep is ignored in project settings
in Claude Code 2.1.232+; only user settings, managed settings, and the --settings flag can override
the sandbox ripgrep binary
     4 |     "ripgrep": "/opt/rg/bin/rg"
Found 0 errors, 1 warning
```
