### PR TITLE
fix(glm): budget enough output for thinking so triage stops coming back empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,14 @@ jobs:
       - name: Release install path tests
         if: matrix.os == 'ubuntu-latest'
         # Covers the glibc floor gate the release build runs, the npm
-        # installer's static-build fallback, and the PyPI wheel builder. None of
-        # them ship inside the Rust workspace, so nothing else exercises them
-        # (see #1371).
+        # installer's static-build fallback, the PyPI wheel builder, and the
+        # watcher's GLM client. None of them ship inside the Rust workspace, so
+        # nothing else exercises them (see #1371).
         run: |
           bash scripts/check-glibc-floor.test.sh
           node npm/test/install-helpers.test.js
           python3 -m unittest discover -s pypi/test
+          node --test scripts/glm-extract.test.js
 
       - name: Schema sync check
         if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Tool-release triage produced no summaries**. Two separate faults, both of
+  which the watcher degrades silently to "post the raw changelog": the
+  `GLM_API_KEY` secret had expired, and `scripts/glm-extract.js` ran with an
+  output budget too small for a thinking model. Reasoning tokens are drawn from
+  the same `max_tokens` budget as the answer, so at 4096 the model intermittently
+  spent the entire budget reasoning and returned `finish_reason: "length"` with
+  empty `content` (reproduced at 1 failure in 3 runs, 4095 of 4096 tokens on
+  reasoning). `MAX_TOKENS` is now 32768, roughly six times the 1.9k-5.2k
+  reasoning observed on real triage prompts, and thinking stays enabled because
+  it measurably improves the "does this touch a validated config surface?"
+  judgement. The default model is now named `glm-5.3` explicitly rather than
+  relying on the endpoint's `glm-5` alias, so an alias move cannot change triage
+  behaviour silently. The empty-content error now also reports `finish_reason`,
+  reasoning size, and usage instead of just "empty content", and
+  `scripts/glm-extract.test.js` - which no workflow ran - is now part of CI.
+
 ## [0.51.0] - 2026-08-27
 
 ### Added

--- a/scripts/glm-extract.js
+++ b/scripts/glm-extract.js
@@ -45,10 +45,12 @@
  *
  * Env:
  *   GLM_API_KEY  required - z.ai key in "id.secret" format
- *   GLM_MODEL    optional - defaults to glm-5 (mid-tier coding model, ~22s for
- *                this workload). Other options:
+ *   GLM_MODEL    optional - defaults to glm-5.3 (what the coding-paas endpoint
+ *                already resolved the `glm-5` alias to; named explicitly so a
+ *                silent alias move cannot change triage behaviour). Other
+ *                options:
  *                  - glm-4.7  - older; observed >120s timeouts in 2026-04 testing
- *                  - glm-5.1  - current flagship; heaviest on quota
+ *                  - glm-5.1  - heaviest on quota
  *                  - glm-5-turbo - per cairn's default; not separately benchmarked here
  *   GLM_BASE_URL optional - defaults to https://api.z.ai/api/coding/paas/v4
  *
@@ -67,7 +69,12 @@ const fs = require('fs');
 // Char budget for stdin payload sent to GLM - applies to both HTML
 // (extract mode) and markdown release notes (agnix-triage mode).
 const INPUT_BUDGET = 80_000;
-const MAX_TOKENS = 4096;
+// Output budget. Thinking is on (see buildRequestBody) and reasoning tokens are
+// drawn from this same budget, so it has to cover reasoning + answer. Measured
+// reasoning on real triage prompts: 1.9k-5.2k tokens, so this leaves ~6x
+// headroom. At 4096 the model intermittently spent the whole budget reasoning
+// and returned `finish_reason: "length"` with empty content.
+const MAX_TOKENS = 32_768;
 const TEMPERATURE = 0.3; // extraction task, prefer determinism
 
 // Module-scoped argv/env holders. Populated by runCli() when invoked
