### PR TITLE
fix: align spec baselines with sentinel hashing

### DIFF
--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Baseline hashes for canonical specification content. Human-facing URLs are kept separately from machine-readable content URLs.",
-  "last_updated": "2026-08-16T21:03:54Z",
+  "last_updated": "2026-08-16T22:37:40Z",
   "sources": {
     "s-tier": {
       "agent-skills-spec": {
@@ -117,7 +117,7 @@
       "claude-code-memory": {
         "url": "https://code.claude.com/docs/en/memory",
         "content_url": "https://code.claude.com/docs/en/memory.md",
-        "hash": "714ee359ae36615df0a70335ebc6bc78c42e01dcc32e616c736ded37c666d2b6",
+        "hash": "fd03743e064531bc23d4fc440b9218c1d2a5efc546da93485cbf0071c4f6aab7",
         "rules": [
           "CC-MEM-001",
           "CC-MEM-002",
@@ -128,7 +128,7 @@
       "claude-code-hooks": {
         "url": "https://code.claude.com/docs/en/hooks",
         "content_url": "https://code.claude.com/docs/en/hooks.md",
-        "hash": "bc6ebfe342d20f3e1100853deebf44c1aae2a12d612f74d421397ac275818da6",
+        "hash": "568c4c920d3a0b36102c0cc01cdfe2bf0a9ea52d9b5fca1f8edac671db31ff6e",
         "rules": [
           "CC-HK-001",
           "CC-HK-002",
@@ -147,7 +147,7 @@
       "claude-code-skills": {
         "url": "https://code.claude.com/docs/en/skills",
         "content_url": "https://code.claude.com/docs/en/skills.md",
-        "hash": "e950bbac5447c551c12d390892314432386331c2772e7aee203a0c74fc4c5312",
+        "hash": "6aa040d59af9d1fb24b9a3ec77afec6bc025ed4eb84d39e5ea7051c0fb0ad5d7",
         "rules": [
           "CC-SK-001",
           "CC-SK-002",
@@ -160,7 +160,7 @@
       "claude-code-plugins": {
         "url": "https://code.claude.com/docs/en/plugins-reference",
         "content_url": "https://code.claude.com/docs/en/plugins-reference.md",
-        "hash": "8d7a7c0649dec858c9d48072af247092ec0c82678ed70b3d4251748c822124ed",
+        "hash": "0740e469e30f3ae8d4bc2ca7bfc41d94184d10e145b5d15f6f26acd69d87eec4",
         "rules": [
           "CC-PL-002",
           "CC-PL-003",
@@ -172,7 +172,7 @@
       "claude-code-subagents": {
         "url": "https://code.claude.com/docs/en/sub-agents",
         "content_url": "https://code.claude.com/docs/en/sub-agents.md",
-        "hash": "ca660359d8230ec7198f05a70943df5bb0474dfe71710a6955811d639890861f",
+        "hash": "261c25d52cb020044dd362b31a526e15b6961457b352008f32d6a8dcb8125a1e",
         "rules": [
           "CC-AG-001",
           "CC-AG-002",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `elicitation_url_dialog` matcher instead of reporting it as invalid, and
   advance the reviewed Claude Code hooks, memory, plugins, skills, and
   subagent specification baselines.
+- **Spec drift baseline hashing**. Recalculate the five reviewed Claude Code
+  hashes with the sentinel's trailing-newline normalization so those sources
+  do not immediately re-report drift.
 
 ### Changed
 - **Tool release baselines**. Advanced Claude Code from `v2.1.232` to


### PR DESCRIPTION
## Summary

- replace the five Claude Code spec hashes with the values produced by the sentinel itself
- keep the reviewed source URLs, rule mappings, and validator fix from #1383 unchanged

## Root cause

PR #1383 committed SHA-256 values for the raw HTTP bodies, including their terminal newline. The sentinel stores each response in Bash command substitution before hashing, which strips trailing newlines, so the newly committed baselines immediately re-reported all five sources as drifted.

## Validation

- local execution of the exact S-tier sentinel step: `drift_detected=false`
- `cargo fmt --check --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo run -p agnix-cli --bin agnix -- eval tests/eval.yaml`
- `cargo test -p agnix-cli --test kiro_ci_gate -- --include-ignored`
- `node scripts/sync-rule-bookkeeping.js --check --skip-docs`
- self-validation: 38 files, zero diagnostics

Follow-up to #1381 and #1383. Baseline-only maintenance; no release is required.