### PR TITLE
chore: refresh Gemini CLI v0.57.0 baseline

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -357,7 +357,7 @@
         "gemini_agent"
       ],
       "github_repo": "google-gemini/gemini-cli",
-      "last_known_version": "v0.56.0",
+      "last_known_version": "v0.57.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [

--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-08-25",
+  "last_updated": "2026-08-26",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   live release notes. Claude Code's change is a Linux glibc 2.44 startup-crash
   fix; OpenCode's changes fix Cloudflare AI Gateway routing, Anthropic model
   slugs, parent-session headers, and immutable-OIDC GitHub auth. None changes
-  an agnix-validated configuration contract.
+  an agnix-validated configuration contract. Advanced Gemini CLI from `v0.56.0`
+  to `v0.57.0`; its changes affect OAuth redirects, IDE and Git worktree state,
+  runtime retry and cancellation behavior, agent enablement, and command help,
+  without changing an agnix-validated configuration contract.
 
 ## [0.50.0] - 2026-08-25
 

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-08-25
+**Last Updated**: 2026-08-26
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -40,7 +40,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json`, `.gemini/agents/*.md` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-08-21 | GM, GM-AG |
+| gemini cli | `GEMINI.md`, `.gemini/settings.json`, `.geminiignore`, `gemini-extension.json`, `.gemini/agents/*.md` | https://github.com/google-gemini/gemini-cli | Automated (tool-release-watch.yml) | As reported | 2026-08-26 | GM, GM-AG |
 
 ### D Tier (no support, nice to have)
 


### PR DESCRIPTION
## Summary

- advance the Gemini CLI release baseline from v0.56.0 to v0.57.0
- record the live release review in Research Tracking and the changelog
- keep existing Gemini rules unchanged because the release changes runtime behavior rather than validated configuration contracts

## Verification

- `UPDATE_BASELINES=true scripts/check-tool-releases.sh` (`ok=12 new=0 skipped=0`)
- `node scripts/sync-rule-bookkeeping.js --check`
- `cargo test -p agnix-core gemini --lib`
- `cargo fmt --all -- --check`
- `cmp -s CLAUDE.md AGENTS.md`
- `git diff --check`

Closes #1424