### PR TITLE
chore: refresh Cline and Amp release baselines

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-08-23",
+  "last_updated": "2026-08-24",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -214,7 +214,7 @@
       ],
       "github_repo": "cline/cline",
       "release_tag_regex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
-      "last_known_version": "v4.1.13",
+      "last_known_version": "v4.1.15",
       "tracked": true,
       "notes": "Tracks only the core Cline vX.Y.Z release train. The repository also publishes desktop-v*, cli-v*, sdk/*, and other interleaved releases that do not correspond to the validator surfaces.",
       "changes_of_interest": {
@@ -321,7 +321,7 @@
       "html_url": "https://ampcode.com/news.rss",
       "version_regex": "https://ampcode\\.com/news/[a-zA-Z0-9._-]+",
       "notes_extractor": "rss_cdata",
-      "last_known_version": "explain-usage",
+      "last_known_version": "friendly-urls-for-sharing-orbs",
       "tracked": true,
       "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed).",
       "changes_of_interest": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Tool release baselines**. Advance Cline to `v4.1.15` and Amp to
+  `friendly-urls-for-sharing-orbs` after reviewing the intervening live release
+  notes. The changes affect runtime MCP approval behavior, model metadata,
+  telemetry, and shared-orb URLs, not an agnix-validated configuration contract.
 - **Maintenance refresh**. Advance Claude Code to `v2.1.241`, Cline to
   `v4.1.13`, OpenCode to `v1.18.21`, and Amp to `explain-usage` after reviewing
   the live releases against agnix's validated configuration surfaces. Refresh

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-08-23
+**Last Updated**: 2026-08-24
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -26,7 +26,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Weekly | 2026-07-26 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-23 | CLN, CL-SK |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-24 | CLN, CL-SK |
 | Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json`, `.cursor/skills/*/SKILL.md` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-21 | CUR, MCP, CR-SK |
 
 ### B Tier (test on significant changes if time permits)
@@ -34,7 +34,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Roo Code | `.roomodes`, `.rooignore`, `.roorules`, `.roo/rules/*.md`, `.roo/rules-{slug}/*.md`, `.roo/mcp.json` | https://github.com/RooCodeInc/Roo-Code | Automated (tool-release-watch.yml) | Quarterly | 2026-07-26 | ROO |
-| amp | `.amp/settings.json`, `.agents/checks/*.md`, `AGENTS.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-08-23 | AGM, AMP, AMP-SK |
+| amp | `.amp/settings.json`, `.agents/checks/*.md`, `AGENTS.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-08-24 | AGM, AMP, AMP-SK |
 
 ### C Tier (community reports fixes only)
 


### PR DESCRIPTION
## Summary
- advance Cline to v4.1.15 after reviewing v4.1.14 and v4.1.15 release notes
- advance Amp to friendly-urls-for-sharing-orbs after reviewing the live RSS entry
- record that neither release changes an agnix-validated configuration contract

Closes #1409
Closes #1410

## Verification
- `UPDATE_BASELINES=true scripts/check-tool-releases.sh` (`ok=12 new=0 skipped=0`)
- `node scripts/sync-rule-bookkeeping.js --check`
- `cargo test -p agnix-cli --test rule_parity` (20 passed)
- `cargo fmt --all -- --check`
- `cmp -s CLAUDE.md AGENTS.md`
- `git diff --check`