### PR TITLE
release: v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-08-25
+
 ### Added
 - **Claude Code 2.1.242 settings validation**. Add `CC-SET-025` for the
   user-or-managed `modelPicker` scope and documented option shape,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -99,14 +99,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.49.0"
+version = "0.50.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -33,8 +33,8 @@ categories = ["development-tools", "command-line-utilities"]
 [workspace.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.49.0" }
-agnix-core = { path = "crates/agnix-core", version = "0.49.0" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.50.0" }
+agnix-core = { path = "crates/agnix-core", version = "0.50.0" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.agnix
 pluginName = agnix
 pluginRepositoryUrl = https://github.com/agent-sh/agnix
 # SemVer format -> https://semver.org
-pluginVersion = 0.49.0
+pluginVersion = 0.50.0
 
 # Supported build number ranges and IntelliJ Platform Versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.49.0",
+      "version": "0.50.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.49.0"
+version = "0.50.0"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Lint agent configurations before they break your workflow. 451 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",


### PR DESCRIPTION
Minor release. Three new Claude Code validation rules, no public API removals.

## Added

- CC-SET-025 validates the user-or-managed `modelPicker` scope and documented option shape.
- CC-SET-026 validates `promptCacheTtl`.
- CC-SET-027 validates `subagentPromptCacheTtl`.
- Rule count: 448 to 451.

## Changed

- Publish the accumulated tool-release baseline, specification, dependency, and compatibility maintenance since v0.49.0.
- Synchronize v0.50.0 across Cargo, npm, VS Code, JetBrains, Zed, and plugin manifests.

## Pre-release checks

- `cargo fmt --check --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace` - 5,203 tests passed
- `agnix eval tests/eval.yaml` - 61/61, 100% precision/recall/F1
- `agnix .` - no issues
- rule bookkeeping, rule counts, locale sync, and CLAUDE/AGENTS byte identity
- `cargo audit` - two allowlisted warnings only
- `cargo deny check advisories`
- `cargo build --release --workspace`