### PR TITLE
feat(pypi): publish agnix wheels to PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,14 @@ jobs:
 
       - name: Release install path tests
         if: matrix.os == 'ubuntu-latest'
-        # Covers the glibc floor gate the release build runs and the npm
-        # installer's static-build fallback. Neither ships inside the Rust
-        # workspace, so nothing else exercises them (see #1371).
+        # Covers the glibc floor gate the release build runs, the npm
+        # installer's static-build fallback, and the PyPI wheel builder. None of
+        # them ship inside the Rust workspace, so nothing else exercises them
+        # (see #1371).
         run: |
           bash scripts/check-glibc-floor.test.sh
           node npm/test/install-helpers.test.js
+          python3 -m unittest discover -s pypi/test
 
       - name: Schema sync check
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -445,6 +445,73 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  pypi:
+    name: Publish PyPI Wheels
+    needs: release
+    runs-on: ubuntu-latest
+    # Skip prereleases
+    if: ${{ !contains(github.ref, '-') }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.x'
+
+      - name: Sync all versions from tag
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          bash scripts/sync-versions.sh "${TAG_VERSION}"
+
+      # The wheels repack the archives this release already built, verified
+      # against their .sha256 sidecars, instead of compiling the same Rust a
+      # sixth time.
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Build wheels
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          python3 pypi/build_wheels.py \
+            --artifacts artifacts \
+            --out pypi/dist \
+            --version "${TAG_VERSION}"
+
+      # Installs the wheel this job is about to upload and runs it, so a wheel
+      # with a broken layout, a stripped exec bit, or the wrong binary fails the
+      # release instead of reaching users.
+      - name: Verify the Linux wheel installs and runs
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          WHEEL=$(ls pypi/dist/agnix-"${TAG_VERSION}"-py3-none-manylinux*_x86_64.whl)
+          python3 -m venv /tmp/wheel-check
+          /tmp/wheel-check/bin/pip install --quiet "$WHEEL"
+          REPORTED=$(/tmp/wheel-check/bin/agnix --version)
+          echo "wheel reports: ${REPORTED}"
+          if [ "$REPORTED" != "agnix ${TAG_VERSION}" ]; then
+            echo "Error: expected 'agnix ${TAG_VERSION}'"
+            exit 1
+          fi
+          /tmp/wheel-check/bin/python -m agnix --version
+
+      - name: Publish to PyPI
+        run: |
+          set -euo pipefail
+          python3 -m pip install --quiet --upgrade twine
+          python3 -m twine check pypi/dist/*.whl
+          # --skip-existing keeps a re-run after a partial upload idempotent,
+          # matching the crates.io publish helper.
+          python3 -m twine upload --skip-existing pypi/dist/*.whl
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
   jetbrains:
     name: Publish JetBrains Plugin
     needs: release

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ lcov*.info
 dist/
 *.wasm
 .intellijPlatform/
+__pycache__/
+*.pyc
 
 # Temporary docs
 IMPLEMENTATION-NEXT-STEPS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **PyPI distribution**. `pip install agnix` and `uvx agnix .` now work. The
+  wheels in `pypi/` bundle the release binary for each supported target
+  (manylinux and musllinux x86_64, manylinux aarch64, macOS Apple silicon,
+  Windows x86_64), so there is no Rust toolchain to install and nothing is
+  downloaded after install. `python -m agnix` and a small Python API
+  (`agnix.run`, `agnix.lint`, `agnix.version`) mirror the Node wrapper.
+  `pypi/build_wheels.py` repacks the archives the release already built and
+  verified against their `.sha256` sidecars, deriving each manylinux tag from
+  the binary's own glibc symbol references rather than a hardcoded floor.
 - **JetBrains plugin: WSL execution mode**
   ([#1346](https://github.com/agent-sh/agnix/issues/1346)). IntelliJ on Windows
   can now run `agnix-lsp` from inside a WSL distribution for projects that live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agnix-validated configuration contract.
 
 ### Fixed
+- **Stale rule count in the npm long description**. `npm/README.md` advertised
+  405 rules against a canonical 451, and no automation covered it, so the number
+  had drifted for several releases and was copied into the new PyPI README.
+  Corrected, and both wrapper READMEs are now in `sync-rule-bookkeeping.js`'s
+  `COUNT_FILES` so CI fails on the next drift.
 - **Rust 1.98 clippy compatibility**. Replace a constant-only `format!` call
   that is now rejected by `clippy::useless_format`.
 - **CC-HK-025 Notification matcher compatibility**. Accept the documented

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ npm install -g agnix
 # Homebrew (macOS/Linux)
 brew tap agent-sh/agnix && brew install agnix
 
+# pip (or `uvx agnix .` to run without installing)
+pip install agnix
+
 # Cargo
 cargo install agnix-cli
 ```

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,6 +69,7 @@ cargo deny check advisories
 2. The GitHub Actions release workflow will automatically:
    - Build binaries for Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
    - Create a GitHub Release with the binaries
+   - Publish the crates, the npm package, and the PyPI wheels
    - Publish the VS Code extension (if applicable)
 
 3. Verify the release at https://github.com/agent-sh/agnix/releases
@@ -100,6 +101,7 @@ After the release workflow completes, verify all install targets work. This shou
 | **Cargo** | `cargo install agnix-cli` | `agnix --version` |
 | **Homebrew** | `brew install agnix` | `agnix --version` |
 | **npm** | `npm install -g agnix` | `agnix --version` |
+| **PyPI** | `pip install agnix` | `agnix --version` |
 | **GitHub Release** | Download from releases page | Run binary directly |
 
 ### Editor Extensions to Verify
@@ -114,7 +116,7 @@ After the release workflow completes, verify all install targets work. This shou
 ### Post-release CI (Ideal)
 
 A `post-release.yml` workflow triggered on release publication should:
-1. Install from each distribution channel (cargo, brew, npm)
+1. Install from each distribution channel (cargo, brew, npm, pip)
 2. Run `agnix --version` to verify correct version
 3. Run `agnix` against a small test fixture to verify basic functionality
 4. Verify editor extension marketplace listings are updated

--- a/npm/README.md
+++ b/npm/README.md
@@ -2,7 +2,7 @@
 
 Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.
 
-**405 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
+**451 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
 
 ## Installation
 

--- a/pypi/README.md
+++ b/pypi/README.md
@@ -2,7 +2,7 @@
 
 Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.
 
-**405 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
+**451 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
 
 ## Installation
 
@@ -47,7 +47,7 @@ agnix . --fix
 agnix . --format json
 
 # Target a specific tool
-agnix . --target ClaudeCode
+agnix . --target claude-code
 ```
 
 `python -m agnix` works the same way as the `agnix` script.
@@ -61,7 +61,7 @@ import agnix
 print(agnix.version())
 
 # Lint a path and get parsed diagnostics
-report = agnix.lint(".", tool="ClaudeCode")
+report = agnix.lint(".", tool="claude-code")
 print(report["summary"])
 
 # Anything else: pass arguments straight through

--- a/pypi/README.md
+++ b/pypi/README.md
@@ -1,0 +1,81 @@
+# agnix
+
+Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.
+
+**405 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
+
+## Installation
+
+```bash
+pip install agnix
+```
+
+Or run it without installing:
+
+```bash
+uvx agnix .
+```
+
+The wheels bundle a prebuilt binary, so there is no Rust toolchain to install
+and nothing is downloaded after `pip install`. Supported platforms:
+
+| Platform | Wheel |
+|----------|-------|
+| Linux x86_64 (glibc) | `manylinux_*_x86_64` |
+| Linux x86_64 (musl, e.g. Alpine) | `musllinux_1_2_x86_64` |
+| Linux aarch64 (glibc) | `manylinux_*_aarch64` |
+| macOS Apple silicon | `macosx_11_0_arm64` |
+| Windows x86_64 | `win_amd64` |
+
+On any other platform, install from source with `cargo install agnix-cli`.
+
+## Usage
+
+### Command line
+
+```bash
+# Lint current directory
+agnix .
+
+# Lint specific file
+agnix CLAUDE.md
+
+# Auto-fix issues
+agnix . --fix
+
+# JSON output
+agnix . --format json
+
+# Target a specific tool
+agnix . --target ClaudeCode
+```
+
+`python -m agnix` works the same way as the `agnix` script.
+
+### Python API
+
+```python
+import agnix
+
+# Version reported by the bundled binary
+print(agnix.version())
+
+# Lint a path and get parsed diagnostics
+report = agnix.lint(".", tool="ClaudeCode")
+print(report["summary"])
+
+# Anything else: pass arguments straight through
+result = agnix.run(["--fix", "CLAUDE.md"])
+print(result.returncode, result.stdout)
+```
+
+## Links
+
+- [Documentation](https://agent-sh.github.io/agnix/)
+- [Repository](https://github.com/agent-sh/agnix)
+- [Issues](https://github.com/agent-sh/agnix/issues)
+- [Changelog](https://github.com/agent-sh/agnix/blob/main/CHANGELOG.md)
+
+## License
+
+MIT OR Apache-2.0

--- a/pypi/agnix/__init__.py
+++ b/pypi/agnix/__init__.py
@@ -15,7 +15,12 @@ from typing import Any, Mapping, Sequence
 
 __version__ = "0.50.0"
 
-__all__ = ["binary_path", "lint", "run", "version", "__version__"]
+__all__ = ["AgnixError", "binary_path", "lint", "run", "version", "__version__"]
+
+
+class AgnixError(RuntimeError):
+    """agnix ran but did not produce the output the caller asked for."""
+
 
 _BINARY_NAME = "agnix" + (sysconfig.get_config_var("EXE") or "")
 
@@ -78,9 +83,13 @@ def lint(
 ) -> Mapping[str, Any]:
     """Lint a file or directory and return the parsed diagnostics.
 
-    `tool` selects the agent target (ClaudeCode, Cursor, ...). A non-JSON
-    `fmt` is returned under a "raw" key, matching the Node API's behaviour on
-    output it cannot parse.
+    `tool` selects the agent target, using the same values as `--target`:
+    `generic`, `claude-code`, `cursor`, `codex`, `kiro`. A format other than
+    `json` is returned unparsed under a "raw" key.
+
+    Raises `AgnixError` if agnix produced no parseable JSON, which is what a
+    rejected argument looks like. Returning an empty report there would read as
+    a clean lint.
     """
     args = ["--format", fmt]
     if tool:
@@ -88,14 +97,17 @@ def lint(
     args.append(target)
 
     result = run(args)
+
+    if fmt != "json":
+        return {"raw": result.stdout}
+
     try:
         return json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return {
-            "files": [],
-            "summary": {"errors": 0, "warnings": 0, "fixable": 0},
-            "raw": result.stdout,
-        }
+    except json.JSONDecodeError as error:
+        raise AgnixError(
+            f"agnix exited {result.returncode} without JSON output"
+            f"{': ' + result.stderr.strip() if result.stderr else ''}"
+        ) from error
 
 
 def version() -> str:

--- a/pypi/agnix/__init__.py
+++ b/pypi/agnix/__init__.py
@@ -1,0 +1,103 @@
+"""agnix - Python API.
+
+Programmatic access to the agnix linter. Mirrors the Node API in npm/index.js.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+__version__ = "0.50.0"
+
+__all__ = ["binary_path", "lint", "run", "version", "__version__"]
+
+_BINARY_NAME = "agnix" + (sysconfig.get_config_var("EXE") or "")
+
+
+def binary_path() -> Path:
+    """Absolute path of the agnix binary installed with this package.
+
+    The wheels ship the binary in the `.data/scripts` directory, which is the
+    only place a wheel can put an executable and keep its exec bit, so it lands
+    in the environment's `bin`/`Scripts` next to the interpreter rather than
+    inside the package.
+    """
+    candidates = [Path(sysconfig.get_path("scripts")) / _BINARY_NAME]
+
+    # pip install --user puts scripts under the user scheme instead.
+    if sys.version_info >= (3, 10):
+        user_scheme = sysconfig.get_preferred_scheme("user")
+    elif sys.platform == "win32":
+        user_scheme = "nt_user"
+    elif sys.platform == "darwin" and sys._framework:
+        user_scheme = "osx_framework_user"
+    else:
+        user_scheme = "posix_user"
+    candidates.append(Path(sysconfig.get_path("scripts", scheme=user_scheme)) / _BINARY_NAME)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    # Last resort: whatever agnix is on PATH, which covers layouts this
+    # package cannot predict (relocated venvs, zipapps, distro repackaging).
+    on_path = shutil.which(_BINARY_NAME)
+    if on_path:
+        return Path(on_path)
+
+    raise FileNotFoundError(
+        f"Could not find the {_BINARY_NAME} binary. Try reinstalling:\n"
+        "  pip install --force-reinstall agnix"
+    )
+
+
+def run(
+    args: Sequence[str] = (),
+    **kwargs: Any,
+) -> subprocess.CompletedProcess:
+    """Run agnix and return the completed process.
+
+    Extra keyword arguments are passed through to `subprocess.run`. Output is
+    captured as text unless the caller overrides `capture_output`/`text`.
+    """
+    kwargs.setdefault("capture_output", True)
+    kwargs.setdefault("text", True)
+    return subprocess.run([str(binary_path()), *args], **kwargs)  # noqa: S603
+
+
+def lint(
+    target: str,
+    tool: str | None = None,
+    fmt: str = "json",
+) -> Mapping[str, Any]:
+    """Lint a file or directory and return the parsed diagnostics.
+
+    `tool` selects the agent target (ClaudeCode, Cursor, ...). A non-JSON
+    `fmt` is returned under a "raw" key, matching the Node API's behaviour on
+    output it cannot parse.
+    """
+    args = ["--format", fmt]
+    if tool:
+        args += ["--target", tool]
+    args.append(target)
+
+    result = run(args)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {
+            "files": [],
+            "summary": {"errors": 0, "warnings": 0, "fixable": 0},
+            "raw": result.stdout,
+        }
+
+
+def version() -> str:
+    """Version string reported by the binary itself."""
+    return run(["--version"]).stdout.strip()

--- a/pypi/agnix/__main__.py
+++ b/pypi/agnix/__main__.py
@@ -1,0 +1,36 @@
+"""`python -m agnix`: hand the process over to the agnix binary.
+
+`pip install agnix` already puts the binary itself on PATH as `agnix`; this
+module is the importable path to the same thing.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from . import binary_path
+
+
+def main() -> None:
+    try:
+        binary = binary_path()
+    except FileNotFoundError as error:
+        print(error, file=sys.stderr)
+        print("Or build from source with:\n  cargo install agnix-cli", file=sys.stderr)
+        raise SystemExit(1) from None
+
+    argv = [str(binary), *sys.argv[1:]]
+
+    # execv replaces this process so signals, exit codes, and terminal
+    # behaviour are the binary's own. Windows has no execv that keeps the
+    # parent's console attached to the child, so it gets a subprocess.
+    if sys.platform == "win32":
+        raise SystemExit(subprocess.call(argv))  # noqa: S603
+
+    os.execv(str(binary), argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/pypi/build_wheels.py
+++ b/pypi/build_wheels.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Build platform-specific agnix wheels from the release archives.
+
+The wheels are repacks, not source builds: release.yml already cross-builds
+`agnix` for every supported target, checksums each archive, and attests it.
+This script takes those archives and wraps each binary in a wheel whose
+platform tag matches the target, so `pip install agnix` and `uvx agnix` get a
+prebuilt binary with no Rust toolchain and no post-install download.
+
+Usage:
+    python3 pypi/build_wheels.py --artifacts artifacts --out pypi/dist
+    python3 pypi/build_wheels.py --artifacts artifacts --version 0.49.0
+
+Every archive named in TARGETS must be present unless --allow-missing is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import csv
+import hashlib
+import io
+import re
+import shutil
+import stat
+import sys
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    print("build_wheels.py needs Python 3.11+ for tomllib", file=sys.stderr)
+    raise SystemExit(2) from None
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPI_DIR = REPO_ROOT / "pypi"
+
+# Wheels are pure-Python plus a binary: no CPython ABI is linked, so the
+# interpreter tag stays py3 and only the platform tag varies.
+PYTHON_TAG = "py3"
+ABI_TAG = "none"
+GENERATOR = "agnix build_wheels.py"
+
+# Zip entries get a fixed timestamp so rebuilding the same release produces
+# byte-identical wheels.
+ZIP_DATE_TIME = (1980, 1, 1, 0, 0, 0)
+
+LICENSE_FILES = ("LICENSE-MIT", "LICENSE-APACHE")
+
+
+@dataclass(frozen=True)
+class Target:
+    """One release target and the wheel it turns into."""
+
+    triple: str
+    archive: str
+    binary: str
+    # Platform tag, or None when it has to be derived from the binary.
+    platform_tag: str | None = None
+
+
+TARGETS = (
+    Target("x86_64-unknown-linux-gnu", "agnix-x86_64-unknown-linux-gnu.tar.gz", "agnix"),
+    Target("aarch64-unknown-linux-gnu", "agnix-aarch64-unknown-linux-gnu.tar.gz", "agnix"),
+    Target(
+        "x86_64-unknown-linux-musl",
+        "agnix-x86_64-unknown-linux-musl.tar.gz",
+        "agnix",
+        # musl builds are static, so the only floor is musl's own ABI version.
+        "musllinux_1_2_x86_64",
+    ),
+    Target(
+        "aarch64-apple-darwin",
+        "agnix-aarch64-apple-darwin.tar.gz",
+        "agnix",
+        # Apple silicon starts at macOS 11.
+        "macosx_11_0_arm64",
+    ),
+    Target(
+        "x86_64-pc-windows-msvc",
+        "agnix-x86_64-pc-windows-msvc.zip",
+        "agnix.exe",
+        "win_amd64",
+    ),
+)
+
+GNU_ARCH_TAGS = {
+    "x86_64-unknown-linux-gnu": "x86_64",
+    "aarch64-unknown-linux-gnu": "aarch64",
+}
+
+GLIBC_REF = re.compile(rb"GLIBC_2\.(\d{1,3})\b")
+
+
+def glibc_platform_tags(binary: Path, arch: str) -> list[str]:
+    """Platform tags for a glibc-linked binary, from its own version refs.
+
+    The floor is read off the binary instead of hardcoded so a toolchain or
+    cross-image bump cannot silently ship a wheel that claims wider
+    compatibility than the binary has. `manylinux_2_17` also gets the legacy
+    `manylinux2014` alias, which older pip versions are the only ones to match.
+    """
+    minors = {int(match.group(1)) for match in GLIBC_REF.finditer(binary.read_bytes())}
+    if not minors:
+        raise ValueError(
+            f"{binary} has no GLIBC_2.x version references; "
+            "it is not a glibc build and needs an explicit platform tag"
+        )
+
+    # PEP 600: manylinux_${GLIBCMAJOR}_${GLIBCMINOR} means "needs at most this
+    # glibc", so the tag has to be the highest symbol version referenced.
+    minor = max(minors)
+    tags = [f"manylinux_2_{minor}_{arch}"]
+    if minor <= 17:
+        tags.append(f"manylinux2014_{arch}")
+    return tags
+
+
+def read_metadata(pyproject: Path) -> dict:
+    with pyproject.open("rb") as handle:
+        return tomllib.load(handle)["project"]
+
+
+def urlsafe_b64_nopad(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def record_hash(data: bytes) -> str:
+    return f"sha256={urlsafe_b64_nopad(hashlib.sha256(data).digest())}"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_sha256_sidecar(contents: str, expected_name: str) -> str:
+    """Read the hash for `expected_name` out of a shasum-style sidecar.
+
+    Mirrors npm/install.js so both wrappers reject a tampered archive the same
+    way.
+    """
+    for line in contents.splitlines():
+        parts = line.strip().split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        raw_hash, raw_name = parts
+        name = raw_name.lstrip("*").replace("\\", "/").rsplit("/", 1)[-1]
+        if name != expected_name:
+            continue
+        expected = raw_hash.lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", expected):
+            raise ValueError(f"Invalid checksum entry for {expected_name}")
+        return expected
+    raise ValueError(f"Checksum file has no entry for {expected_name}")
+
+
+def verify_archive(archive: Path) -> None:
+    """Verify an archive against its `.sha256` sidecar when one is present."""
+    sidecar = archive.with_name(archive.name + ".sha256")
+    if not sidecar.is_file():
+        print(f"  no .sha256 sidecar for {archive.name}, skipping verification")
+        return
+
+    expected = parse_sha256_sidecar(sidecar.read_text(encoding="utf-8"), archive.name)
+    actual = sha256_file(archive)
+    if actual != expected:
+        raise ValueError(
+            f"Checksum mismatch for {archive.name}: expected {expected}, got {actual}"
+        )
+    print(f"  checksum verified: {archive.name}")
+
+
+def extract_binary(archive: Path, member: str, dest_dir: Path) -> Path:
+    """Extract one named binary out of a release archive."""
+    dest = dest_dir / member
+
+    if archive.name.endswith(".zip"):
+        with zipfile.ZipFile(archive) as zf:
+            with zf.open(member) as src, dest.open("wb") as out:
+                shutil.copyfileobj(src, out)
+    else:
+        with tarfile.open(archive, "r:gz") as tf:
+            extracted = tf.extractfile(member)
+            if extracted is None:
+                raise ValueError(f"{archive.name} has no regular file entry {member}")
+            with extracted as src, dest.open("wb") as out:
+                shutil.copyfileobj(src, out)
+
+    dest.chmod(0o755)
+    return dest
+
+
+def metadata_document(meta: dict, long_description: str) -> str:
+    """RFC 822 METADATA per the core metadata spec (version 2.4)."""
+    lines = [
+        "Metadata-Version: 2.4",
+        f"Name: {meta['name']}",
+        f"Version: {meta['version']}",
+        f"Summary: {meta['description']}",
+        f"Requires-Python: {meta['requires-python']}",
+        f"License-Expression: {meta['license']}",
+    ]
+    for author in meta.get("authors", []):
+        lines.append(f"Author: {author['name']}")
+        if author.get("email"):
+            lines.append(f"Author-email: {author['name']} <{author['email']}>")
+    for license_file in LICENSE_FILES:
+        lines.append(f"License-File: {license_file}")
+    if meta.get("keywords"):
+        lines.append(f"Keywords: {','.join(meta['keywords'])}")
+    for classifier in meta.get("classifiers", []):
+        lines.append(f"Classifier: {classifier}")
+    for label, url in meta.get("urls", {}).items():
+        lines.append(f"Project-URL: {label}, {url}")
+    lines.append("Description-Content-Type: text/markdown")
+    lines.append("")
+    lines.append(long_description)
+    return "\n".join(lines)
+
+
+def wheel_document(tags: list[str]) -> str:
+    lines = [
+        "Wheel-Version: 1.0",
+        f"Generator: {GENERATOR}",
+        # A binary in platlib, so not purelib.
+        "Root-Is-Purelib: false",
+    ]
+    lines += [f"Tag: {PYTHON_TAG}-{ABI_TAG}-{tag}" for tag in tags]
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_wheel(
+    meta: dict,
+    target: Target,
+    binary: Path,
+    tags: list[str],
+    out_dir: Path,
+) -> Path:
+    name = meta["name"]
+    version = meta["version"]
+    dist_info = f"{name}-{version}.dist-info"
+    data_scripts = f"{name}-{version}.data/scripts"
+    tag_segment = ".".join(tags)
+    wheel_path = out_dir / f"{name}-{version}-{PYTHON_TAG}-{ABI_TAG}-{tag_segment}.whl"
+
+    # (archive path, bytes, executable) - collected first so RECORD covers
+    # exactly what is written.
+    entries: list[tuple[str, bytes, bool]] = []
+    for source in sorted((PYPI_DIR / name).glob("*.py")):
+        entries.append((f"{name}/{source.name}", source.read_bytes(), False))
+
+    # The binary goes in the data scripts directory, not inside the package:
+    # installers only carry the exec bit over for members under .data/scripts,
+    # and this is what puts `agnix` itself on PATH.
+    entries.append((f"{data_scripts}/{target.binary}", binary.read_bytes(), True))
+
+    long_description = (PYPI_DIR / "README.md").read_text(encoding="utf-8")
+    entries.append(
+        (
+            f"{dist_info}/METADATA",
+            metadata_document(meta, long_description).encode("utf-8"),
+            False,
+        )
+    )
+    entries.append((f"{dist_info}/WHEEL", wheel_document(tags).encode("utf-8"), False))
+    for license_file in LICENSE_FILES:
+        entries.append(
+            (
+                f"{dist_info}/licenses/{license_file}",
+                (REPO_ROOT / license_file).read_bytes(),
+                False,
+            )
+        )
+
+    record = io.StringIO(newline="")
+    writer = csv.writer(record, lineterminator="\n")
+    for arcname, data, _ in entries:
+        writer.writerow([arcname, record_hash(data), len(data)])
+    writer.writerow([f"{dist_info}/RECORD", "", ""])
+    entries.append((f"{dist_info}/RECORD", record.getvalue().encode("utf-8"), False))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(wheel_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for arcname, data, executable in entries:
+            info = zipfile.ZipInfo(arcname, date_time=ZIP_DATE_TIME)
+            # create_system 3 (Unix) plus a full st_mode, S_IFREG included:
+            # pip only carries the exec bit over for entries whose mode passes
+            # S_ISREG, so permission bits alone leave the binary unrunnable.
+            info.create_system = 3
+            mode = stat.S_IFREG | (0o755 if executable else 0o644)
+            info.external_attr = mode << 16
+            info.compress_type = zipfile.ZIP_DEFLATED
+            zf.writestr(info, data)
+
+    return wheel_path
+
+
+def platform_tags_for(target: Target, binary: Path) -> list[str]:
+    if target.platform_tag:
+        return [target.platform_tag]
+    return glibc_platform_tags(binary, GNU_ARCH_TAGS[target.triple])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifacts",
+        type=Path,
+        required=True,
+        help="directory holding the release archives and their .sha256 sidecars",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=PYPI_DIR / "dist",
+        help="directory to write wheels into (default: pypi/dist)",
+    )
+    parser.add_argument(
+        "--version",
+        help="fail unless pypi/pyproject.toml declares this version",
+    )
+    parser.add_argument(
+        "--allow-missing",
+        action="store_true",
+        help="skip targets whose archive is absent instead of failing",
+    )
+    args = parser.parse_args(argv)
+
+    meta = read_metadata(PYPI_DIR / "pyproject.toml")
+    if args.version and args.version != meta["version"]:
+        print(
+            f"Error: pypi/pyproject.toml is at {meta['version']}, expected {args.version}. "
+            "Run scripts/sync-versions.sh.",
+            file=sys.stderr,
+        )
+        return 1
+
+    built: list[Path] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        for target in TARGETS:
+            archive = args.artifacts / target.archive
+            print(f"{target.triple}:")
+            if not archive.is_file():
+                if args.allow_missing:
+                    print(f"  {target.archive} missing, skipped")
+                    continue
+                print(f"  Error: {archive} not found", file=sys.stderr)
+                return 1
+
+            verify_archive(archive)
+            work = Path(tmp) / target.triple
+            work.mkdir()
+            binary = extract_binary(archive, target.binary, work)
+            tags = platform_tags_for(target, binary)
+            wheel = build_wheel(meta, target, binary, tags, args.out)
+            built.append(wheel)
+            print(f"  {wheel.name}")
+
+    if not built:
+        print("Error: no wheels built", file=sys.stderr)
+        return 1
+
+    print(f"\n{len(built)} wheel(s) in {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "agnix"
+version = "0.50.0"
+description = "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more."
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT OR Apache-2.0"
+license-files = ["LICENSE-MIT", "LICENSE-APACHE"]
+authors = [{ name = "Avi Fenesh", email = "avifenesh@gmail.com" }]
+keywords = [
+    "agent",
+    "linter",
+    "claude",
+    "claude-code",
+    "mcp",
+    "model-context-protocol",
+    "skills",
+    "validation",
+    "cursor",
+    "copilot",
+    "codex",
+    "ai",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Rust",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Testing",
+]
+
+[project.urls]
+Homepage = "https://github.com/agent-sh/agnix"
+Repository = "https://github.com/agent-sh/agnix"
+Issues = "https://github.com/agent-sh/agnix/issues"
+Changelog = "https://github.com/agent-sh/agnix/blob/main/CHANGELOG.md"
+
+# No [project.scripts]: the wheels ship the Rust binary itself as the `agnix`
+# entry in the environment's scripts directory, so a console_scripts shim of the
+# same name would collide with it. `python -m agnix` reaches the same binary.
+
+# No [build-system]: the wheels are not produced by a PEP 517 backend.
+# `build_wheels.py` repacks the release binaries that release.yml already built,
+# verified against their .sha256 sidecars and attested. Building from source here
+# would compile the same Rust five more times and drop the attestation chain.
+# This file is the single source of truth for the metadata the builder writes.

--- a/pypi/test/test_api.py
+++ b/pypi/test/test_api.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for the agnix Python API.
+
+These exercise argument handling and output parsing with a stubbed subprocess,
+so they run without the binary the wheels bundle.
+
+Run with:
+    python3 -m unittest discover -s pypi/test
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import agnix  # noqa: E402
+
+
+def completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["agnix"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class LintTests(unittest.TestCase):
+    def test_parses_json_report(self):
+        report = '{"files": [], "summary": {"errors": 1, "warnings": 0}}'
+        with mock.patch.object(agnix, "run", return_value=completed(report)) as run:
+            result = agnix.lint(".", tool="claude-code")
+
+        self.assertEqual(result["summary"]["errors"], 1)
+        # --target takes the CLI's kebab-case values; clap rejects anything else.
+        self.assertEqual(
+            run.call_args.args[0],
+            ["--format", "json", "--target", "claude-code", "."],
+        )
+
+    def test_omits_target_when_no_tool_given(self):
+        with mock.patch.object(agnix, "run", return_value=completed("{}")) as run:
+            agnix.lint("CLAUDE.md")
+
+        self.assertEqual(run.call_args.args[0], ["--format", "json", "CLAUDE.md"])
+
+    def test_non_json_output_raises_instead_of_reporting_clean(self):
+        # A rejected argument exits non-zero with an empty stdout. Returning an
+        # empty report here would read as "no issues found".
+        rejected = completed(
+            stderr="error: invalid value 'ClaudeCode' for '--target <TARGET>'",
+            returncode=2,
+        )
+        with mock.patch.object(agnix, "run", return_value=rejected):
+            with self.assertRaises(agnix.AgnixError) as caught:
+                agnix.lint(".", tool="ClaudeCode")
+
+        message = str(caught.exception)
+        self.assertIn("exited 2", message)
+        self.assertIn("invalid value 'ClaudeCode'", message)
+
+    def test_non_json_format_is_returned_raw(self):
+        with mock.patch.object(agnix, "run", return_value=completed("2 issues\n")):
+            result = agnix.lint(".", fmt="sarif")
+
+        self.assertEqual(result, {"raw": "2 issues\n"})
+
+
+class VersionTests(unittest.TestCase):
+    def test_version_strips_whitespace(self):
+        with mock.patch.object(agnix, "run", return_value=completed("agnix 1.2.3\n")):
+            self.assertEqual(agnix.version(), "agnix 1.2.3")
+
+    def test_module_version_matches_pyproject(self):
+        pyproject = (Path(agnix.__file__).resolve().parent.parent / "pyproject.toml").read_text()
+        self.assertIn(f'version = "{agnix.__version__}"', pyproject)
+
+
+class BinaryPathTests(unittest.TestCase):
+    def test_prefers_the_scripts_directory(self):
+        with mock.patch.object(agnix.sysconfig, "get_path", return_value="/venv/bin"):
+            with mock.patch.object(Path, "is_file", return_value=True):
+                self.assertEqual(agnix.binary_path(), Path("/venv/bin") / agnix._BINARY_NAME)
+
+    def test_falls_back_to_path_lookup(self):
+        with mock.patch.object(agnix.sysconfig, "get_path", return_value="/venv/bin"):
+            with mock.patch.object(Path, "is_file", return_value=False):
+                with mock.patch.object(agnix.shutil, "which", return_value="/usr/bin/agnix"):
+                    self.assertEqual(agnix.binary_path(), Path("/usr/bin/agnix"))
+
+    def test_raises_when_nothing_is_found(self):
+        with mock.patch.object(agnix.sysconfig, "get_path", return_value="/venv/bin"):
+            with mock.patch.object(Path, "is_file", return_value=False):
+                with mock.patch.object(agnix.shutil, "which", return_value=None):
+                    with self.assertRaises(FileNotFoundError):
+                        agnix.binary_path()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pypi/test/test_api.py
+++ b/pypi/test/test_api.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import subprocess
 import sys
 import unittest
+import unittest.mock as mock
 from pathlib import Path
-from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 

--- a/pypi/test/test_build_wheels.py
+++ b/pypi/test/test_build_wheels.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Tests for the PyPI wheel builder.
+
+Run with:
+    python3 -m unittest discover -s pypi/test
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import stat
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import build_wheels as bw  # noqa: E402
+
+
+def fake_glibc_binary(minors: tuple[int, ...]) -> bytes:
+    refs = b"".join(b"GLIBC_2.%d\x00" % minor for minor in minors)
+    return b"\x7fELF" + refs + b"payload"
+
+
+class PlatformTagTests(unittest.TestCase):
+    def test_highest_glibc_reference_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "agnix"
+            binary.write_bytes(fake_glibc_binary((2, 17, 4, 14)))
+            # Highest referenced symbol is the floor: a binary needing 2.17
+            # must not claim to run on 2.4.
+            self.assertEqual(
+                bw.glibc_platform_tags(binary, "x86_64"),
+                ["manylinux_2_17_x86_64", "manylinux2014_x86_64"],
+            )
+
+    def test_newer_glibc_gets_no_legacy_alias(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "agnix"
+            binary.write_bytes(fake_glibc_binary((28, 31)))
+            self.assertEqual(
+                bw.glibc_platform_tags(binary, "aarch64"), ["manylinux_2_31_aarch64"]
+            )
+
+    def test_binary_without_glibc_refs_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            binary = Path(tmp) / "agnix"
+            binary.write_bytes(b"\x7fELFstatic")
+            with self.assertRaises(ValueError):
+                bw.glibc_platform_tags(binary, "x86_64")
+
+    def test_explicit_tags_bypass_detection(self):
+        musl = next(t for t in bw.TARGETS if t.triple == "x86_64-unknown-linux-musl")
+        self.assertEqual(
+            bw.platform_tags_for(musl, Path("/nonexistent")), ["musllinux_1_2_x86_64"]
+        )
+
+
+class SidecarTests(unittest.TestCase):
+    digest = "a" * 64
+
+    def test_matches_entry_by_basename(self):
+        contents = f"{'b' * 64}  other.tar.gz\n{self.digest}  ./dist/agnix.tar.gz\n"
+        self.assertEqual(
+            bw.parse_sha256_sidecar(contents, "agnix.tar.gz"), self.digest
+        )
+
+    def test_accepts_binary_mode_asterisk(self):
+        self.assertEqual(
+            bw.parse_sha256_sidecar(f"{self.digest} *agnix.zip\n", "agnix.zip"),
+            self.digest,
+        )
+
+    def test_missing_entry_raises(self):
+        with self.assertRaises(ValueError):
+            bw.parse_sha256_sidecar(f"{self.digest}  other.zip\n", "agnix.zip")
+
+    def test_malformed_hash_raises(self):
+        with self.assertRaises(ValueError):
+            bw.parse_sha256_sidecar("nothex  agnix.zip\n", "agnix.zip")
+
+
+class ExtractTests(unittest.TestCase):
+    def test_extracts_from_tar_gz_and_marks_executable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "agnix.tar.gz"
+            payload = tmp_path / "agnix"
+            payload.write_bytes(b"binary")
+            with tarfile.open(archive, "w:gz") as tf:
+                tf.add(payload, arcname="agnix")
+
+            dest = tmp_path / "out"
+            dest.mkdir()
+            extracted = bw.extract_binary(archive, "agnix", dest)
+            self.assertEqual(extracted.read_bytes(), b"binary")
+            self.assertTrue(extracted.stat().st_mode & 0o111)
+
+    def test_extracts_from_zip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "agnix.zip"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("agnix.exe", b"windows binary")
+
+            dest = tmp_path / "out"
+            dest.mkdir()
+            extracted = bw.extract_binary(archive, "agnix.exe", dest)
+            self.assertEqual(extracted.read_bytes(), b"windows binary")
+
+
+class WheelTests(unittest.TestCase):
+    def setUp(self):
+        self.meta = bw.read_metadata(bw.PYPI_DIR / "pyproject.toml")
+
+    def build(self, target: bw.Target, tags: list[str], out_dir: Path) -> Path:
+        binary = out_dir / "binary"
+        binary.write_bytes(b"fake agnix binary")
+        return bw.build_wheel(self.meta, target, binary, tags, out_dir / "dist")
+
+    def test_wheel_layout_and_record(self):
+        target = next(t for t in bw.TARGETS if t.triple == "x86_64-unknown-linux-gnu")
+        with tempfile.TemporaryDirectory() as tmp:
+            wheel = self.build(target, ["manylinux_2_17_x86_64"], Path(tmp))
+            version = self.meta["version"]
+            self.assertEqual(
+                wheel.name, f"agnix-{version}-py3-none-manylinux_2_17_x86_64.whl"
+            )
+
+            with zipfile.ZipFile(wheel) as zf:
+                names = set(zf.namelist())
+                dist_info = f"agnix-{version}.dist-info"
+                data_scripts = f"agnix-{version}.data/scripts"
+                self.assertIn("agnix/__init__.py", names)
+                self.assertIn("agnix/__main__.py", names)
+                # The binary must live under .data/scripts: installers drop the
+                # exec bit anywhere else, which leaves `agnix` unrunnable.
+                self.assertIn(f"{data_scripts}/agnix", names)
+                self.assertNotIn("agnix/agnix", names)
+                self.assertIn(f"{dist_info}/METADATA", names)
+                self.assertIn(f"{dist_info}/WHEEL", names)
+                self.assertIn(f"{dist_info}/RECORD", names)
+                # A console_scripts shim named agnix would collide with the
+                # binary the wheel installs under the same name.
+                self.assertNotIn(f"{dist_info}/entry_points.txt", names)
+                self.assertIn(f"{dist_info}/licenses/LICENSE-MIT", names)
+                self.assertIn(f"{dist_info}/licenses/LICENSE-APACHE", names)
+
+                # RECORD must cover every archive member exactly once, with
+                # hashes pip can verify.
+                record = zf.read(f"{dist_info}/RECORD").decode("utf-8")
+                rows = list(csv.reader(io.StringIO(record)))
+                recorded = {row[0] for row in rows if row}
+                self.assertEqual(recorded, names)
+                for row in rows:
+                    if not row or row[0] == f"{dist_info}/RECORD":
+                        continue
+                    self.assertEqual(row[1], bw.record_hash(zf.read(row[0])))
+                    self.assertEqual(int(row[2]), len(zf.read(row[0])))
+
+                info = zf.getinfo(f"{data_scripts}/agnix")
+                mode = info.external_attr >> 16
+                # pip's zip_item_is_executable() needs S_ISREG to pass before
+                # it looks at the exec bits at all.
+                self.assertTrue(stat.S_ISREG(mode))
+                self.assertTrue(mode & 0o111)
+                self.assertEqual(info.create_system, 3)
+
+                wheel_meta = zf.read(f"{dist_info}/WHEEL").decode("utf-8")
+                self.assertIn("Root-Is-Purelib: false", wheel_meta)
+                self.assertIn("Tag: py3-none-manylinux_2_17_x86_64", wheel_meta)
+
+                metadata = zf.read(f"{dist_info}/METADATA").decode("utf-8")
+                self.assertIn("Metadata-Version: 2.4", metadata)
+                self.assertIn("Name: agnix", metadata)
+                self.assertIn(f"Version: {version}", metadata)
+                self.assertIn("License-Expression: MIT OR Apache-2.0", metadata)
+                self.assertIn("Description-Content-Type: text/markdown", metadata)
+
+    def test_multiple_tags_join_in_filename(self):
+        target = next(t for t in bw.TARGETS if t.triple == "x86_64-unknown-linux-gnu")
+        with tempfile.TemporaryDirectory() as tmp:
+            wheel = self.build(
+                target, ["manylinux_2_17_x86_64", "manylinux2014_x86_64"], Path(tmp)
+            )
+            self.assertTrue(
+                wheel.name.endswith(
+                    "-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+                ),
+                wheel.name,
+            )
+
+    def test_windows_wheel_bundles_exe(self):
+        target = next(t for t in bw.TARGETS if t.triple == "x86_64-pc-windows-msvc")
+        with tempfile.TemporaryDirectory() as tmp:
+            wheel = self.build(target, ["win_amd64"], Path(tmp))
+            version = self.meta["version"]
+            with zipfile.ZipFile(wheel) as zf:
+                self.assertIn(f"agnix-{version}.data/scripts/agnix.exe", zf.namelist())
+
+    def test_rebuild_is_reproducible(self):
+        target = next(t for t in bw.TARGETS if t.triple == "aarch64-apple-darwin")
+        with tempfile.TemporaryDirectory() as tmp:
+            first = self.build(target, ["macosx_11_0_arm64"], Path(tmp)).read_bytes()
+            second = self.build(target, ["macosx_11_0_arm64"], Path(tmp)).read_bytes()
+            self.assertEqual(first, second)
+
+
+class VersionTests(unittest.TestCase):
+    def test_pyproject_matches_workspace_version(self):
+        cargo = (bw.REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+        section = cargo.split("[workspace.package]", 1)[1]
+        workspace_version = next(
+            line.split('"')[1]
+            for line in section.splitlines()
+            if line.startswith("version = ")
+        )
+        meta = bw.read_metadata(bw.PYPI_DIR / "pyproject.toml")
+        self.assertEqual(meta["version"], workspace_version)
+
+        init = (bw.PYPI_DIR / "agnix" / "__init__.py").read_text(encoding="utf-8")
+        self.assertIn(f'__version__ = "{workspace_version}"', init)
+
+    def test_version_mismatch_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            code = bw.main(
+                ["--artifacts", tmp, "--out", tmp, "--version", "0.0.0-not-real"]
+            )
+            self.assertEqual(code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/sync-rule-bookkeeping.js
+++ b/scripts/sync-rule-bookkeeping.js
@@ -182,6 +182,12 @@ const COUNT_FILES = [
   { path: path.join(ROOT, 'website', 'docs', 'intro.md') },
   { path: path.join(ROOT, 'website', 'docs', 'getting-started.md') },
   { path: path.join(ROOT, 'website', 'docs', 'contributing.md') },
+  // Wrapper READMEs. These ship as the npm and PyPI long descriptions, so
+  // their count phrase is the first number most installers ever read, and
+  // nothing covered them: npm/README.md sat at 405 while the canonical count
+  // was 451, and that stale number was copied straight into pypi/README.md.
+  { path: path.join(ROOT, 'npm', 'README.md') },
+  { path: path.join(ROOT, 'pypi', 'README.md') },
 ];
 
 // Files whose top-level `version` field must track the Cargo.toml

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -60,6 +60,19 @@ if [ -f npm/package.json ]; then
   echo "  npm/package.json -> $VERSION"
 fi
 
+# PyPI wrapper
+if [ -f pypi/pyproject.toml ]; then
+  sed -i.bak "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" pypi/pyproject.toml
+  rm -f pypi/pyproject.toml.bak
+  echo "  pypi/pyproject.toml -> $VERSION"
+fi
+
+if [ -f pypi/agnix/__init__.py ]; then
+  sed -i.bak "s/^__version__ = \"[^\"]*\"/__version__ = \"$VERSION\"/" pypi/agnix/__init__.py
+  rm -f pypi/agnix/__init__.py.bak
+  echo "  pypi/agnix/__init__.py -> $VERSION"
+fi
+
 # JetBrains plugin
 if [ -f editors/jetbrains/gradle.properties ]; then
   sed -i.bak "s/pluginVersion = .*/pluginVersion = $VERSION/" editors/jetbrains/gradle.properties

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: "Install agnix via npm, Homebrew, Cargo, or download pre-built binaries."
+description: "Install agnix via npm, Homebrew, pip, Cargo, or download pre-built binaries."
 ---
 
 # Installation
@@ -23,6 +23,32 @@ npx agnix .
 
 ```bash
 brew tap agent-sh/agnix && brew install agnix
+```
+
+## pip / uv
+
+```bash
+pip install agnix
+```
+
+Or run without installing:
+
+```bash
+uvx agnix .
+```
+
+The wheels bundle a pre-built binary, so no Rust toolchain is needed and nothing
+is downloaded after install. Wheels are published for Linux x86_64 (glibc and
+musl), Linux aarch64, macOS Apple silicon, and Windows x86_64; on any other
+platform, use `cargo install agnix-cli`.
+
+`python -m agnix` runs the same binary, and a small Python API is available:
+
+```python
+import agnix
+
+report = agnix.lint(".", tool="ClaudeCode")
+print(agnix.version(), report["summary"])
 ```
 
 ## Cargo (Rust toolchain)

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -47,7 +47,7 @@ platform, use `cargo install agnix-cli`.
 ```python
 import agnix
 
-report = agnix.lint(".", tool="ClaudeCode")
+report = agnix.lint(".", tool="claude-code")
 print(agnix.version(), report["summary"])
 ```
 


### PR DESCRIPTION
## What

Adds a PyPI distribution: `pip install agnix` and `uvx agnix .` join the npm, Homebrew, and cargo channels.

New `pypi/` directory:

| File | Purpose |
|---|---|
| `pyproject.toml` | Single source of truth for the wheel metadata (no PEP 517 backend - see below) |
| `agnix/__init__.py` | Python API mirroring `npm/index.js`: `run`, `lint`, `version`, `binary_path` |
| `agnix/__main__.py` | `python -m agnix`, execs the binary |
| `build_wheels.py` | Repacks release archives into one platform wheel per target |
| `test/test_build_wheels.py` | Unit tests for the builder |

## Why repack instead of maturin

`release.yml` already cross-builds `agnix` for all five targets, checksums each archive, and attests it. Building through maturin would compile the same Rust a sixth time per platform and drop the attestation chain. `build_wheels.py` verifies each archive against its `.sha256` sidecar - the same check `npm/install.js` does - and wraps the binary as-is.

## Details worth reviewing

- **manylinux tags are derived, not hardcoded.** Each glibc wheel's tag comes from the highest `GLIBC_2.x` symbol the binary actually references (currently 2.18, well under the 2.31 floor `check-glibc-floor.sh` enforces). A toolchain or cross-image bump therefore cannot silently ship a wheel claiming wider compatibility than the binary has. `manylinux_2_17` additionally gets the legacy `manylinux2014` alias.
- **Binary location.** It ships under `agnix-<version>.data/scripts/`, the only wheel location whose executable bit survives installation, and lands as `agnix` on PATH directly. There is deliberately no `console_scripts` entry named `agnix`, which would collide with it. `external_attr` carries a full `st_mode` including `S_IFREG`, because pip's `zip_item_is_executable()` checks `S_ISREG` before it looks at permission bits - permission bits alone install the binary non-executable.
- **Platform coverage.** manylinux + musllinux x86_64, manylinux aarch64, macOS arm64, Windows x86_64. Intel macOS is not covered because no such release binary exists; that platform falls back to `cargo install agnix-cli`, as documented.
- **Wheels are reproducible** (fixed zip timestamps), so rebuilding a release produces byte-identical artifacts.

## Release wiring

New `pypi` job in `release.yml`, `needs: release`, prereleases skipped, mirroring the npm job:

1. Sync versions from the tag
2. Download the release artifacts
3. Build wheels
4. **Install the Linux wheel and assert `agnix --version` equals the tag** before any upload
5. `twine check`, then `twine upload --skip-existing` (idempotent on re-run, matching the crates.io helper)

`scripts/sync-versions.sh` now also syncs `pypi/pyproject.toml` and `pypi/agnix/__init__.py`.

## Blocking on

A `PYPI_API_TOKEN` repository secret. Everything else is in place; the job will fail at the upload step until it is set.

## Verification

Built wheels from the real published v0.49.0 archives and installed one in a clean venv:

- `agnix --version` -> `agnix 0.49.0`
- `python -m agnix --version` -> `agnix 0.49.0`
- `agnix.version()`, `agnix.lint(...)`, `agnix.binary_path()` all work
- `uvx --from <wheel> agnix --version` works
- `twine check` PASSED on both wheels
- 16 builder tests pass; `agnix .` on this tree reports no issues

## Docs

README install block, `website/docs/installation.md` (new pip/uv section), `docs/RELEASING.md` (PyPI row and publish step), CHANGELOG - all in this commit.


Closes #1430.
