### PR TITLE
chore(agnix): refresh Claude and OpenCode baselines

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -17,7 +17,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.243",
+      "last_known_version": "v2.1.245",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -102,7 +102,7 @@
         "per_client_skill"
       ],
       "github_repo": "sst/opencode",
-      "last_known_version": "v1.18.22",
+      "last_known_version": "v1.18.23",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workspace URIs at the LSP boundary, validates configuration, and skips the
   host-local binary installer. Native launches remain unchanged.
 
+### Changed
+- **Tool release baselines**. Advanced Claude Code from `v2.1.243` to
+  `v2.1.245` and OpenCode from `v1.18.22` to `v1.18.23` after reviewing their
+  live release notes. Claude Code's change is a Linux glibc 2.44 startup-crash
+  fix; OpenCode's changes fix Cloudflare AI Gateway routing, Anthropic model
+  slugs, parent-session headers, and immutable-OIDC GitHub auth. None changes
+  an agnix-validated configuration contract.
+
 ## [0.50.0] - 2026-08-25
 
 ### Added


### PR DESCRIPTION
Closes #1420
Closes #1421

## Summary

- advance the live Claude Code baseline from v2.1.243 to v2.1.245
- advance the live OpenCode baseline from v1.18.22 to v1.18.23
- record the release-note triage in the unreleased changelog
- no validated configuration contract changed, so no new rule or generated rule-doc update is needed

## Evidence

- Claude Code v2.1.245 release notes: https://github.com/anthropics/claude-code/releases/tag/v2.1.245
- OpenCode v1.18.23 release notes: https://github.com/anomalyco/opencode/releases/tag/v1.18.23
- `UPDATE_BASELINES=true bash scripts/check-tool-releases.sh` -> `ok=10 new=2 skipped=0` before the baseline copy
- Research Tracking global and per-tool review dates are current at 2026-08-25

## Verification

- `node scripts/sync-rule-bookkeeping.js --check --skip-docs`
- `python3 scripts/check-rule-counts.py`
- `bash scripts/check-locale-sync.sh`
- `cargo fmt --check --all`
- `cargo test --workspace`
- `CLAUDE.md` and `AGENTS.md` remain byte-identical
- `git diff --check`