### PR TITLE
release: v0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-08-27
+
 ### Added
 - **PyPI distribution**. `pip install agnix` and `uvx agnix .` now work. The
   wheels in `pypi/` bundle the release binary for each supported target
@@ -62,6 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runtime retry and cancellation behavior, agent enablement, and command help,
   without changing an agnix-validated configuration contract.
 
+### Fixed
+- **Stale rule count in the npm long description**. `npm/README.md` advertised
+  405 rules against a canonical 451, and no automation covered it, so the number
+  had drifted for several releases and was copied into the new PyPI README.
+  Corrected, and both wrapper READMEs are now in `sync-rule-bookkeeping.js`'s
+  `COUNT_FILES` so CI fails on the next drift.
+
 ## [0.50.0] - 2026-08-25
 
 ### Added
@@ -99,11 +108,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agnix-validated configuration contract.
 
 ### Fixed
-- **Stale rule count in the npm long description**. `npm/README.md` advertised
-  405 rules against a canonical 451, and no automation covered it, so the number
-  had drifted for several releases and was copied into the new PyPI README.
-  Corrected, and both wrapper READMEs are now in `sync-rule-bookkeeping.js`'s
-  `COUNT_FILES` so CI fails on the next drift.
 - **Rust 1.98 clippy compatibility**. Replace a constant-only `format!` call
   that is now rejected by `clippy::useless_format`.
 - **CC-HK-025 Notification matcher compatibility**. Accept the documented

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -99,14 +99,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.50.0"
+version = "0.51.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -33,8 +33,8 @@ categories = ["development-tools", "command-line-utilities"]
 [workspace.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.50.0" }
-agnix-core = { path = "crates/agnix-core", version = "0.50.0" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.51.0" }
+agnix-core = { path = "crates/agnix-core", version = "0.51.0" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.agnix
 pluginName = agnix
 pluginRepositoryUrl = https://github.com/agent-sh/agnix
 # SemVer format -> https://semver.org
-pluginVersion = 0.50.0
+pluginVersion = 0.51.0
 
 # Supported build number ranges and IntelliJ Platform Versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.50.0",
+      "version": "0.51.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.50.0"
+version = "0.51.0"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.50.0",
+  "version": "0.51.0",
   "description": "Lint agent configurations before they break your workflow. 451 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",

--- a/pypi/agnix/__init__.py
+++ b/pypi/agnix/__init__.py
@@ -13,7 +13,7 @@ import sysconfig
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-__version__ = "0.50.0"
+__version__ = "0.51.0"
 
 __all__ = ["AgnixError", "binary_path", "lint", "run", "version", "__version__"]
 

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnix"
-version = "0.50.0"
+version = "0.51.0"
 description = "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts v0.51.0. Tag `v0.51.0` after merge to trigger the release workflow.

## Contents

**Added**
- PyPI distribution (#1431, closes #1430) - `pip install agnix`, `uvx agnix .`, platform wheels built from the release binaries. **This release is the first real exercise of the new `pypi` job**, so it also claims the `agnix` name on PyPI.
- JetBrains plugin WSL execution mode (#1346)

**Changed**
- Tool and spec baseline refreshes (#1425, #1426, #1427, #1428, #1429): Claude Code `v2.1.246`, Cursor `3.17.21`, amp `setup-without-a-commit`, Gemini CLI `v0.57.0`, OpenCode `v1.18.23`, plus eight re-baselined spec sources

**Fixed**
- Stale rule count in the npm long description (405 vs canonical 451), now guarded by `sync-rule-bookkeeping.js`

## Version sync

`scripts/sync-versions.sh` propagated `0.51.0` from `[workspace.package]` to the npm, PyPI, VS Code (+lock), JetBrains, Zed, and plugin manifests. The PyPI wrapper is in that list for the first time.

## One correction included

The npm rule-count entry from #1431 had been written into the frozen `[0.50.0]` section rather than `[Unreleased]`. Per-version sections are historical, so this PR moves it into `[0.51.0]` where it belongs. Nothing else in `[0.50.0]` changed.

## Local verification

- `cargo check --workspace` - clean
- `cargo fmt --check --all` - clean
- `node scripts/sync-rule-bookkeeping.js --check --skip-docs` - in sync
- `python3 -m unittest discover -s pypi/test` - 25 passed

Full test matrix, clippy, eval, and self-lint run in CI here and again in the release workflow's `test` job before anything publishes.

## Post-merge plan

1. Tag `v0.51.0` and push
2. Watch `release.yml`: build (5 targets) -> release -> crates.io / npm / **PyPI** / VS Code / JetBrains / Zed
3. Verify `pip install agnix` and `agnix --version` from a clean env, since the PyPI upload step has never run against the live registry