@@ -243,6 +250,30 @@ function buildAgnixTriagePrompt(notes, interests, rulesManifest, ctx = { toolDis
   return lines.filter((line) => line !== null).join('\n');
 }
 
+/**
+ * Build the chat-completions request body.
+ *
+ * Thinking is enabled deliberately: the triage has to decide whether a change
+ * touches a validated config surface, and reasoning measurably improves that
+ * judgement. The catch is that reasoning tokens are drawn from the same
+ * `max_tokens` budget as the answer, so the budget has to cover both. At the
+ * old 4096 the model intermittently spent all of it reasoning and returned
+ * `finish_reason: "length"` with an empty `content` (1 failure in 3 runs on the
+ * Cline v4.1.16 prompt, 4095 of 4096 tokens on reasoning), which the watcher
+ * silently degrades to "post the raw changelog". MAX_TOKENS now carries ~6x the
+ * observed reasoning headroom instead.
+ */
+function buildRequestBody(model, prompt) {
+  return {
+    model,
+    messages: [{ role: 'user', content: prompt }],
+    stream: false,
+    max_tokens: MAX_TOKENS,
+    temperature: TEMPERATURE,
+    thinking: { type: 'enabled' },
+  };
+}
+
 function parseArgv(argv) {
   const parsedFlags = {};
   const positional = [];
@@ -282,7 +313,7 @@ async function runCli() {
     process.exit(2);
   }
 
-  model = process.env.GLM_MODEL || 'glm-5';
+  model = process.env.GLM_MODEL || 'glm-5.3';
   baseUrl = (process.env.GLM_BASE_URL || 'https://api.z.ai/api/coding/paas/v4').replace(/\/$/, '');
 
   const stdin = (await readStdin()).slice(0, INPUT_BUDGET);
@@ -308,13 +339,7 @@ async function runCli() {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        model,
-        messages: [{ role: 'user', content: prompt }],
-        stream: false,
-        max_tokens: MAX_TOKENS,
-        temperature: TEMPERATURE,
-      }),
+      body: JSON.stringify(buildRequestBody(model, prompt)),
       signal: AbortSignal.timeout(180_000),
     });
   } catch (err) {
@@ -338,7 +363,15 @@ async function runCli() {
 
   const content = data?.choices?.[0]?.message?.content || '';
   if (!content.trim()) {
-    console.error('GLM returned empty content');
+    // Say why, so the watcher's WARN line is actionable. A truncated answer
+    // (`finish_reason: "length"`) needs a bigger MAX_TOKENS; anything else is
+    // a model or prompt problem.
+    const choice = data?.choices?.[0] ?? {};
+    const reasoningChars = (choice.message?.reasoning_content ?? '').length;
+    console.error(
+      `GLM returned empty content (finish_reason=${choice.finish_reason ?? 'unknown'}, ` +
+        `reasoning_chars=${reasoningChars}, usage=${JSON.stringify(data?.usage ?? {})})`
+    );
     process.exit(1);
   }
   process.stdout.write(content);
@@ -349,6 +382,7 @@ async function runCli() {
 module.exports = {
   buildExtractPrompt,
   buildAgnixTriagePrompt,
+  buildRequestBody,
   parseArgv,
 };
 

--- a/scripts/glm-extract.test.js
+++ b/scripts/glm-extract.test.js
@@ -20,6 +20,7 @@ const assert = require('node:assert/strict');
 const {
   buildExtractPrompt,
   buildAgnixTriagePrompt,
+  buildRequestBody,
   parseArgv,
 } = require('./glm-extract.js');
 
@@ -139,4 +140,32 @@ test('parseArgv splits flags and positionals correctly', () => {
 test('parseArgv handles bare flags as boolean true', () => {
   const { flags } = parseArgv(['--pretty']);
   assert.equal(flags.pretty, true);
+});
+
+test('buildRequestBody keeps thinking enabled', () => {
+  const body = buildRequestBody('glm-5.3', 'prompt text');
+  // Reasoning improves the "does this touch a validated config surface?"
+  // judgement, so it stays on.
+  assert.deepEqual(body.thinking, { type: 'enabled' });
+});
+
+test('buildRequestBody budgets enough output for reasoning plus answer', () => {
+  const body = buildRequestBody('glm-5.3', 'prompt text');
+  // Reasoning tokens come out of max_tokens. Measured reasoning on real triage
+  // prompts is 1.9k-5.2k; at 4096 the answer was intermittently truncated away
+  // entirely (finish_reason "length", empty content).
+  assert.ok(
+    body.max_tokens >= 16_384,
+    `max_tokens ${body.max_tokens} leaves too little room for reasoning + answer`
+  );
+});
+
+test('buildRequestBody sends a non-streaming single-turn request', () => {
+  const body = buildRequestBody('glm-5-turbo', 'prompt text');
+  assert.equal(body.model, 'glm-5-turbo');
+  assert.equal(body.stream, false);
+  assert.deepEqual(body.messages, [{ role: 'user', content: 'prompt text' }]);
+  assert.equal(typeof body.max_tokens, 'number');
+  assert.ok(body.max_tokens > 0);
+  assert.equal(typeof body.temperature, 'number');
 });


### PR DESCRIPTION
Follow-up to rotating the `GLM_API_KEY` secret. The watcher's triage was broken by **two** independent faults, and it degrades both to a WARN line plus a raw changelog, so neither was visible in the issues themselves.

## Fault 1: expired secret (fixed outside this PR)

`GLM HTTP 401: Authentication Failed` on every run. Rotated to a key that authenticates against the same endpoint and model this script uses.

## Fault 2: output budget too small for a thinking model (this PR)

With auth working, the next run failed differently: `GLM returned empty content`.

Reasoning tokens come out of the same `max_tokens` budget as the answer, so at 4096 the model intermittently spent all of it reasoning:

```
DEBUG finish_reason=length reasoning_len=18621 usage={"completion_tokens":4096,
  "completion_tokens_details":{"reasoning_tokens":4095},"prompt_tokens":854,...}
```

Reproduced at **1 failure in 3 runs** on the Cline v4.1.16 notes - which is why it first looked like a key problem, and why it went unnoticed: the fallback is silent.

**Thinking stays enabled.** Deciding whether a change touches a validated config surface is exactly the judgement reasoning helps with. The budget was the bug: `MAX_TOKENS` goes 4096 -> **32768**, about 6x the reasoning measured on real triage prompts.

Probed on `glm-5.3` with thinking on, same prompt:

| max_tokens | finish_reason | reasoning tokens | content |
|---|---|---|---|
| 4096 | `length` (intermittent) | 4095 | **empty** |
| 16384 | `stop` | 1858 | 276 chars |
| 32768 | `stop` | 5137 | 957 chars |
| 65536 | `stop` | 5248 | 377 chars |
| 98304 | `stop` | 4397 | 302 chars |

Observed reasoning peaks around 5.2k, so 32768 leaves ample headroom without asking for a budget the endpoint might reject.

## Default model named explicitly

`GLM_MODEL` now defaults to `glm-5.3` instead of `glm-5`. The coding-paas endpoint was already resolving that alias to glm-5.3 (visible in the response's `model` field), so naming it pins triage behaviour against a silent alias move.

## Also in here

- **Diagnosable failure.** The empty-content error now reports `finish_reason`, reasoning size, and usage. Previously the log said only `GLM returned empty content`, which is what made this take a reproduction loop to pin down.
- **`buildRequestBody()` extracted and exported**, so the request shape is unit-testable; tests assert thinking stays enabled and the budget keeps room for reasoning plus answer.
- **`scripts/glm-extract.test.js` now runs in CI.** No workflow ran it, so the prompt-contract tests it was written to enforce had never gated a change. It joins the glibc-floor, npm-installer, and PyPI-wheel tests in the "Release install path tests" step.

## Verification

Live against the real endpoint with the rotated key, on the **heaviest** prompt (Claude Code v2.1.247 notes plus the 23KB rule manifest): **3 of 3 runs** succeeded, and the output is a real grounded triage proposing next-in-sequence rule ids:

```
#### Agnix-relevant changes
- `Added the SendFeedback tool` -- matches: `New built-in tool names (affecting the allow-list validator)`
- `turn off with the feedbackDrafts setting` -- matches: `New or renamed top-level keys in settings.json`
- `Added {id, text, cooldownSessions, priority} entries, tipsFile, and label to spinnerTipsOverride` -- matches: ...
- `plugin marketplace hardening: names containing control or invisible characters are rejected` -- matches: `Plugin manifest schema changes`

#### Rule candidates
- CC-SET-028: Non-boolean `feedbackDrafts` setting
- CC-SET-029: Invalid `spinnerTipsOverride` tip entry shape
- CC-PL-016: Plugin name contains control or invisible characters
```

Cline v4.1.16 also ran 4 of 4 clean. `node --test scripts/glm-extract.test.js` - 12 passed.