### PR TITLE
release: v0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.49.0] - 2026-08-15
+
 ### Added
 - **CC-SET-024: ineffective project-level `sandbox.ripgrep`**
   ([#1358](https://github.com/agent-sh/agnix/issues/1358)). Claude Code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -99,14 +99,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.48.1"
+version = "0.49.0"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.48.1"
+version = "0.49.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -33,8 +33,8 @@ categories = ["development-tools", "command-line-utilities"]
 [workspace.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.48.1" }
-agnix-core = { path = "crates/agnix-core", version = "0.48.1" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.49.0" }
+agnix-core = { path = "crates/agnix-core", version = "0.49.0" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.agnix
 pluginName = agnix
 pluginRepositoryUrl = https://github.com/agent-sh/agnix
 # SemVer format -> https://semver.org
-pluginVersion = 0.48.1
+pluginVersion = 0.49.0
 
 # Supported build number ranges and IntelliJ Platform Versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.48.1",
+      "version": "0.49.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.48.1"
+version = "0.49.0"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.48.1",
+  "version": "0.49.0",
   "description": "Lint agent configurations before they break your workflow. 448 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",


### PR DESCRIPTION
Minor release. One new validation rule, no API changes.

## Added

- **CC-SET-024: ineffective project-level `sandbox.ripgrep`** (#1358) - Claude Code v2.1.232 honours the sandbox ripgrep binary only from user settings, managed settings, and the `--settings` flag, so a value in a repository's `.claude/settings.json` or `.claude/settings.local.json` is silently ignored. agnix warns on that dead override and names the scopes that still apply. Rule count 447 -> 448.

## Changed

- **Tool release baselines** (#1356, #1357, #1358, #1359, #1375) - Kiro CLI `2.17.0` to `2.18.0`, OpenCode `v1.18.17` to `v1.18.18`, Claude Code `v2.1.229` to `v2.1.232`, Cline `v4.1.8` to `v4.1.9`, Cursor `3.15.19` to `3.16.17`. Only the Claude Code and Kiro CLI releases touched a validated surface.
- **Kiro CLI inventory covers `AGENTS.md` steering** (#1356) - Kiro CLI 2.18.0 loads nested `AGENTS.md` as steering context from anywhere in the workspace tree, so the inventory and release baseline now list `AGENTS.md` and the `agents_md` validator (AGM rules) for Kiro. No validation behaviour change.

## Pre-release checks

All run locally on this commit:

```
cargo fmt --check --all                                              -> clean
cargo clippy --workspace --all-targets --all-features -- -D warnings -> 0 warnings
cargo test --workspace                                               -> 5186 passed, 0 failed
cargo run -p agnix-cli --bin agnix -- eval tests/eval.yaml            -> All 61 cases passed
cargo run -p agnix-cli --bin agnix -- .                              -> No issues found (self-lint)
cargo audit                                                          -> 2 allowlisted warnings only
cargo deny check advisories                                          -> advisories ok
node scripts/sync-rule-bookkeeping.js --check --skip-docs            -> in sync
python3 scripts/check-rule-counts.py                                 -> pass
bash scripts/check-locale-sync.sh                                    -> in sync
cargo build --release --workspace                                    -> agnix 0.49.0, agnix-lsp 0.49.0
```

Version synced across all manifests via `scripts/sync-versions.sh`.
