### PR TITLE
chore: refresh tool and spec baselines after triage

### DIFF
--- a/.github/spec-baselines.json
+++ b/.github/spec-baselines.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "description": "Baseline hashes for canonical specification content. Human-facing URLs are kept separately from machine-readable content URLs.",
-  "last_updated": "2026-08-23T09:50:05Z",
+  "last_updated": "2026-08-26T22:02:14Z",
   "sources": {
     "s-tier": {
       "agent-skills-spec": {
@@ -128,7 +128,7 @@
       "claude-code-hooks": {
         "url": "https://code.claude.com/docs/en/hooks",
         "content_url": "https://code.claude.com/docs/en/hooks.md",
-        "hash": "bdc60cee2ffcfa0d43763a69629cf28ddf1d14d6e9cdf29fc1ab2af0c708fd8c",
+        "hash": "784c137b0217adf9170cef2999b833f57bc954bf823185ed08f0e2f3cea1ce04",
         "rules": [
           "CC-HK-001",
           "CC-HK-002",
@@ -147,7 +147,7 @@
       "claude-code-skills": {
         "url": "https://code.claude.com/docs/en/skills",
         "content_url": "https://code.claude.com/docs/en/skills.md",
-        "hash": "0da4530a1a1d92d4d635d3a5347198c0b0a8ddaefc4e308dbf2fda9dfce115e7",
+        "hash": "d93942933033f8a222624ce209164d0774a1f990254c12812cdcb259a6906b3c",
         "rules": [
           "CC-SK-001",
           "CC-SK-002",
@@ -160,7 +160,7 @@
       "claude-code-plugins": {
         "url": "https://code.claude.com/docs/en/plugins-reference",
         "content_url": "https://code.claude.com/docs/en/plugins-reference.md",
-        "hash": "b2da869773fe08bbfab2f14c2a82c399ea7a91c03fd04c6dad9fbacb005d97d4",
+        "hash": "8c82f0a782126dee7d6e6cc50e2ee77beb6b043cda556af6cd510b7ed99ff951",
         "rules": [
           "CC-PL-002",
           "CC-PL-003",
@@ -231,7 +231,7 @@
       "cursor-rules": {
         "url": "https://cursor.com/docs/rules",
         "content_url": "https://cursor.com/docs/rules.md",
-        "hash": "c861f9650a843824b496f0a3190ecd9671c121acae623e150b041d0eb9e84d70",
+        "hash": "a2c5c228914798fa3bd014a74c62421663f56c90e89885224e03b617678c0d9a",
         "rules": [
           "CUR-001",
           "CUR-002",
@@ -248,7 +248,7 @@
       "cursor-hooks": {
         "url": "https://cursor.com/docs/hooks",
         "content_url": "https://cursor.com/docs/hooks.md",
-        "hash": "952d09cb40387dcb70944ce73fffa446317b6cb4f107c9bc2a52d236bc887e3b",
+        "hash": "0d3a3ce6900141d4fa7d135d842ec49c2243f5ed4bb5bab8eb359ba8c6a4df78",
         "rules": [
           "CUR-010",
           "CUR-011",
@@ -262,7 +262,7 @@
       "cursor-subagents": {
         "url": "https://cursor.com/docs/subagents",
         "content_url": "https://cursor.com/docs/subagents.md",
-        "hash": "c9c01a48171c3a0bcaa37f9412654395c27fecbd5f50535bfa59363f49c8bd46",
+        "hash": "7da0eafd67c4a33534b6663264bb9a6715983df043ba2826dd74f1d002965e3d",
         "rules": [
           "CUR-014",
           "CUR-015"
@@ -279,7 +279,7 @@
       "cursor-environment-schema": {
         "url": "https://cursor.com/schemas/environment.schema.json",
         "content_url": "https://cursor.com/schemas/environment.schema.json",
-        "hash": "5683735c6227f1316aa141587ba57b4bddde98c54417f1797ff20e7c2f176341",
+        "hash": "688e2055f803efeb567b6d7c4b04f0aac326ed55ba409cdfe6e10275a194018d",
         "rules": [
           "CUR-016"
         ]
@@ -287,7 +287,7 @@
       "cursor-mcp": {
         "url": "https://cursor.com/docs/mcp",
         "content_url": "https://cursor.com/docs/mcp.md",
-        "hash": "0d85294f9c849ef4f69194ca97242599e4d8f1c6bc44b77cfaedcc2bfc56da98",
+        "hash": "b08ca32e6d16cfd8488c01bf2d48760c34e996832eb428c3c56a46254500ab49",
         "rules": [
           "MCP-009",
           "MCP-010",

--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1",
-  "last_updated": "2026-08-26",
+  "last_updated": "2026-08-27",
   "description": "Tracks the latest release of every tool agnix validates (one entry per tool with a validator in crates/agnix-core/src/rules/). Used by .github/workflows/tool-release-watch.yml to open per-tool issues when a new release is published. Untracked tools include the precise publication URL in untracked_reason so a maintainer can monitor manually.\n\nOptional `changes_of_interest` per tool describes what agnix cares about: `config_surfaces` (files agnix validates), `relevant` (change-types that likely affect a validator), `irrelevant` (safe to skip). When set and GLM_API_KEY is available, the watcher runs scripts/glm-extract.js --mode=agnix-triage to produce a pre-filtered summary at the top of the issue body. Falls back gracefully to the full changelog on any LLM failure.",
   "tools": {
     "claude-code": {
@@ -17,7 +17,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.245",
+      "last_known_version": "v2.1.246",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -253,7 +253,7 @@
       "github_repo": null,
       "html_url": "https://api2.cursor.sh/updates/api/update/darwin/cursor/0.0.1/stable",
       "version_regex": "[0-9]+\\.[0-9]+\\.[0-9]+",
-      "last_known_version": "3.17.19",
+      "last_known_version": "3.17.21",
       "tracked": true,
       "notes": "Tracked via Cursor's stable update endpoint (the same one the desktop app polls). Returns JSON like {\"url\":\"...\",\"name\":\"3.1.17\"}. Channel is hardcoded to 'stable' for darwin; the version is platform-agnostic (same release ships across darwin/linux/win32). Prose changelog at https://cursor.com/changelog (Next.js SPA - not scrapeable from raw HTML).",
       "changes_of_interest": {
@@ -324,7 +324,7 @@
       "html_url": "https://ampcode.com/news.rss",
       "version_regex": "https://ampcode\\.com/news/[a-zA-Z0-9._-]+",
       "notes_extractor": "rss_cdata",
-      "last_known_version": "friendly-urls-for-sharing-orbs",
+      "last_known_version": "setup-without-a-commit",
       "tracked": true,
       "notes": "Tracked via the amp news RSS feed; the 'version' is the slug of the latest /news/ post (e.g., amp-free-is-ad-free). Source is not on GitHub; npm @sourcegraph/amp publishes per-commit (no semver gates) so npm version-bump tracking would be noise. Issue body uses the first <item><description> CDATA from the RSS feed (already structured HTML - no LLM needed).",
       "changes_of_interest": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   host-local binary installer. Native launches remain unchanged.
 
 ### Changed
+- **Tool and spec baselines refreshed** (closes
+  [#1426](https://github.com/agent-sh/agnix/issues/1426),
+  [#1427](https://github.com/agent-sh/agnix/issues/1427),
+  [#1428](https://github.com/agent-sh/agnix/issues/1428),
+  [#1429](https://github.com/agent-sh/agnix/issues/1429)). Advanced Claude Code
+  from `v2.1.245` to `v2.1.246`, Cursor from `3.17.19` to `3.17.21`, and amp from
+  `friendly-urls-for-sharing-orbs` to `setup-without-a-commit`, and re-baselined
+  the eight drifted spec sources (Claude Code hooks/skills/plugins-reference;
+  Cursor rules/hooks/subagents/mcp and the environment schema). Reviewing all
+  eight against the rules they back found no contract change that agnix asserts
+  incorrectly: Claude Code's 31 known hook events still cover every event the
+  hooks reference documents, the skill frontmatter allowlist still covers all 20
+  documented fields, the plugin path-bearing keys remain a superset of the
+  documented table, Cursor's hook events (including the still-supported
+  `beforeShellExecution` / `beforeMCPExecution`) and per-script options are
+  unchanged, subagent frontmatter and model-parameter syntax still validate, the
+  environment schema's property set still matches `ALLOWED_ROOT_FIELDS`, and
+  neither MCP nor hook entries reject unknown fields, so newly documented keys
+  cannot produce false positives. Coverage gaps the review surfaced (upstream's
+  new wildcard-permission warning, unvalidated `keybindings.json`, Cursor's
+  now-required MCP `type` and STDIO-only `envFile`) are recorded in
+  RESEARCH-TRACKING. amp's release stores pre-clone and pre-setup scripts in
+  server-side project settings rather than any validated file. Cline
+  (`v4.1.16`) and Codex (`rust-v0.150.0`) published after those issues were
+  opened and are deliberately left at their previous baselines so the watcher
+  files their own triage issues.
 - **Tool release baselines**. Advanced Claude Code from `v2.1.243` to
   `v2.1.245` and OpenCode from `v1.18.22` to `v1.18.23` after reviewing their
   live release notes. Claude Code's change is a Linux glibc 2.44 startup-crash

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -2,7 +2,7 @@
 
 > Master document for tracking AI tool ecosystem changes, research updates, and community feedback.
 
-**Last Updated**: 2026-08-26
+**Last Updated**: 2026-08-27
 **Review Cadence**: Monthly (1st week of each month)
 **Related**: [MONTHLY-REVIEW.md](./MONTHLY-REVIEW.md) | [VALIDATION-RULES.md](./VALIDATION-RULES.md) | [INDEX.md](./INDEX.md)
 
@@ -16,7 +16,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
-| Claude Code | `CLAUDE.md`, `.claude/settings.json`, `.claude/settings.local.json`, `.claude/managed-settings.json`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `.claude/hooks configuration`, `.mcp.json`, `.claude-plugin/plugin.json`, `.claude/rules/**/*.md`, `.claude/output-styles/*.md` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-25 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET, CC-OS, MCP |
+| Claude Code | `CLAUDE.md`, `.claude/settings.json`, `.claude/settings.local.json`, `.claude/managed-settings.json`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `.claude/hooks configuration`, `.mcp.json`, `.claude-plugin/plugin.json`, `.claude/rules/**/*.md`, `.claude/output-styles/*.md` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-27 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET, CC-OS, MCP |
 | Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex/skills/*/SKILL.md`, `.codex-plugin/plugin.json`, Agent Plugins root `plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-25 | AGM, XP, CDX, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ, CX-SK |
 | OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json`, `.opencode/skills/*/SKILL.md` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-25 | AGM, XP, OC, OC-AG, OC-AGM, OC-CFG, OC-DEP, OC-LSP, OC-PM, OC-TUI, OC-SK |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/**/*.{json,md}`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md`, `AGENTS.md` (nested, loaded as steering since 2.18.0) | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-08-21 | AGM, KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
@@ -27,14 +27,14 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Weekly | 2026-07-26 | COP |
 | Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-24 | CLN, CL-SK |
-| Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json`, `.cursor/skills/*/SKILL.md` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-25 | CUR, MCP, CR-SK |
+| Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json`, `.cursor/skills/*/SKILL.md` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-27 | CUR, MCP, CR-SK |
 
 ### B Tier (test on significant changes if time permits)
 
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Roo Code | `.roomodes`, `.rooignore`, `.roorules`, `.roo/rules/*.md`, `.roo/rules-{slug}/*.md`, `.roo/mcp.json` | https://github.com/RooCodeInc/Roo-Code | Automated (tool-release-watch.yml) | Quarterly | 2026-07-26 | ROO |
-| amp | `.amp/settings.json`, `.agents/checks/*.md`, `AGENTS.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-08-24 | AGM, AMP, AMP-SK |
+| amp | `.amp/settings.json`, `.agents/checks/*.md`, `AGENTS.md` | https://ampcode.com/news | Automated (tool-release-watch.yml via ampcode.com/news.rss; tracks latest news-post slug as the release marker) | Quarterly | 2026-08-27 | AGM, AMP, AMP-SK |
 
 ### C Tier (community reports fixes only)
 
@@ -195,6 +195,10 @@ Tracking community input that influences rule development, tool support decision
 |------|--------|----------|--------|
 | 2026-02-05 | Tool inventory audit | B/C/D tier tools lack rule coverage | Awaiting community contributions; issue templates now available |
 | 2026-02-05 | Cross-tool compatibility | Users mixing Cursor + Claude Code + Copilot report silent failures | XP-004/005/006 rules address some cases; more patterns needed |
+| 2026-08-27 | Claude Code v2.1.246 triage | Startup warning added upstream for `permissions` entries with a wildcard before the subcommand (e.g. `Bash(git * main)`), which also match options inserted before it | No agnix rule covers this pattern; candidate CC-SET rule |
+| 2026-08-27 | Claude Code v2.1.246 triage | `keybindings.json` now skips bindings whose action name is unknown and warns under `--debug` | agnix does not validate `keybindings.json` at all; candidate new file type |
+| 2026-08-27 | Cursor MCP doc revision | STDIO table now marks `type` as Required, and documents `envFile` as STDIO-only (remote HTTP/SSE servers do not support it) | agnix infers the transport when `type` is absent and has no rule for `envFile` on a remote server; candidate MCP rules |
+| 2026-08-27 | Cursor hooks doc revision | Per-script options table types `matcher` as `object` while every example in the same document uses a string | Upstream doc inconsistency; CUR-017 deliberately leaves `matcher` unvalidated until it is resolved |
 
 ---
 


### PR DESCRIPTION
Closes #1426, closes #1427, closes #1428, closes #1429.

## What moved

| Baseline | From | To |
|---|---|---|
| Claude Code | `v2.1.245` | `v2.1.246` |
| Cursor | `3.17.19` | `3.17.21` |
| amp | `friendly-urls-for-sharing-orbs` | `setup-without-a-commit` |
| Spec hashes | 8 sources | re-baselined |

The eight drifted sources: Claude Code hooks / skills / plugins-reference, and Cursor rules / hooks / subagents / mcp / environment schema. The three Claude Code sources drifted *after* #1426 was filed - they are the doc side of the same v2.1.246 release #1428 tracks, so all four issues resolve together.

Baselines were regenerated by dispatching the documented workflows with `update_baselines: true` ([tool-release-watch](https://github.com/agent-sh/agnix/actions/runs/33017940968), [spec-drift](https://github.com/agent-sh/agnix/actions/runs/33017942745)); only hashes and `last_updated` changed in `spec-baselines.json`.

## Triage result: no rule changes required

Each drifted source was diffed against the rules it backs:

- **Claude Code hooks** - `VALID_EVENTS` (31 entries) covers every event heading in the reference. The four headings not in the list (`Configuration`, `Disclaimer`, `Limitations`, `Timeouts`) are prose sections, not events.
- **Claude Code skills** - the frontmatter allowlist in `schemas/skill.rs` covers all 20 documented fields, including `arguments`, `effort`, `shell`, `compatibility`, `paths`.
- **Claude Code plugins** - the 10 path-bearing manifest keys checked by CC-PL-007/008 are a superset of the documented component table.
- **Cursor hooks** - `beforeShellExecution` and `beforeMCPExecution` lost their dedicated doc sections but remain in the support table and examples, so keeping them in `CURSOR_HOOK_EVENTS` is correct and removing them would false-positive. Per-script options are unchanged; CUR-017 already type-checks `timeout`, `loop_limit`, and `failClosed`.
- **Cursor subagents** - `name`, `description`, `model`, `readonly`, `is_background` all handled, all optional as documented; bracketed model parameters (`composer-2.5[fast=false]`) already parse.
- **Cursor environment schema** - property set across `definitions.common` + `definitions.container` matches `ALLOWED_ROOT_FIELDS` exactly; `terminals`' nested-array form, `ports` bounds, and `build` are covered.
- **Cursor rules** - `.mdc` requirement and the `description` / `globs` / `alwaysApply` key set unchanged.
- **Cursor MCP** - the validator does not reject unknown server fields, so newly documented `envFile` cannot false-positive.

## Gaps recorded, not guessed at

Added to RESEARCH-TRACKING's pending items rather than invented as rules in a baseline-refresh PR:

1. Claude Code v2.1.246 now warns at startup about `permissions` entries with a wildcard before the subcommand (`Bash(git * main)`) - no agnix rule covers this.
2. `keybindings.json` is not validated at all; upstream now skips unknown action names with a `--debug` warning.
3. Cursor's MCP doc now marks `type` as **Required** for STDIO servers, while agnix infers the transport when it is absent.
4. Cursor documents `envFile` as STDIO-only; no rule flags it on an HTTP/SSE server.
5. The Cursor hooks per-script table types `matcher` as `object` while every example uses a string - an upstream inconsistency, so CUR-017 leaves it unvalidated deliberately.

## Deliberately not bumped

Cline (`v4.1.16`) and Codex (`rust-v0.150.0`) published after these issues were opened. Bumping them here would suppress the watcher's own triage issues for two S/A-tier tools, so they stay at their previous baselines and the next scheduled run files them.

## Also worth flagging

The watcher's LLM pre-triage is failing: `GLM HTTP 401: Authentication Failed`, so every tool-release issue falls back to the raw changelog. Needs a fresh `GLM_API_KEY`.

## Verification

- `node scripts/sync-rule-bookkeeping.js --check --skip-docs` - in sync
- `python3 scripts/check-rule-counts.py` - clean
- `cargo test -p agnix-cli --test rule_parity` - 20 passed (includes `test_spec_baseline_rule_ids_exist`)