### PR TITLE
feat(jetbrains): support WSL-hosted language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **JetBrains plugin: WSL execution mode**
+  ([#1346](https://github.com/agent-sh/agnix/issues/1346)). IntelliJ on Windows
+  can now run `agnix-lsp` from inside a WSL distribution for projects that live
+  in WSL, without Remote Development. The plugin launches an argument-safe
+  `wsl.exe --distribution <name> --exec <path>` command, maps document and
+  workspace URIs at the LSP boundary, validates configuration, and skips the
+  host-local binary installer. Native launches remain unchanged.
+
 ## [0.50.0] - 2026-08-25
 
 ### Added

--- a/editors/jetbrains/CHANGELOG.md
+++ b/editors/jetbrains/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- WSL execution mode for `agnix-lsp` (#1346). On Windows, projects that live inside a WSL distribution can now run the language server inside that distribution without JetBrains Remote Development. Enable **Run agnix-lsp inside WSL (Windows only)** in Settings > Tools > agnix, optionally name the distribution (empty reuses the distribution the project is opened from, detected from its `\\wsl$\` or `\\wsl.localhost\` path), and give the absolute Linux path to `agnix-lsp`. The server is started as an argument list via `wsl.exe --distribution <name> --exec <path>` - no shell is involved, so spaces in paths need no quoting - and document/workspace URIs are translated between Windows and Linux paths (including `/mnt/<drive>` automounts) at the LSP request and response boundary. Host-local binary installation and download are skipped while WSL mode is on, invalid configuration is rejected in the settings dialog, and a launch-time notification with a "Settings" action reports misconfiguration. Native launches keep their existing behavior.
+
 ### Fixed
 
 - Render `SKILL.md` files with Markdown syntax highlighting instead of

--- a/editors/jetbrains/README.md
+++ b/editors/jetbrains/README.md
@@ -49,6 +49,48 @@ After the sandbox IDE launches:
 3. Confirm diagnostics appear for invalid files and clear after fixes.
 4. Use `Tools > agnix > Restart Language Server` and verify reconnect.
 
+## WSL Execution Mode (Windows)
+
+If your project lives inside a WSL distribution (`\\wsl$\Ubuntu\home\you\project`
+or `\\wsl.localhost\Ubuntu\...`) and `agnix-lsp` is installed inside that
+distribution rather than on Windows, enable WSL execution mode so the server runs
+where the files are. This does not require JetBrains Remote Development.
+
+`Settings > Tools > agnix`:
+
+1. Check **Run agnix-lsp inside WSL (Windows only)**.
+2. **WSL distribution** - the name as printed by `wsl --list --quiet`, for
+   example `Ubuntu`. Leave it empty to reuse the distribution the project itself
+   is opened from (derived from its `\\wsl$\` / `\\wsl.localhost\` path).
+3. **agnix-lsp path in WSL** - the absolute *Linux* path inside the distribution,
+   for example `/home/you/.cargo/bin/agnix-lsp`. Windows paths and relative paths
+   are rejected.
+
+Behavior while WSL mode is on:
+
+- The server is started as an argument list through
+  `wsl.exe --distribution <name> --exec <path>`. No shell is involved, so spaces
+  in the path need no quoting and nothing is interpreted by `bash`.
+- Document and workspace URIs are translated at the LSP boundary: UNC paths under
+  the selected distribution become plain Linux paths, `C:\src` becomes
+  `/mnt/c/src`, and diagnostics coming back from the server are mapped to the
+  matching Windows path. If your distribution moves the automount root away from
+  `/mnt` (`[automount] root=` in `/etc/wsl.conf`), drive-letter paths outside WSL
+  will not map.
+- No working directory is passed to `wsl.exe`; `agnix-lsp` takes the workspace
+  root from the translated `rootUri`.
+- Host-local install and download of `agnix-lsp.exe` are skipped, so the Windows
+  binary is not fetched.
+- Files opened from a *different* distribution than the configured one are not
+  mapped, and the server is not asked to validate them.
+
+Misconfiguration (blank or shell-unsafe distribution name, non-Linux path) is
+rejected when you apply the settings, and a launch-time error notification with a
+**Settings** action appears if the stored configuration cannot produce a command.
+
+Turning the checkbox off restores the normal host-local launch path exactly as
+before.
+
 ## Real IDE Test Matrix
 
 Run these checks against real installs (not only sandbox):
@@ -65,11 +107,21 @@ For each IDE, verify:
 4. Diagnostics and hover work on supported files.
 5. Unrelated `settings.json` files (for example `.vscode/settings.json`) do not activate agnix diagnostics.
 
+On Windows with WSL installed, additionally verify:
+
+1. A project opened from `\\wsl.localhost\<distro>\...` with WSL mode enabled
+   starts the server and reports diagnostics at the right lines.
+2. Quick fixes applied from the IDE land in the correct file inside the distribution.
+3. Disabling WSL mode falls back to the host-local binary with no leftover state.
+
 ## Troubleshooting
 
 - If `agnix-lsp` is not detected, set `LSP binary path` explicitly.
 - For download issues, verify internet access to GitHub release asset domains.
 - Enable trace logging with `Trace level = Messages` or `Verbose`.
+- In WSL mode, confirm the path resolves inside the distribution:
+  `wsl --distribution <name> --exec <path> --version`. If that fails, the plugin
+  cannot start it either.
 
 ### "agnix-lsp could not be started (access denied)" on locked-down Windows
 

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/binary/PlatformInfo.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/binary/PlatformInfo.kt
@@ -111,6 +111,9 @@ object PlatformInfo {
      */
     fun isSupported(): Boolean = getBinaryInfo() != null
 
+    /** WSL process execution is available only when the IDE itself runs on Windows. */
+    fun supportsWslExecution(os: OS = getOS()): Boolean = os == OS.WINDOWS
+
     /**
      * Get a human-readable platform description.
      */

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixDocumentMatcher.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixDocumentMatcher.kt
@@ -3,7 +3,11 @@ package io.agnix.jetbrains.lsp
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.redhat.devtools.lsp4ij.AbstractDocumentMatcher
+import io.agnix.jetbrains.binary.PlatformInfo
 import io.agnix.jetbrains.filetype.AgnixFileTypes
+import io.agnix.jetbrains.settings.AgnixSettings
+import io.agnix.jetbrains.wsl.WslLaunch
+import io.agnix.jetbrains.wsl.WslPaths
 
 /**
  * Path-aware matcher to avoid attaching agnix-lsp to unrelated files that share
@@ -11,6 +15,43 @@ import io.agnix.jetbrains.filetype.AgnixFileTypes
  */
 class AgnixDocumentMatcher : AbstractDocumentMatcher() {
     override fun match(virtualFile: VirtualFile, project: Project): Boolean {
-        return AgnixFileTypes.isAgnixFilePath(virtualFile.path)
+        val settings = AgnixSettings.getInstance()
+        return matchesPath(
+            path = virtualFile.path,
+            projectBasePath = project.basePath,
+            wslEnabled = settings.wslEnabled,
+            wslHostSupported = PlatformInfo.supportsWslExecution(),
+            distribution = settings.wslDistribution,
+            lspPath = settings.wslLspPath
+        )
+    }
+
+    companion object {
+        /**
+         * Pure matching policy used by [match] and unit tests.
+         *
+         * When WSL mode is active, returning false is essential: returning true
+         * would let LSP4IJ fall back to the untranslated Windows URI.
+         */
+        internal fun matchesPath(
+            path: String,
+            projectBasePath: String?,
+            wslEnabled: Boolean,
+            wslHostSupported: Boolean,
+            distribution: String,
+            lspPath: String
+        ): Boolean {
+            if (!AgnixFileTypes.isAgnixFilePath(path)) return false
+            if (!wslEnabled || !wslHostSupported) return true
+
+            val resolution = WslLaunch.resolve(
+                enabled = true,
+                distribution = distribution,
+                lspPath = lspPath,
+                projectBasePath = projectBasePath
+            )
+            val ready = resolution as? WslLaunch.Resolution.Ready ?: return false
+            return WslPaths.toLinuxPath(path, ready.distribution) != null
+        }
     }
 }

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspClientFeatures.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspClientFeatures.kt
@@ -1,0 +1,93 @@
+package io.agnix.jetbrains.lsp
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures
+import io.agnix.jetbrains.settings.AgnixSettings
+import io.agnix.jetbrains.wsl.WslLaunch
+import io.agnix.jetbrains.wsl.WslPaths
+import org.eclipse.lsp4j.InitializeParams
+import java.net.URI
+
+/**
+ * Client features for agnix-lsp.
+ *
+ * When WSL execution mode is active the server runs inside the distribution and
+ * only understands Linux paths, while the Windows IDE addresses the same files
+ * through `\\wsl.localhost\<distro>\...`. This class rewrites every path that
+ * crosses the LSP boundary: outgoing document URIs and the initialize workspace
+ * root, and incoming URIs (diagnostics, locations) on the way back.
+ *
+ * With WSL execution mode off, all hooks return null / leave params untouched, so
+ * LSP4IJ keeps its default URI handling.
+ */
+class AgnixLspClientFeatures : LSPClientFeatures() {
+
+    private val logger = Logger.getInstance(AgnixLspClientFeatures::class.java)
+
+    /** IDE file -> Linux `file:` URI. Null falls back to `FileUriSupport.DEFAULT`. */
+    override fun getFileUri(file: VirtualFile): URI? {
+        val distribution = wslDistribution() ?: return null
+        val linuxPath = WslPaths.toLinuxPath(file.path, distribution)
+        if (linuxPath == null) {
+            logger.warn("Cannot map ${file.path} into WSL distribution $distribution")
+            return null
+        }
+        return WslPaths.toLinuxFileUri(linuxPath)
+    }
+
+    /** Linux `file:` URI -> IDE file. Null falls back to `FileUriSupport.DEFAULT`. */
+    override fun findFileByUri(fileUri: String): VirtualFile? {
+        val distribution = wslDistribution() ?: return null
+        val linuxPath = WslPaths.linuxPathFromFileUri(fileUri) ?: return null
+        val windowsPath = WslPaths.toWindowsPath(linuxPath, distribution) ?: return null
+        return LocalFileSystem.getInstance().findFileByPath(WslPaths.toIdeaPath(windowsPath))
+    }
+
+    /**
+     * Translate the workspace root sent at initialize.
+     *
+     * agnix-lsp derives the project root from `rootUri`, so a Windows UNC root
+     * would leave project-level rules pointing at a path that does not exist
+     * inside the distribution.
+     */
+    // rootUri/rootPath are deprecated in LSP but are what agnix-lsp reads to find the
+    // workspace root, so both are translated alongside workspaceFolders.
+    @Suppress("DEPRECATION")
+    override fun initializeParams(params: InitializeParams) {
+        super.initializeParams(params)
+
+        val distribution = wslDistribution() ?: return
+
+        params.rootUri?.let { rootUri ->
+            WslPaths.toLinuxFileUri(rootUri, distribution)?.let { params.rootUri = it.toString() }
+        }
+        params.rootPath?.let { rootPath ->
+            WslPaths.toLinuxPath(rootPath, distribution)?.let { params.rootPath = it }
+        }
+        params.workspaceFolders?.forEach { folder ->
+            folder.uri?.let { folderUri ->
+                WslPaths.toLinuxFileUri(folderUri, distribution)?.let { folder.uri = it.toString() }
+            }
+        }
+    }
+
+    /**
+     * Distribution to translate paths for, or null when WSL execution mode is off
+     * or misconfigured (the descriptor reports misconfiguration at launch).
+     */
+    private fun wslDistribution(): String? {
+        val settings = AgnixSettings.getInstance()
+        if (!settings.wslEnabled) return null
+
+        val basePath = runCatching { project.basePath }.getOrNull()
+        val resolution = WslLaunch.resolve(
+            enabled = true,
+            distribution = settings.wslDistribution,
+            lspPath = settings.wslLspPath,
+            projectBasePath = basePath
+        )
+        return (resolution as? WslLaunch.Resolution.Ready)?.distribution
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspClientFeatures.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspClientFeatures.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures
+import io.agnix.jetbrains.binary.PlatformInfo
 import io.agnix.jetbrains.settings.AgnixSettings
 import io.agnix.jetbrains.wsl.WslLaunch
 import io.agnix.jetbrains.wsl.WslPaths
@@ -79,7 +80,7 @@ class AgnixLspClientFeatures : LSPClientFeatures() {
      */
     private fun wslDistribution(): String? {
         val settings = AgnixSettings.getInstance()
-        if (!settings.wslEnabled) return null
+        if (!settings.wslEnabled || !PlatformInfo.supportsWslExecution()) return null
 
         val basePath = runCatching { project.basePath }.getOrNull()
         val resolution = WslLaunch.resolve(

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerDescriptor.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerDescriptor.kt
@@ -7,6 +7,7 @@ import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider
 import io.agnix.jetbrains.binary.AgnixBinaryResolver
 import io.agnix.jetbrains.notifications.AgnixNotifications
 import io.agnix.jetbrains.settings.AgnixSettings
+import io.agnix.jetbrains.wsl.WslLaunch
 import java.io.File
 
 /**
@@ -22,10 +23,18 @@ class AgnixLspServerDescriptor(
     private val logger = Logger.getInstance(AgnixLspServerDescriptor::class.java)
 
     init {
-        // Resolve binary path without blocking download - only check existing locations
-        val binaryPath = resolveBinaryPathNonBlocking()
-        if (binaryPath != null) {
-            configureCommandLine(binaryPath)
+        when (val resolution = resolveWslLaunch()) {
+            is WslLaunch.Resolution.Ready -> configureWslCommandLine(resolution)
+            is WslLaunch.Resolution.Invalid ->
+                // Reported to the user in start(); the descriptor must not show UI from init.
+                logger.warn("WSL execution mode is misconfigured: ${resolution.message}")
+            WslLaunch.Resolution.Disabled -> {
+                // Resolve binary path without blocking download - only check existing locations
+                val binaryPath = resolveBinaryPathNonBlocking()
+                if (binaryPath != null) {
+                    configureCommandLine(binaryPath)
+                }
+            }
         }
     }
 
@@ -33,6 +42,30 @@ class AgnixLspServerDescriptor(
         val commandLine = GeneralCommandLine(binaryPath)
             .withWorkDirectory(project.basePath ?: System.getProperty("user.home"))
         setCommandLine(commandLine)
+    }
+
+    /**
+     * Launch agnix-lsp inside WSL.
+     *
+     * The Windows-side working directory is left at the IDE default: a Linux path
+     * is not a valid Windows working directory, and agnix-lsp takes its workspace
+     * from the LSP `rootUri` (translated by [AgnixLspClientFeatures]).
+     */
+    private fun configureWslCommandLine(launch: WslLaunch.Resolution.Ready) {
+        val command = WslLaunch.buildCommand(launch.distribution, launch.lspPath)
+        logger.info("Starting agnix-lsp through WSL distribution ${launch.distribution}: ${launch.lspPath}")
+        setCommandLine(GeneralCommandLine(command))
+    }
+
+    /** WSL launch decision from the current settings and project location. */
+    private fun resolveWslLaunch(): WslLaunch.Resolution {
+        val settings = AgnixSettings.getInstance()
+        return WslLaunch.resolve(
+            enabled = settings.wslEnabled,
+            distribution = settings.wslDistribution,
+            lspPath = settings.wslLspPath,
+            projectBasePath = project.basePath
+        )
     }
 
     /**
@@ -73,6 +106,24 @@ class AgnixLspServerDescriptor(
     }
 
     override fun start() {
+        // Re-resolve WSL settings here: they can change between descriptor creation
+        // and a server (re)start.
+        when (val resolution = resolveWslLaunch()) {
+            is WslLaunch.Resolution.Ready -> {
+                configureWslCommandLine(resolution)
+                // If a policy blocks the launch it is wsl.exe that was refused, not
+                // the Linux binary, so report the launcher in the failure path.
+                startProcess("${WslLaunch.WSL_EXECUTABLE} (${resolution.lspPath})")
+                return
+            }
+            is WslLaunch.Resolution.Invalid -> {
+                logger.error("WSL execution mode is misconfigured: ${resolution.message}")
+                AgnixNotifications.notifyWslLaunchProblem(project, resolution.message)
+                return
+            }
+            WslLaunch.Resolution.Disabled -> Unit
+        }
+
         var commandLine = getCommandLine()
 
         // On first run, LSP4IJ installer may download agnix-lsp after descriptor init.
@@ -98,7 +149,15 @@ class AgnixLspServerDescriptor(
             return
         }
 
-        logger.info("Starting agnix-lsp: ${commandLine.commandLineString}")
+        startProcess(binaryPath)
+    }
+
+    /**
+     * Start the configured process, turning an OS-level execution block into an
+     * actionable notification.
+     */
+    private fun startProcess(binaryPath: String) {
+        logger.info("Starting agnix-lsp: ${getCommandLine()?.commandLineString}")
         try {
             super.start()
         } catch (e: Exception) {

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerDescriptor.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerDescriptor.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider
 import io.agnix.jetbrains.binary.AgnixBinaryResolver
+import io.agnix.jetbrains.binary.PlatformInfo
 import io.agnix.jetbrains.notifications.AgnixNotifications
 import io.agnix.jetbrains.settings.AgnixSettings
 import io.agnix.jetbrains.wsl.WslLaunch
@@ -61,7 +62,7 @@ class AgnixLspServerDescriptor(
     private fun resolveWslLaunch(): WslLaunch.Resolution {
         val settings = AgnixSettings.getInstance()
         return WslLaunch.resolve(
-            enabled = settings.wslEnabled,
+            enabled = settings.wslEnabled && PlatformInfo.supportsWslExecution(),
             distribution = settings.wslDistribution,
             lspPath = settings.wslLspPath,
             projectBasePath = project.basePath

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerInstaller.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerInstaller.kt
@@ -23,7 +23,7 @@ class AgnixLspServerInstaller : LanguageServerInstallerBase() {
         progress("Checking agnix-lsp installation...", 0.15, indicator)
 
         val settings = AgnixSettings.getInstance()
-        if (settings.wslEnabled) {
+        if (settings.wslEnabled && PlatformInfo.supportsWslExecution()) {
             // The server lives inside the WSL distribution, so the Windows-side
             // installer cannot see it and must not download a Windows binary.
             logger.info("WSL execution mode enabled; skipping host-local agnix-lsp installation")

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerInstaller.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerInstaller.kt
@@ -23,6 +23,13 @@ class AgnixLspServerInstaller : LanguageServerInstallerBase() {
         progress("Checking agnix-lsp installation...", 0.15, indicator)
 
         val settings = AgnixSettings.getInstance()
+        if (settings.wslEnabled) {
+            // The server lives inside the WSL distribution, so the Windows-side
+            // installer cannot see it and must not download a Windows binary.
+            logger.info("WSL execution mode enabled; skipping host-local agnix-lsp installation")
+            return true
+        }
+
         val configuredPath = settings.lspPath.trim()
         if (configuredPath.isNotEmpty()) {
             val configuredBinary = File(configuredPath)

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerSupportProvider.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/lsp/AgnixLspServerSupportProvider.kt
@@ -3,6 +3,7 @@ package io.agnix.jetbrains.lsp
 import com.intellij.openapi.project.Project
 import com.redhat.devtools.lsp4ij.LanguageServerFactory
 import com.redhat.devtools.lsp4ij.client.LanguageClientImpl
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures
 import com.redhat.devtools.lsp4ij.installation.ServerInstaller
 import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider
 
@@ -24,6 +25,10 @@ class AgnixLspServerSupportProvider : LanguageServerFactory {
 
     override fun createServerInstaller(): ServerInstaller {
         return AgnixLspServerInstaller()
+    }
+
+    override fun createClientFeatures(): LSPClientFeatures {
+        return AgnixLspClientFeatures()
     }
 
     /**

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/notifications/AgnixNotifications.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/notifications/AgnixNotifications.kt
@@ -167,6 +167,34 @@ object AgnixNotifications {
     }
 
     /**
+     * Notify that WSL execution mode is enabled but cannot be used as configured.
+     *
+     * Covers a missing distribution name that could not be derived from the project
+     * location and a WSL agnix-lsp path that is not an absolute Linux path.
+     */
+    fun notifyWslLaunchProblem(project: Project, message: String) {
+        val notification = NotificationGroupManager.getInstance()
+            .getNotificationGroup(NOTIFICATION_GROUP_ID)
+            .createNotification(
+                "agnix-lsp WSL configuration problem",
+                message,
+                NotificationType.ERROR
+            )
+
+        notification.addAction(object : AnAction("Settings") {
+            override fun actionPerformed(e: AnActionEvent) {
+                ShowSettingsUtil.getInstance().showSettingsDialog(
+                    project,
+                    AgnixSettingsConfigurable::class.java
+                )
+                notification.expire()
+            }
+        })
+
+        notification.notify(project)
+    }
+
+    /**
      * Notify that the LSP server encountered an error.
      */
     fun notifyServerError(project: Project, error: String) {

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettings.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettings.kt
@@ -35,6 +35,27 @@ class AgnixSettings : PersistentStateComponent<AgnixSettings> {
     var autoDownload: Boolean = true
 
     /**
+     * Whether to run agnix-lsp inside WSL through `wsl.exe` (Windows hosts).
+     *
+     * Off by default: the native host-local launch path stays the default on
+     * every platform.
+     */
+    var wslEnabled: Boolean = false
+
+    /**
+     * WSL distribution that hosts agnix-lsp, as printed by `wsl --list --quiet`.
+     *
+     * Empty means "use the distribution the project itself is opened from"
+     * (`\\wsl.localhost\<distro>\...`).
+     */
+    var wslDistribution: String = ""
+
+    /**
+     * Absolute Linux path to agnix-lsp inside the WSL distribution.
+     */
+    var wslLspPath: String = ""
+
+    /**
      * Trace level for LSP communication (off, messages, verbose).
      */
     var traceLevel: TraceLevel = TraceLevel.OFF

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsComponent.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsComponent.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import javax.swing.JComboBox
 import javax.swing.JComponent
@@ -22,6 +23,9 @@ class AgnixSettingsComponent {
     private val enabledCheckBox = JBCheckBox("Enable agnix validation")
     private val lspPathField = TextFieldWithBrowseButton()
     private val autoDownloadCheckBox = JBCheckBox("Automatically download LSP binary if not found")
+    private val wslEnabledCheckBox = JBCheckBox("Run agnix-lsp inside WSL (Windows only)")
+    private val wslDistributionField = JBTextField()
+    private val wslLspPathField = JBTextField()
     private val traceLevelComboBox = JComboBox(AgnixSettings.TraceLevel.entries.toTypedArray())
     private val codeLensCheckBox = JBCheckBox("Show CodeLens annotations")
     private val lspPathChooserDescriptor = FileChooserDescriptor(
@@ -44,6 +48,13 @@ class AgnixSettingsComponent {
             .addLabeledComponent(JBLabel("LSP binary path:"), lspPathField, 1, false)
             .addTooltip("Leave empty to use auto-detection or downloaded binary")
             .addComponent(autoDownloadCheckBox)
+            .addSeparator()
+            .addComponent(wslEnabledCheckBox)
+            .addTooltip("Starts agnix-lsp with wsl.exe instead of a host-local executable")
+            .addLabeledComponent(JBLabel("WSL distribution:"), wslDistributionField, 1, false)
+            .addTooltip("Name from 'wsl --list --quiet'; leave empty to use the project's own distribution")
+            .addLabeledComponent(JBLabel("WSL agnix-lsp path:"), wslLspPathField, 1, false)
+            .addTooltip("Absolute Linux path, for example /home/you/.cargo/bin/agnix-lsp")
             .addSeparator()
             .addLabeledComponent(JBLabel("Trace level:"), traceLevelComboBox, 1, false)
             .addTooltip("Set to 'Messages' or 'Verbose' for debugging LSP communication")
@@ -88,6 +99,24 @@ class AgnixSettingsComponent {
         get() = autoDownloadCheckBox.isSelected
         set(value) {
             autoDownloadCheckBox.isSelected = value
+        }
+
+    var wslEnabled: Boolean
+        get() = wslEnabledCheckBox.isSelected
+        set(value) {
+            wslEnabledCheckBox.isSelected = value
+        }
+
+    var wslDistribution: String
+        get() = wslDistributionField.text
+        set(value) {
+            wslDistributionField.text = value
+        }
+
+    var wslLspPath: String
+        get() = wslLspPathField.text
+        set(value) {
+            wslLspPathField.text = value
         }
 
     var traceLevel: AgnixSettings.TraceLevel

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsComponent.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsComponent.kt
@@ -8,6 +8,7 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
+import io.agnix.jetbrains.binary.PlatformInfo
 import javax.swing.JComboBox
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -40,6 +41,10 @@ class AgnixSettingsComponent {
 
     init {
         configureLspPathFileChooser()
+        val wslAvailable = PlatformInfo.supportsWslExecution()
+        wslEnabledCheckBox.isEnabled = wslAvailable
+        wslDistributionField.isEnabled = wslAvailable
+        wslLspPathField.isEnabled = wslAvailable
 
         // Build the form
         mainPanel = FormBuilder.createFormBuilder()

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurable.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurable.kt
@@ -2,6 +2,8 @@ package io.agnix.jetbrains.settings
 
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.project.ProjectManager
+import com.redhat.devtools.lsp4ij.LanguageServerManager
 import io.agnix.jetbrains.binary.AgnixBinaryResolver
 import io.agnix.jetbrains.binary.PlatformInfo
 import io.agnix.jetbrains.wsl.WslLaunch
@@ -52,6 +54,16 @@ class AgnixSettingsConfigurable : Configurable {
 
         val wslDistribution = component.wslDistribution.trim()
         val wslLspPath = component.wslLspPath.trim()
+        val previousWslSettings = WslLaunchSettings(
+            enabled = settings.wslEnabled,
+            distribution = settings.wslDistribution,
+            lspPath = settings.wslLspPath
+        )
+        val nextWslSettings = WslLaunchSettings(
+            enabled = component.wslEnabled,
+            distribution = wslDistribution,
+            lspPath = wslLspPath
+        )
         if (component.wslEnabled && PlatformInfo.supportsWslExecution()) {
             // An empty distribution is allowed here: it means "use the distribution the
             // project is opened from", which is only known once a project is open.
@@ -80,6 +92,17 @@ class AgnixSettingsConfigurable : Configurable {
         if (lspPathChanged) {
             AgnixBinaryResolver.clearCache()
         }
+
+        if (shouldRestartForWslChange(
+                wslHostSupported = PlatformInfo.supportsWslExecution(),
+                previous = previousWslSettings,
+                next = nextWslSettings
+            )
+        ) {
+            ProjectManager.getInstance().openProjects.forEach { project ->
+                LanguageServerManager.getInstance(project).stop("io.agnix.lsp")
+            }
+        }
     }
 
     override fun reset() {
@@ -100,3 +123,15 @@ class AgnixSettingsConfigurable : Configurable {
         settingsComponent = null
     }
 }
+
+internal data class WslLaunchSettings(
+    val enabled: Boolean,
+    val distribution: String,
+    val lspPath: String
+)
+
+internal fun shouldRestartForWslChange(
+    wslHostSupported: Boolean,
+    previous: WslLaunchSettings,
+    next: WslLaunchSettings
+): Boolean = wslHostSupported && previous != next

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurable.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurable.kt
@@ -3,6 +3,7 @@ package io.agnix.jetbrains.settings
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ConfigurationException
 import io.agnix.jetbrains.binary.AgnixBinaryResolver
+import io.agnix.jetbrains.wsl.WslLaunch
 import javax.swing.JComponent
 
 /**
@@ -32,6 +33,9 @@ class AgnixSettingsConfigurable : Configurable {
         return component.enabled != settings.enabled ||
             component.lspPath.trim() != settings.lspPath ||
             component.autoDownload != settings.autoDownload ||
+            component.wslEnabled != settings.wslEnabled ||
+            component.wslDistribution.trim() != settings.wslDistribution ||
+            component.wslLspPath.trim() != settings.wslLspPath ||
             component.traceLevel != settings.traceLevel ||
             component.codeLensEnabled != settings.codeLensEnabled
     }
@@ -45,11 +49,29 @@ class AgnixSettingsConfigurable : Configurable {
             throw ConfigurationException(message)
         }
 
+        val wslDistribution = component.wslDistribution.trim()
+        val wslLspPath = component.wslLspPath.trim()
+        if (component.wslEnabled) {
+            // An empty distribution is allowed here: it means "use the distribution the
+            // project is opened from", which is only known once a project is open.
+            if (wslDistribution.isNotEmpty()) {
+                WslLaunch.validateDistribution(wslDistribution)?.let { message ->
+                    throw ConfigurationException(message)
+                }
+            }
+            WslLaunch.validateLspPath(wslLspPath)?.let { message ->
+                throw ConfigurationException(message)
+            }
+        }
+
         val lspPathChanged = settings.lspPath != lspPath
 
         settings.enabled = component.enabled
         settings.lspPath = lspPath
         settings.autoDownload = component.autoDownload
+        settings.wslEnabled = component.wslEnabled
+        settings.wslDistribution = wslDistribution
+        settings.wslLspPath = wslLspPath
         settings.traceLevel = component.traceLevel
         settings.codeLensEnabled = component.codeLensEnabled
 
@@ -66,6 +88,9 @@ class AgnixSettingsConfigurable : Configurable {
         component.enabled = settings.enabled
         component.lspPath = settings.lspPath
         component.autoDownload = settings.autoDownload
+        component.wslEnabled = settings.wslEnabled
+        component.wslDistribution = settings.wslDistribution
+        component.wslLspPath = settings.wslLspPath
         component.traceLevel = settings.traceLevel
         component.codeLensEnabled = settings.codeLensEnabled
     }

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurable.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurable.kt
@@ -3,6 +3,7 @@ package io.agnix.jetbrains.settings
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.options.ConfigurationException
 import io.agnix.jetbrains.binary.AgnixBinaryResolver
+import io.agnix.jetbrains.binary.PlatformInfo
 import io.agnix.jetbrains.wsl.WslLaunch
 import javax.swing.JComponent
 
@@ -51,7 +52,7 @@ class AgnixSettingsConfigurable : Configurable {
 
         val wslDistribution = component.wslDistribution.trim()
         val wslLspPath = component.wslLspPath.trim()
-        if (component.wslEnabled) {
+        if (component.wslEnabled && PlatformInfo.supportsWslExecution()) {
             // An empty distribution is allowed here: it means "use the distribution the
             // project is opened from", which is only known once a project is open.
             if (wslDistribution.isNotEmpty()) {

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/startup/AgnixStartupActivity.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/startup/AgnixStartupActivity.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import io.agnix.jetbrains.binary.AgnixBinaryResolver
+import io.agnix.jetbrains.binary.PlatformInfo
 import io.agnix.jetbrains.notifications.AgnixNotifications
 import io.agnix.jetbrains.settings.AgnixSettings
 
@@ -28,6 +29,16 @@ class AgnixStartupActivity : ProjectActivity {
             return
         }
 
+        if (!shouldCheckHostBinary(
+                pluginEnabled = settings.enabled,
+                wslEnabled = settings.wslEnabled,
+                wslHostSupported = PlatformInfo.supportsWslExecution()
+            )
+        ) {
+            logger.info("WSL execution mode enabled; skipping host-local agnix-lsp startup probe")
+            return
+        }
+
         logger.info("agnix startup activity running for project: ${project.name}")
 
         // Check for LSP binary using cached resolver
@@ -48,5 +59,13 @@ class AgnixStartupActivity : ProjectActivity {
             // Show notification to user
             AgnixNotifications.notifyBinaryNotFound(project)
         }
+    }
+
+    companion object {
+        internal fun shouldCheckHostBinary(
+            pluginEnabled: Boolean,
+            wslEnabled: Boolean,
+            wslHostSupported: Boolean
+        ): Boolean = pluginEnabled && !(wslEnabled && wslHostSupported)
     }
 }

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/startup/AgnixStartupActivity.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/startup/AgnixStartupActivity.kt
@@ -7,6 +7,7 @@ import io.agnix.jetbrains.binary.AgnixBinaryResolver
 import io.agnix.jetbrains.binary.PlatformInfo
 import io.agnix.jetbrains.notifications.AgnixNotifications
 import io.agnix.jetbrains.settings.AgnixSettings
+import io.agnix.jetbrains.wsl.WslLaunch
 
 /**
  * Startup activity for the agnix plugin.
@@ -35,7 +36,21 @@ class AgnixStartupActivity : ProjectActivity {
                 wslHostSupported = PlatformInfo.supportsWslExecution()
             )
         ) {
-            logger.info("WSL execution mode enabled; skipping host-local agnix-lsp startup probe")
+            val resolution = WslLaunch.resolve(
+                enabled = true,
+                distribution = settings.wslDistribution,
+                lspPath = settings.wslLspPath,
+                projectBasePath = project.basePath
+            )
+            when (resolution) {
+                is WslLaunch.Resolution.Invalid -> {
+                    logger.warn("WSL execution mode is misconfigured: ${resolution.message}")
+                    AgnixNotifications.notifyWslLaunchProblem(project, resolution.message)
+                }
+                is WslLaunch.Resolution.Ready ->
+                    logger.info("WSL execution mode enabled; skipping host-local agnix-lsp startup probe")
+                WslLaunch.Resolution.Disabled -> Unit
+            }
             return
         }
 

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/wsl/WslLaunch.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/wsl/WslLaunch.kt
@@ -1,0 +1,126 @@
+package io.agnix.jetbrains.wsl
+
+/**
+ * Pure `wsl.exe` command construction and WSL settings validation.
+ *
+ * The command is always built as an argument *list* and handed to
+ * `GeneralCommandLine` unquoted, so distribution names and Linux paths that
+ * contain spaces cannot be re-split or injected: `--exec` runs the binary
+ * directly without a Linux shell, so no second round of quoting applies inside
+ * the distribution.
+ *
+ * The JetBrains `WSLDistribution.patchCommandLine` API is deliberately not used:
+ * it is `@ApiStatus.Experimental` and the plugin ships for build range 233 to
+ * 262.*, where a moved or changed experimental API would break the plugin
+ * verifier. `wsl.exe --distribution <name> --exec <binary>` is documented CLI
+ * surface and stable across WSL 1 and WSL 2.
+ *
+ * Kept free of IntelliJ Platform types so it can be unit-tested without the
+ * platform test framework.
+ */
+object WslLaunch {
+
+    /** Launcher used on the Windows side. Resolved through `PATH` (System32). */
+    const val WSL_EXECUTABLE = "wsl.exe"
+
+    const val DISTRIBUTION_REQUIRED_MESSAGE =
+        "WSL distribution is required. Run 'wsl --list --quiet' in a Windows terminal and " +
+            "copy the exact name, for example Ubuntu. Leave it empty only when the project " +
+            "itself is opened from a \\\\wsl.localhost or \\\\wsl$ path."
+
+    const val DISTRIBUTION_INVALID_MESSAGE =
+        "WSL distribution name must not start with '-' or contain slashes, quotes, or control characters."
+
+    const val LINUX_PATH_REQUIRED_MESSAGE =
+        "WSL agnix-lsp path must be an absolute Linux path inside the distribution, " +
+            "for example /home/you/.cargo/bin/agnix-lsp."
+
+    private val forbiddenInDistribution = charArrayOf('/', '\\', '"', '\'')
+
+    /**
+     * Outcome of turning the persisted settings into a launch decision.
+     */
+    sealed class Resolution {
+        /** WSL execution mode is off; the native launch path is used unchanged. */
+        object Disabled : Resolution()
+
+        /** WSL execution mode is on but misconfigured; [message] is user-facing. */
+        data class Invalid(val message: String) : Resolution()
+
+        /** WSL execution mode is on and usable. */
+        data class Ready(val distribution: String, val lspPath: String) : Resolution()
+    }
+
+    /**
+     * Resolve WSL execution settings.
+     *
+     * An empty distribution falls back to the one encoded in [projectBasePath]
+     * when the IDE already opened the project from a WSL UNC path.
+     */
+    fun resolve(
+        enabled: Boolean,
+        distribution: String,
+        lspPath: String,
+        projectBasePath: String?
+    ): Resolution {
+        if (!enabled) return Resolution.Disabled
+
+        val effectiveDistribution = distribution.trim()
+            .ifEmpty { WslPaths.distributionFromUncPath(projectBasePath).orEmpty() }
+        validateDistribution(effectiveDistribution)?.let { return Resolution.Invalid(it) }
+
+        val effectiveLspPath = lspPath.trim()
+        validateLspPath(effectiveLspPath)?.let { return Resolution.Invalid(it) }
+
+        return Resolution.Ready(effectiveDistribution, effectiveLspPath)
+    }
+
+    /** Returns an error message for an unusable distribution name, or null. */
+    fun validateDistribution(distribution: String): String? {
+        val trimmed = distribution.trim()
+        if (trimmed.isEmpty()) return DISTRIBUTION_REQUIRED_MESSAGE
+        // A leading '-' would be parsed as a wsl.exe option instead of a value.
+        if (trimmed.startsWith("-")) return DISTRIBUTION_INVALID_MESSAGE
+        if (trimmed.any { it in forbiddenInDistribution || it.isControlChar() }) {
+            return DISTRIBUTION_INVALID_MESSAGE
+        }
+        return null
+    }
+
+    /** Returns an error message for an unusable Linux binary path, or null. */
+    fun validateLspPath(lspPath: String): String? {
+        val trimmed = lspPath.trim()
+        if (!trimmed.startsWith("/")) return LINUX_PATH_REQUIRED_MESSAGE
+        if (trimmed.any { it.isControlChar() }) return LINUX_PATH_REQUIRED_MESSAGE
+        return null
+    }
+
+    /** Returns the first validation error for the pair, or null when both are usable. */
+    fun validate(distribution: String, lspPath: String): String? =
+        validateDistribution(distribution) ?: validateLspPath(lspPath)
+
+    /**
+     * Build the `wsl.exe` argument list that starts agnix-lsp over stdio.
+     *
+     * No working directory is passed: `wsl.exe --cd` only exists on newer WSL
+     * builds, and agnix-lsp derives its workspace from the LSP `rootUri` rather
+     * than the process working directory.
+     *
+     * @throws IllegalArgumentException when [distribution] or [lspPath] is unusable.
+     */
+    fun buildCommand(distribution: String, lspPath: String): List<String> {
+        val trimmedDistribution = distribution.trim()
+        val trimmedLspPath = lspPath.trim()
+        validate(trimmedDistribution, trimmedLspPath)?.let { throw IllegalArgumentException(it) }
+
+        return listOf(
+            WSL_EXECUTABLE,
+            "--distribution",
+            trimmedDistribution,
+            "--exec",
+            trimmedLspPath
+        )
+    }
+
+    private fun Char.isControlChar(): Boolean = this.code < 0x20 || this.code == 0x7F
+}

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/wsl/WslPaths.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/wsl/WslPaths.kt
@@ -1,0 +1,172 @@
+package io.agnix.jetbrains.wsl
+
+import java.net.URI
+import java.util.Locale
+
+/**
+ * Pure Windows <-> WSL path and `file:` URI translation.
+ *
+ * A Windows IDE that opens a WSL-hosted project sees it through one of the two
+ * WSL UNC roots (`\\wsl$\<distro>\...` or `\\wsl.localhost\<distro>\...`), while
+ * agnix-lsp running inside the distribution only understands Linux paths. Every
+ * path that crosses the LSP boundary therefore has to be rewritten in both
+ * directions.
+ *
+ * Kept free of IntelliJ Platform types so it can be unit-tested without the
+ * platform test framework (same rationale as [io.agnix.jetbrains.lsp.LspProcessErrors]).
+ */
+object WslPaths {
+
+    /** UNC hosts IntelliJ uses for WSL shares; both are accepted on input. */
+    private const val WSL_DOLLAR_HOST = "wsl$"
+    private const val WSL_LOCALHOST_HOST = "wsl.localhost"
+
+    /**
+     * Default WSL automount root for Windows drives. Configurable per distribution
+     * via `/etc/wsl.conf` (`[automount] root=`); only paths outside the distribution
+     * (for example a file on `C:`) are mapped through it.
+     */
+    private const val AUTOMOUNT_ROOT = "/mnt"
+
+    private val driveRootPath = Regex("^([A-Za-z]):(/.*)?$")
+    private val mountedDrivePath = Regex("^$AUTOMOUNT_ROOT/([a-zA-Z])(/.*)?$")
+    private val leadingDriveInUriPath = Regex("^/[A-Za-z]:(/.*)?$")
+
+    /** A WSL UNC path split into its distribution and Linux parts. */
+    data class WslUncPath(val distribution: String, val linuxPath: String)
+
+    /**
+     * Parse a WSL UNC path into distribution + Linux path.
+     *
+     * Accepts backslash form (`\\wsl.localhost\Ubuntu\home\me`) and the
+     * forward-slash form IntelliJ uses for `VirtualFile.getPath()`
+     * (`//wsl.localhost/Ubuntu/home/me`). Returns null for anything else.
+     */
+    fun parseUncPath(path: String): WslUncPath? {
+        val normalized = path.trim().replace('\\', '/')
+        if (!normalized.startsWith("//")) return null
+
+        val segments = normalized.removePrefix("//").split('/')
+        if (segments.size < 2) return null
+
+        val host = segments[0].lowercase(Locale.ROOT)
+        if (host != WSL_DOLLAR_HOST && host != WSL_LOCALHOST_HOST) return null
+
+        val distribution = segments[1]
+        if (distribution.isEmpty()) return null
+
+        val linuxSegments = segments.drop(2).filter { it.isNotEmpty() }
+        return WslUncPath(distribution, "/" + linuxSegments.joinToString("/"))
+    }
+
+    /**
+     * Distribution name encoded in a WSL UNC path, or null if [path] is not one.
+     *
+     * Used to default the configured distribution to whatever the IDE already
+     * opened the project from.
+     */
+    fun distributionFromUncPath(path: String?): String? =
+        path?.let { parseUncPath(it)?.distribution }
+
+    /**
+     * Translate a Windows-side path to the Linux path agnix-lsp expects.
+     *
+     * - WSL UNC path for [distribution] -> its Linux path
+     * - WSL UNC path for a *different* distribution -> null (not reachable)
+     * - Windows drive path -> automount path (`C:\src` -> `/mnt/c/src`)
+     * - already-absolute Linux path -> unchanged
+     */
+    fun toLinuxPath(windowsPath: String, distribution: String): String? {
+        val trimmed = windowsPath.trim()
+        if (trimmed.isEmpty()) return null
+
+        parseUncPath(trimmed)?.let { unc ->
+            return if (unc.distribution.equals(distribution, ignoreCase = true)) unc.linuxPath else null
+        }
+
+        val normalized = trimmed.replace('\\', '/')
+        driveRootPath.matchEntire(normalized)?.let { match ->
+            val drive = match.groupValues[1].lowercase(Locale.ROOT)
+            val rest = match.groupValues[2].trimStart('/')
+            return if (rest.isEmpty()) "$AUTOMOUNT_ROOT/$drive" else "$AUTOMOUNT_ROOT/$drive/$rest"
+        }
+
+        return if (normalized.startsWith("/")) normalized else null
+    }
+
+    /**
+     * Translate a Linux path back to a Windows path the IDE can resolve.
+     *
+     * Automount paths map back to their drive (`/mnt/c/src` -> `C:\src`); anything
+     * else maps to the `\\wsl.localhost\<distribution>\...` share.
+     */
+    fun toWindowsPath(linuxPath: String, distribution: String): String? {
+        val trimmed = linuxPath.trim()
+        if (!trimmed.startsWith("/")) return null
+
+        mountedDrivePath.matchEntire(trimmed)?.let { match ->
+            val drive = match.groupValues[1].uppercase(Locale.ROOT)
+            val rest = match.groupValues[2]
+            return "$drive:" + rest.replace('/', '\\').ifEmpty { "\\" }
+        }
+
+        if (distribution.isBlank()) return null
+        val rest = trimmed.trim('/').replace('/', '\\')
+        val root = "\\\\$WSL_LOCALHOST_HOST\\$distribution"
+        return if (rest.isEmpty()) root else "$root\\$rest"
+    }
+
+    /**
+     * IntelliJ VFS spelling of a Windows path (forward slashes, UNC keeps `//`).
+     */
+    fun toIdeaPath(windowsPath: String): String = windowsPath.replace('\\', '/')
+
+    /** `file:` URI for an absolute Linux path, or null if [linuxPath] is not absolute. */
+    fun toLinuxFileUri(linuxPath: String): URI? {
+        if (!linuxPath.startsWith("/")) return null
+        // Empty host keeps the canonical `file:///path` form; the constructor
+        // percent-encodes characters that are illegal in a URI path.
+        return runCatching { URI("file", "", linuxPath, null) }.getOrNull()
+    }
+
+    /**
+     * Windows-side path carried by a `file:` URI.
+     *
+     * Handles the UNC spellings a Windows IDE can emit (`file://wsl.localhost/...`,
+     * `file:////wsl.localhost/...`, `file://wsl$/...`) and drive URIs
+     * (`file:///C:/src`).
+     */
+    fun windowsPathFromFileUri(fileUri: String): String? {
+        val uri = runCatching { URI(fileUri.trim()) }.getOrNull() ?: return null
+        if (!"file".equals(uri.scheme, ignoreCase = true)) return null
+
+        val path = uri.path ?: return null
+        if (path.isEmpty()) return null
+
+        val host = uri.host ?: uri.authority
+        if (!host.isNullOrEmpty()) return "//$host$path"
+
+        // `file:///C:/src` -> `C:/src`
+        return if (leadingDriveInUriPath.matches(path)) path.substring(1) else path
+    }
+
+    /** Absolute Linux path carried by a plain `file:///...` URI. */
+    fun linuxPathFromFileUri(fileUri: String): String? {
+        val uri = runCatching { URI(fileUri.trim()) }.getOrNull() ?: return null
+        if (!"file".equals(uri.scheme, ignoreCase = true)) return null
+        if (!uri.host.isNullOrEmpty() || !uri.authority.isNullOrEmpty()) return null
+
+        val path = uri.path ?: return null
+        return if (path.startsWith("/") && !leadingDriveInUriPath.matches(path)) path else null
+    }
+
+    /**
+     * Rewrite a Windows-side `file:` URI into the Linux `file:` URI for
+     * [distribution], or null when it cannot be reached from that distribution.
+     */
+    fun toLinuxFileUri(fileUri: String, distribution: String): URI? {
+        val windowsPath = windowsPathFromFileUri(fileUri) ?: return null
+        val linuxPath = toLinuxPath(windowsPath, distribution) ?: return null
+        return toLinuxFileUri(linuxPath)
+    }
+}

--- a/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/wsl/WslPaths.kt
+++ b/editors/jetbrains/src/main/kotlin/io/agnix/jetbrains/wsl/WslPaths.kt
@@ -85,6 +85,9 @@ object WslPaths {
         }
 
         val normalized = trimmed.replace('\\', '/')
+        // A regular Windows UNC share is not a Linux absolute path and is not
+        // reachable merely because the language server runs inside WSL.
+        if (normalized.startsWith("//")) return null
         driveRootPath.matchEntire(normalized)?.let { match ->
             val drive = match.groupValues[1].lowercase(Locale.ROOT)
             val rest = match.groupValues[2].trimStart('/')

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/binary/PlatformInfoTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/binary/PlatformInfoTest.kt
@@ -45,6 +45,14 @@ class PlatformInfoTest {
     }
 
     @Test
+    fun `WSL execution is supported only on Windows`() {
+        assertTrue(PlatformInfo.supportsWslExecution(PlatformInfo.OS.WINDOWS))
+        assertFalse(PlatformInfo.supportsWslExecution(PlatformInfo.OS.MACOS))
+        assertFalse(PlatformInfo.supportsWslExecution(PlatformInfo.OS.LINUX))
+        assertFalse(PlatformInfo.supportsWslExecution(PlatformInfo.OS.UNKNOWN))
+    }
+
+    @Test
     fun `getPlatformDescription returns non-empty string`() {
         val description = PlatformInfo.getPlatformDescription()
 

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/lsp/AgnixDocumentMatcherTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/lsp/AgnixDocumentMatcherTest.kt
@@ -1,0 +1,64 @@
+package io.agnix.jetbrains.lsp
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AgnixDocumentMatcherTest {
+
+    @Test
+    fun `WSL mode excludes files from another distribution`() {
+        assertFalse(
+            matches(
+                path = "//wsl.localhost/Debian/home/me/project/SKILL.md",
+                projectBasePath = "//wsl.localhost/Ubuntu/home/me/project"
+            )
+        )
+    }
+
+    @Test
+    fun `WSL mode includes mappable files from the active distribution`() {
+        assertTrue(
+            matches(
+                path = "//wsl.localhost/Ubuntu/home/me/project/SKILL.md",
+                projectBasePath = "//wsl.localhost/Ubuntu/home/me/project"
+            )
+        )
+    }
+
+    @Test
+    fun `synced WSL preference is ignored on non Windows hosts`() {
+        assertTrue(
+            matches(
+                path = "/home/me/project/SKILL.md",
+                projectBasePath = "/home/me/project",
+                wslHostSupported = false
+            )
+        )
+    }
+
+    @Test
+    fun `invalid active WSL configuration does not attach documents`() {
+        assertFalse(
+            matches(
+                path = "//wsl.localhost/Ubuntu/home/me/project/SKILL.md",
+                projectBasePath = "//wsl.localhost/Ubuntu/home/me/project",
+                lspPath = "relative/agnix-lsp"
+            )
+        )
+    }
+
+    private fun matches(
+        path: String,
+        projectBasePath: String?,
+        wslHostSupported: Boolean = true,
+        lspPath: String = "/home/me/.cargo/bin/agnix-lsp"
+    ): Boolean = AgnixDocumentMatcher.matchesPath(
+        path = path,
+        projectBasePath = projectBasePath,
+        wslEnabled = true,
+        wslHostSupported = wslHostSupported,
+        distribution = "Ubuntu",
+        lspPath = lspPath
+    )
+}

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurableTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/settings/AgnixSettingsConfigurableTest.kt
@@ -1,0 +1,47 @@
+package io.agnix.jetbrains.settings
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AgnixSettingsConfigurableTest {
+
+    private val native = WslLaunchSettings(
+        enabled = false,
+        distribution = "",
+        lspPath = ""
+    )
+
+    @Test
+    fun `toggling WSL mode changes the launch identity`() {
+        assertTrue(shouldRestartForWslChange(true, native, native.copy(enabled = true)))
+    }
+
+    @Test
+    fun `switching distribution changes the launch identity`() {
+        val ubuntu = WslLaunchSettings(true, "Ubuntu", "/usr/bin/agnix-lsp")
+        assertTrue(shouldRestartForWslChange(true, ubuntu, ubuntu.copy(distribution = "Debian")))
+    }
+
+    @Test
+    fun `switching WSL binary changes the launch identity`() {
+        val original = WslLaunchSettings(true, "Ubuntu", "/usr/bin/agnix-lsp")
+        assertTrue(
+            shouldRestartForWslChange(
+                true,
+                original,
+                original.copy(lspPath = "/opt/agnix/agnix-lsp")
+            )
+        )
+    }
+
+    @Test
+    fun `unrelated settings leave the launch identity unchanged`() {
+        assertFalse(shouldRestartForWslChange(true, native, native.copy()))
+    }
+
+    @Test
+    fun `non Windows hosts never restart for synced WSL changes`() {
+        assertFalse(shouldRestartForWslChange(false, native, native.copy(enabled = true)))
+    }
+}

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/startup/AgnixStartupActivityTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/startup/AgnixStartupActivityTest.kt
@@ -1,0 +1,41 @@
+package io.agnix.jetbrains.startup
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AgnixStartupActivityTest {
+
+    @Test
+    fun `valid Windows WSL mode skips the host binary probe`() {
+        assertFalse(
+            AgnixStartupActivity.shouldCheckHostBinary(
+                pluginEnabled = true,
+                wslEnabled = true,
+                wslHostSupported = true
+            )
+        )
+    }
+
+    @Test
+    fun `synced WSL setting off Windows keeps the native probe`() {
+        assertTrue(
+            AgnixStartupActivity.shouldCheckHostBinary(
+                pluginEnabled = true,
+                wslEnabled = true,
+                wslHostSupported = false
+            )
+        )
+    }
+
+    @Test
+    fun `disabled plugin never probes the host binary`() {
+        assertFalse(
+            AgnixStartupActivity.shouldCheckHostBinary(
+                pluginEnabled = false,
+                wslEnabled = false,
+                wslHostSupported = false
+            )
+        )
+    }
+}

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/wsl/WslLaunchTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/wsl/WslLaunchTest.kt
@@ -1,0 +1,136 @@
+package io.agnix.jetbrains.wsl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for wsl.exe command construction and WSL settings resolution.
+ */
+class WslLaunchTest {
+
+    @Test
+    fun `command runs the linux binary without a shell`() {
+        assertEquals(
+            listOf("wsl.exe", "--distribution", "Ubuntu", "--exec", "/home/me/.cargo/bin/agnix-lsp"),
+            WslLaunch.buildCommand("Ubuntu", "/home/me/.cargo/bin/agnix-lsp")
+        )
+    }
+
+    @Test
+    fun `distribution and path with spaces stay single arguments`() {
+        val command = WslLaunch.buildCommand("Ubuntu 24.04", "/home/me/my tools/agnix-lsp")
+        assertEquals("Ubuntu 24.04", command[2])
+        assertEquals("/home/me/my tools/agnix-lsp", command[4])
+        assertEquals(5, command.size)
+    }
+
+    @Test
+    fun `surrounding whitespace is trimmed from command arguments`() {
+        assertEquals(
+            listOf("wsl.exe", "--distribution", "Ubuntu", "--exec", "/usr/local/bin/agnix-lsp"),
+            WslLaunch.buildCommand("  Ubuntu  ", "  /usr/local/bin/agnix-lsp  ")
+        )
+    }
+
+    @Test
+    fun `option-looking distribution is rejected instead of injected`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            WslLaunch.buildCommand("--user root", "/usr/local/bin/agnix-lsp")
+        }
+        assertEquals(WslLaunch.DISTRIBUTION_INVALID_MESSAGE, error.message)
+    }
+
+    @Test
+    fun `windows lsp path is rejected in wsl mode`() {
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            WslLaunch.buildCommand("Ubuntu", "C:\\Program Files\\agnix\\agnix-lsp.exe")
+        }
+        assertEquals(WslLaunch.LINUX_PATH_REQUIRED_MESSAGE, error.message)
+    }
+
+    @Test
+    fun `distribution validation rejects empty separators and control characters`() {
+        assertEquals(WslLaunch.DISTRIBUTION_REQUIRED_MESSAGE, WslLaunch.validateDistribution("   "))
+        assertEquals(WslLaunch.DISTRIBUTION_INVALID_MESSAGE, WslLaunch.validateDistribution("Ubuntu/extra"))
+        assertEquals(WslLaunch.DISTRIBUTION_INVALID_MESSAGE, WslLaunch.validateDistribution("Ubuntu\\extra"))
+        assertEquals(WslLaunch.DISTRIBUTION_INVALID_MESSAGE, WslLaunch.validateDistribution("Ubu\"ntu"))
+        assertEquals(WslLaunch.DISTRIBUTION_INVALID_MESSAGE, WslLaunch.validateDistribution("Ubuntu\u0000"))
+        assertNull(WslLaunch.validateDistribution("Ubuntu-24.04"))
+    }
+
+    @Test
+    fun `lsp path validation requires an absolute linux path`() {
+        assertEquals(WslLaunch.LINUX_PATH_REQUIRED_MESSAGE, WslLaunch.validateLspPath(""))
+        assertEquals(WslLaunch.LINUX_PATH_REQUIRED_MESSAGE, WslLaunch.validateLspPath("agnix-lsp"))
+        assertEquals(WslLaunch.LINUX_PATH_REQUIRED_MESSAGE, WslLaunch.validateLspPath("~/bin/agnix-lsp"))
+        assertEquals(WslLaunch.LINUX_PATH_REQUIRED_MESSAGE, WslLaunch.validateLspPath("/usr/bin/agnix\nlsp"))
+        assertNull(WslLaunch.validateLspPath("/usr/bin/agnix-lsp"))
+    }
+
+    @Test
+    fun `disabled mode keeps the native launch path`() {
+        val resolution = WslLaunch.resolve(
+            enabled = false,
+            distribution = "Ubuntu",
+            lspPath = "/usr/bin/agnix-lsp",
+            projectBasePath = "//wsl.localhost/Ubuntu/home/me/project"
+        )
+        assertEquals(WslLaunch.Resolution.Disabled, resolution)
+    }
+
+    @Test
+    fun `configured distribution wins`() {
+        val resolution = WslLaunch.resolve(
+            enabled = true,
+            distribution = "Debian",
+            lspPath = "/usr/bin/agnix-lsp",
+            projectBasePath = "//wsl.localhost/Ubuntu/home/me/project"
+        )
+        assertEquals(WslLaunch.Resolution.Ready("Debian", "/usr/bin/agnix-lsp"), resolution)
+    }
+
+    @Test
+    fun `empty distribution falls back to the project distribution`() {
+        val resolution = WslLaunch.resolve(
+            enabled = true,
+            distribution = "",
+            lspPath = "/usr/bin/agnix-lsp",
+            projectBasePath = "//wsl.localhost/Ubuntu-24.04/home/me/project"
+        )
+        assertEquals(WslLaunch.Resolution.Ready("Ubuntu-24.04", "/usr/bin/agnix-lsp"), resolution)
+    }
+
+    @Test
+    fun `missing distribution for a non-wsl project is reported`() {
+        val resolution = WslLaunch.resolve(
+            enabled = true,
+            distribution = "",
+            lspPath = "/usr/bin/agnix-lsp",
+            projectBasePath = "C:\\src\\project"
+        )
+        assertEquals(WslLaunch.Resolution.Invalid(WslLaunch.DISTRIBUTION_REQUIRED_MESSAGE), resolution)
+    }
+
+    @Test
+    fun `missing linux path is reported`() {
+        val resolution = WslLaunch.resolve(
+            enabled = true,
+            distribution = "Ubuntu",
+            lspPath = "",
+            projectBasePath = "//wsl.localhost/Ubuntu/home/me/project"
+        )
+        assertEquals(WslLaunch.Resolution.Invalid(WslLaunch.LINUX_PATH_REQUIRED_MESSAGE), resolution)
+    }
+
+    @Test
+    fun `validate reports the distribution problem first`() {
+        assertEquals(
+            WslLaunch.DISTRIBUTION_REQUIRED_MESSAGE,
+            WslLaunch.validate("", "not-a-linux-path")
+        )
+        assertTrue(WslLaunch.validate("Ubuntu", "/usr/bin/agnix-lsp") == null)
+    }
+}

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/wsl/WslPathsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/wsl/WslPathsTest.kt
@@ -131,6 +131,15 @@ class WslPathsTest {
     }
 
     @Test
+    fun `file uri preserves literal percent sequences through round trip`() {
+        val linuxPath = "/home/me/report%20final/SKILL.md"
+        val uri = WslPaths.toLinuxFileUri(linuxPath)
+
+        assertEquals("file:///home/me/report%2520final/SKILL.md", uri.toString())
+        assertEquals(linuxPath, WslPaths.linuxPathFromFileUri(uri.toString()))
+    }
+
+    @Test
     fun `windows path is recovered from unc and drive file uris`() {
         assertEquals(
             "//wsl.localhost/Ubuntu/home/me/SKILL.md",

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/wsl/WslPathsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/wsl/WslPathsTest.kt
@@ -1,0 +1,162 @@
+package io.agnix.jetbrains.wsl
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for Windows <-> WSL path and URI translation.
+ */
+class WslPathsTest {
+
+    @Test
+    fun `parses wsl localhost unc path in idea forward slash form`() {
+        val parsed = WslPaths.parseUncPath("//wsl.localhost/Ubuntu/home/me/project")
+        assertEquals("Ubuntu", parsed?.distribution)
+        assertEquals("/home/me/project", parsed?.linuxPath)
+    }
+
+    @Test
+    fun `parses legacy wsl dollar unc path in backslash form`() {
+        val parsed = WslPaths.parseUncPath("\\\\wsl$\\Debian\\home\\me")
+        assertEquals("Debian", parsed?.distribution)
+        assertEquals("/home/me", parsed?.linuxPath)
+    }
+
+    @Test
+    fun `parses distribution root`() {
+        val parsed = WslPaths.parseUncPath("//wsl.localhost/Ubuntu/")
+        assertEquals("Ubuntu", parsed?.distribution)
+        assertEquals("/", parsed?.linuxPath)
+    }
+
+    @Test
+    fun `non wsl paths are not unc wsl paths`() {
+        assertNull(WslPaths.parseUncPath("C:\\src\\project"))
+        assertNull(WslPaths.parseUncPath("//fileserver/share/project"))
+        assertNull(WslPaths.parseUncPath("/home/me/project"))
+        assertNull(WslPaths.parseUncPath("//wsl.localhost"))
+        assertNull(WslPaths.parseUncPath("//wsl.localhost//home/me"))
+    }
+
+    @Test
+    fun `distribution is derived from the project location`() {
+        assertEquals(
+            "Ubuntu-24.04",
+            WslPaths.distributionFromUncPath("//wsl.localhost/Ubuntu-24.04/home/me/project")
+        )
+        assertNull(WslPaths.distributionFromUncPath("C:\\src\\project"))
+        assertNull(WslPaths.distributionFromUncPath(null))
+    }
+
+    @Test
+    fun `unc path maps to linux path for the same distribution`() {
+        assertEquals(
+            "/home/me/project/SKILL.md",
+            WslPaths.toLinuxPath("\\\\wsl.localhost\\Ubuntu\\home\\me\\project\\SKILL.md", "Ubuntu")
+        )
+    }
+
+    @Test
+    fun `unc distribution match is case insensitive`() {
+        assertEquals(
+            "/home/me",
+            WslPaths.toLinuxPath("//wsl.localhost/ubuntu/home/me", "Ubuntu")
+        )
+    }
+
+    @Test
+    fun `unc path of another distribution is not reachable`() {
+        assertNull(WslPaths.toLinuxPath("//wsl.localhost/Debian/home/me", "Ubuntu"))
+    }
+
+    @Test
+    fun `windows drive path maps to the automount root`() {
+        assertEquals("/mnt/c/src/project", WslPaths.toLinuxPath("C:\\src\\project", "Ubuntu"))
+        assertEquals("/mnt/d", WslPaths.toLinuxPath("D:\\", "Ubuntu"))
+        assertEquals("/mnt/c/src", WslPaths.toLinuxPath("c:/src", "Ubuntu"))
+    }
+
+    @Test
+    fun `linux paths pass through and junk is rejected`() {
+        assertEquals("/home/me/project", WslPaths.toLinuxPath("/home/me/project", "Ubuntu"))
+        assertNull(WslPaths.toLinuxPath("   ", "Ubuntu"))
+        assertNull(WslPaths.toLinuxPath("relative/path", "Ubuntu"))
+    }
+
+    @Test
+    fun `linux path maps back to the wsl share`() {
+        assertEquals(
+            "\\\\wsl.localhost\\Ubuntu\\home\\me\\project",
+            WslPaths.toWindowsPath("/home/me/project", "Ubuntu")
+        )
+        assertEquals("\\\\wsl.localhost\\Ubuntu", WslPaths.toWindowsPath("/", "Ubuntu"))
+    }
+
+    @Test
+    fun `automount path maps back to its windows drive`() {
+        assertEquals("C:\\src\\project", WslPaths.toWindowsPath("/mnt/c/src/project", "Ubuntu"))
+        assertEquals("C:\\", WslPaths.toWindowsPath("/mnt/c", "Ubuntu"))
+    }
+
+    @Test
+    fun `relative linux path has no windows mapping`() {
+        assertNull(WslPaths.toWindowsPath("home/me", "Ubuntu"))
+        assertNull(WslPaths.toWindowsPath("/home/me", ""))
+    }
+
+    @Test
+    fun `idea path spelling uses forward slashes`() {
+        assertEquals(
+            "//wsl.localhost/Ubuntu/home/me",
+            WslPaths.toIdeaPath("\\\\wsl.localhost\\Ubuntu\\home\\me")
+        )
+    }
+
+    @Test
+    fun `linux path becomes a canonical file uri`() {
+        assertEquals("file:///home/me/project/SKILL.md", WslPaths.toLinuxFileUri("/home/me/project/SKILL.md").toString())
+        assertNull(WslPaths.toLinuxFileUri("home/me"))
+    }
+
+    @Test
+    fun `file uri encodes spaces`() {
+        assertEquals("file:///home/me/my%20project/SKILL.md", WslPaths.toLinuxFileUri("/home/me/my project/SKILL.md").toString())
+    }
+
+    @Test
+    fun `windows path is recovered from unc and drive file uris`() {
+        assertEquals(
+            "//wsl.localhost/Ubuntu/home/me/SKILL.md",
+            WslPaths.windowsPathFromFileUri("file://wsl.localhost/Ubuntu/home/me/SKILL.md")
+        )
+        assertEquals(
+            "//wsl.localhost/Ubuntu/home/me/SKILL.md",
+            WslPaths.windowsPathFromFileUri("file:////wsl.localhost/Ubuntu/home/me/SKILL.md")
+        )
+        assertEquals("C:/src/project", WslPaths.windowsPathFromFileUri("file:///C:/src/project"))
+        assertNull(WslPaths.windowsPathFromFileUri("http://example.com/x"))
+        assertNull(WslPaths.windowsPathFromFileUri("not a uri"))
+    }
+
+    @Test
+    fun `linux path is recovered only from plain file uris`() {
+        assertEquals("/home/me/SKILL.md", WslPaths.linuxPathFromFileUri("file:///home/me/SKILL.md"))
+        assertEquals("/home/me/my project/SKILL.md", WslPaths.linuxPathFromFileUri("file:///home/me/my%20project/SKILL.md"))
+        assertNull(WslPaths.linuxPathFromFileUri("file://wsl.localhost/Ubuntu/home/me"))
+        assertNull(WslPaths.linuxPathFromFileUri("file:///C:/src"))
+    }
+
+    @Test
+    fun `windows file uri is rewritten to the linux file uri`() {
+        assertEquals(
+            "file:///home/me/project/SKILL.md",
+            WslPaths.toLinuxFileUri("file://wsl.localhost/Ubuntu/home/me/project/SKILL.md", "Ubuntu").toString()
+        )
+        assertEquals(
+            "file:///mnt/c/src/SKILL.md",
+            WslPaths.toLinuxFileUri("file:///C:/src/SKILL.md", "Ubuntu").toString()
+        )
+        assertNull(WslPaths.toLinuxFileUri("file://wsl.localhost/Debian/home/me", "Ubuntu"))
+    }
+}

--- a/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/wsl/WslPathsTest.kt
+++ b/editors/jetbrains/src/test/kotlin/io/agnix/jetbrains/wsl/WslPathsTest.kt
@@ -40,6 +40,12 @@ class WslPathsTest {
     }
 
     @Test
+    fun `regular windows unc share is not treated as a linux path`() {
+        assertNull(WslPaths.toLinuxPath("\\\\fileserver\\share\\project\\SKILL.md", "Ubuntu"))
+        assertNull(WslPaths.toLinuxPath("//fileserver/share/project/SKILL.md", "Ubuntu"))
+    }
+
+    @Test
     fun `distribution is derived from the project location`() {
         assertEquals(
             "Ubuntu-24.04",


### PR DESCRIPTION
## Summary

- add an explicit opt-in WSL execution mode for the JetBrains plugin while preserving native launch as the default
- launch `agnix-lsp` through an argument-safe `wsl.exe --distribution <name> --exec <path>` command without a shell
- derive or configure the distribution, validate the Linux binary path, and translate document/workspace URIs between Windows, WSL UNC, drive automount, and Linux forms
- skip host-local binary installation while WSL mode is active and surface actionable settings errors
- document setup, limitations, troubleshooting, and real-IDE checks

Closes #1346

## Verification

- `./gradlew --no-daemon test verifyPlugin` with JDK 17
- all 9 supported JetBrains IDE versions reported compatible from 2023.3.8 through 2026.2
- native-mode, argument safety, distribution selection, project/path mapping, URI round-trip, invalid configuration, and cross-distribution behavior have regression coverage
- `git diff --check`
- `CLAUDE.md` and `AGENTS.md` remain byte-identical

The implementation was prepared and verified in an isolated worktree; the original dirty checkout was not modified.