### PR TITLE
feat(rules): cover Claude Code v2.1.247 settings and fix stale tool list

### DIFF
--- a/.github/tool-release-baselines.json
+++ b/.github/tool-release-baselines.json
@@ -17,7 +17,7 @@
         "mcp"
       ],
       "github_repo": "anthropics/claude-code",
-      "last_known_version": "v2.1.246",
+      "last_known_version": "v2.1.247",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -63,7 +63,7 @@
         "per_client_skill"
       ],
       "github_repo": "openai/codex",
-      "last_known_version": "rust-v0.149.1",
+      "last_known_version": "rust-v0.150.0",
       "tracked": true,
       "changes_of_interest": {
         "config_surfaces": [
@@ -217,7 +217,7 @@
       ],
       "github_repo": "cline/cline",
       "release_tag_regex": "^v[0-9]+\\.[0-9]+\\.[0-9]+$",
-      "last_known_version": "v4.1.15",
+      "last_known_version": "v4.1.16",
       "tracked": true,
       "notes": "Tracks only the core Cline vX.Y.Z release train. The repository also publishes desktop-v*, cli-v*, sdk/*, and other interleaved releases that do not correspond to the validator surfaces.",
       "changes_of_interest": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 451 rules, 75+ sources, rules.json
+knowledge-base/     # 454 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-451 rules defined in `knowledge-base/rules.json` (source of truth)
+454 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 451 validation rules across 40 validators
+- 454 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **CC-SET-028: invalid `feedbackDrafts` setting**
+  ([#1435](https://github.com/agent-sh/agnix/issues/1435)). Claude Code v2.1.247
+  added the `SendFeedback` tool and the `feedbackDrafts` setting that governs it.
+  The setting is a string enum - `notify`, `quiet`, or `off` - so the natural
+  guess of a boolean silently leaves the default `notify` in place. Flags any
+  value outside the documented enum.
+- **CC-SET-029: invalid `spinnerTipsOverride` shape**
+  ([#1435](https://github.com/agent-sh/agnix/issues/1435)). v2.1.247 extended the
+  key with tip objects (`id`, `text`, `cooldownSessions`, `priority`), `tipsFile`,
+  and `label`. Claude Code drops an invalid tip with a debug warning instead of
+  rejecting the file, so a malformed tip is simply never shown. Validates the
+  object's fields, each tip entry, the documented `id`/`text` limits, the
+  `0`-`1000` and `-10`-`10` numeric ranges, the 40-character `label` cap, and
+  that `tipsFile` is absolute or `~/`-rooted.
+- **CC-PL-016: plugin name not kebab-case**. The plugin reference documents
+  `name` as a kebab-case identifier with no spaces, and v2.1.247 hardened
+  marketplace handling to reject names containing control or invisible
+  characters. Those fail kebab-case by construction, so this catches them before
+  a plugin reaches a marketplace.
+
+### Fixed
+- **`SendFeedback` and `ListAgents` reported as unknown tools**
+  ([#1435](https://github.com/agent-sh/agnix/issues/1435)). `KNOWN_AGENT_TOOLS`
+  had not been refreshed since 2026-07-31, so CC-AG-009/010 flagged two
+  documented built-in tools - `ListAgents` from Claude Code v2.1.224 and
+  `SendFeedback` from v2.1.238 - as invalid names in an agent's `tools` or
+  `disallowedTools` list. Diffed the whole list against the live tools reference,
+  and these were the only two missing.
+
+### Changed
+- **Tool baselines refreshed** (closes
+  [#1435](https://github.com/agent-sh/agnix/issues/1435),
+  [#1436](https://github.com/agent-sh/agnix/issues/1436),
+  [#1437](https://github.com/agent-sh/agnix/issues/1437)). Claude Code
+  `v2.1.246` to `v2.1.247`, Cline `v4.1.15` to `v4.1.16`, and Codex CLI
+  `rust-v0.149.1` to `rust-v0.150.0`. Cline's release moves hook workspace
+  resolution from shared global state to the VS Code window, which changes
+  runtime behaviour rather than any validated file contract. Codex adds an
+  `Interrupt` hook event; CDX-PL-013 validates hook shape without an event-name
+  allowlist, so nothing false-positives, and the missing allowlist is recorded in
+  RESEARCH-TRACKING along with the uncovered `spinnerVerbs` setting.
+
 ### Fixed
 - **Tool-release triage produced no summaries**. Two separate faults, both of
   which the watcher degrades silently to "post the raw changelog": the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ editors/
 ├── vscode/         # VS Code extension
 ├── jetbrains/      # JetBrains IDE plugin
 └── zed/            # Zed extension
-knowledge-base/     # 451 rules, 75+ sources, rules.json
+knowledge-base/     # 454 rules, 75+ sources, rules.json
 
 tests/fixtures/     # Test cases by category
 ```
@@ -178,7 +178,7 @@ cargo run --bin agnix-mcp   # Run MCP server
 
 ## Rules Reference
 
-451 rules defined in `knowledge-base/rules.json` (source of truth)
+454 rules defined in `knowledge-base/rules.json` (source of truth)
 
 
 Human-readable docs: `knowledge-base/VALIDATION-RULES.md`
@@ -190,7 +190,7 @@ Format: `[CATEGORY]-[NUMBER]` (AS-004, CC-HK-001, etc.)
 ## Current State
 
 - v0.37.3 - Production-ready with full validation pipeline
-- 451 validation rules across 40 validators
+- 454 validation rules across 40 validators
 
 - 4200+ passing tests
 - LSP + MCP servers with VS Code extension

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>451 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
+<p align="center">Catch broken agent configs before your AI tools silently ignore them.<br>454 rules across Claude Code, Codex CLI, OpenCode, Cursor, Copilot, and more -<br>validating CLAUDE.md, SKILL.md, hooks, MCP configs, and other agent files.</p>
 
 <p align="center"><strong>Auto-fix</strong> | <strong><a href="https://github.com/marketplace/actions/agnix-ci">GitHub Action</a></strong> | <strong><a href="https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix">VS Code</a> + <a href="https://plugins.jetbrains.com/plugin/30087-agnix">JetBrains</a> + <a href="https://github.com/agent-sh/agnix.nvim">Neovim</a> + <a href="https://zed.dev/extensions?query=agnix">Zed</a></strong></p>
 
@@ -37,7 +37,7 @@
 
 **Bad patterns get amplified.** AI assistants don't ignore wrong configs - they [learn from them](https://www.augmentcode.com/guides/enterprise-coding-standards-12-rules-for-ai-ready-teams).
 
-agnix validates all of it - 451 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
+agnix validates all of it - 454 rules sourced from official specs, academic research, and real-world breakage patterns. Auto-fix included.
 
 > **Want to try it first?** [Open the playground](https://agent-sh.github.io/agnix/playground) - paste any agent config, see diagnostics instantly. No install, runs in your browser.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -12,9 +12,9 @@
 | Memory (Claude Code) | CLAUDE.md, CLAUDE.local.md, .claude/rules/*.md | 13 |
 | Instructions (Cross-Tool) | AGENTS.md, AGENTS.local.md, AGENTS.override.md | 6 |
 | Agents | agents/*.md | 18 |
-| Plugins | plugin.json | 15 |
+| Plugins | plugin.json | 16 |
 | Claude Output Styles | .claude/output-styles/*.md | 6 |
-| Claude Settings | .claude/settings.json | 27 |
+| Claude Settings | .claude/settings.json | 29 |
 | Prompt Engineering | CLAUDE.md, AGENTS.md | 6 |
 | Cross-Platform | AGENTS.md | 10 |
 | MCP | tool definitions | 26 |

--- a/crates/agnix-cli/locales/en.yml
+++ b/crates/agnix-cli/locales/en.yml
@@ -1382,6 +1382,27 @@ rules:
   cc_set_027:
     message: subagentPromptCacheTtl must be 5m or 1h (got %{actual})
     suggestion: Set subagentPromptCacheTtl to 5m or 1h.
+  cc_set_028:
+    message: feedbackDrafts must be notify, quiet, or off (got %{actual})
+    suggestion: Set feedbackDrafts to notify, quiet, or off. It is a string enum, not a boolean.
+  cc_set_029:
+    suggestion: Match the documented spinnerTipsOverride shape - Claude Code drops an invalid tip with a debug warning instead of reporting it.
+    not_object: spinnerTipsOverride must be an object with tips, tipsFile, label, or excludeDefault (got %{actual})
+    unknown_field: spinnerTipsOverride has unknown field '%{field}'
+    label_not_string: spinnerTipsOverride.label must be a string (got %{actual})
+    label_too_long: spinnerTipsOverride.label is %{len} characters, over the %{max} character limit
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault must be a boolean (got %{actual})
+    tips_file_not_string: spinnerTipsOverride.tipsFile must be a string path (got %{actual})
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' is not absolute or ~/-rooted, so Claude Code cannot load it
+    tips_not_array: spinnerTipsOverride.tips must be an array (got %{actual})
+    tip_not_object: spinnerTipsOverride.tips entry %{index} must be a string or an object (got %{actual})
+    tip_id: spinnerTipsOverride.tips entry %{index} needs an 'id' of up to 64 letters, digits, '.', '_', or '-'
+    tip_text: spinnerTipsOverride.tips entry %{index} needs a non-empty 'text' of at most %{max} characters
+    tip_range: spinnerTipsOverride.tips entry %{index} has '%{field}' outside %{min}..%{max}
+    tip_unknown_field: spinnerTipsOverride.tips entry %{index} has unknown field '%{field}'
+  cc_pl_016:
+    message: Plugin name '%{name}' is not kebab-case
+    suggestion: Use lowercase letters, digits, and hyphens only. Claude Code rejects names with control or invisible characters.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -894,6 +894,27 @@ rules:
 # Core - Library messages
 # ===========================================================================
 core:
+  cc_set_028:
+    message: feedbackDrafts debe ser notify, quiet u off (se recibió %{actual})
+    suggestion: Establece feedbackDrafts en notify, quiet u off. Es una cadena enumerada, no un booleano.
+  cc_set_029:
+    suggestion: Usa la forma documentada de spinnerTipsOverride - Claude Code descarta un consejo inválido con un aviso de depuración en lugar de informarlo.
+    not_object: spinnerTipsOverride debe ser un objeto con tips, tipsFile, label o excludeDefault (se recibió %{actual})
+    unknown_field: spinnerTipsOverride tiene el campo desconocido '%{field}'
+    label_not_string: spinnerTipsOverride.label debe ser una cadena (se recibió %{actual})
+    label_too_long: spinnerTipsOverride.label tiene %{len} caracteres, más del límite de %{max}
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault debe ser booleano (se recibió %{actual})
+    tips_file_not_string: spinnerTipsOverride.tipsFile debe ser una ruta en texto (se recibió %{actual})
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' no es absoluta ni empieza por ~/, así que Claude Code no puede cargarla
+    tips_not_array: spinnerTipsOverride.tips debe ser un arreglo (se recibió %{actual})
+    tip_not_object: la entrada %{index} de spinnerTipsOverride.tips debe ser una cadena o un objeto (se recibió %{actual})
+    tip_id: la entrada %{index} de spinnerTipsOverride.tips necesita un 'id' de hasta 64 letras, dígitos, '.', '_' o '-'
+    tip_text: la entrada %{index} de spinnerTipsOverride.tips necesita un 'text' no vacío de hasta %{max} caracteres
+    tip_range: la entrada %{index} de spinnerTipsOverride.tips tiene '%{field}' fuera de %{min}..%{max}
+    tip_unknown_field: la entrada %{index} de spinnerTipsOverride.tips tiene el campo desconocido '%{field}'
+  cc_pl_016:
+    message: El nombre de plugin '%{name}' no está en kebab-case
+    suggestion: Usa solo minúsculas, dígitos y guiones. Claude Code rechaza nombres con caracteres de control o invisibles.
   error:
     file_read: 'Error al leer archivo: %{path}'
     file_write: 'Error al escribir archivo: %{path}'

--- a/crates/agnix-cli/locales/es.yml
+++ b/crates/agnix-cli/locales/es.yml
@@ -893,7 +893,6 @@ rules:
 # ===========================================================================
 # Core - Library messages
 # ===========================================================================
-core:
   cc_set_028:
     message: feedbackDrafts debe ser notify, quiet u off (se recibió %{actual})
     suggestion: Establece feedbackDrafts en notify, quiet u off. Es una cadena enumerada, no un booleano.
@@ -915,6 +914,7 @@ core:
   cc_pl_016:
     message: El nombre de plugin '%{name}' no está en kebab-case
     suggestion: Usa solo minúsculas, dígitos y guiones. Claude Code rechaza nombres con caracteres de control o invisibles.
+core:
   error:
     file_read: 'Error al leer archivo: %{path}'
     file_write: 'Error al escribir archivo: %{path}'

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -841,6 +841,27 @@ rules:
 # Core - Library messages
 # ===========================================================================
 core:
+  cc_set_028:
+    message: feedbackDrafts 必须为 notify、quiet 或 off（实际为 %{actual}）
+    suggestion: 将 feedbackDrafts 设置为 notify、quiet 或 off。它是字符串枚举，而不是布尔值。
+  cc_set_029:
+    suggestion: 请遵循 spinnerTipsOverride 的文档结构 - Claude Code 会以调试警告丢弃无效提示，而不会报错。
+    not_object: spinnerTipsOverride 必须是包含 tips、tipsFile、label 或 excludeDefault 的对象（实际为 %{actual}）
+    unknown_field: spinnerTipsOverride 含有未知字段 '%{field}'
+    label_not_string: spinnerTipsOverride.label 必须是字符串（实际为 %{actual}）
+    label_too_long: spinnerTipsOverride.label 有 %{len} 个字符，超过 %{max} 个字符的限制
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault 必须是布尔值（实际为 %{actual}）
+    tips_file_not_string: spinnerTipsOverride.tipsFile 必须是字符串路径（实际为 %{actual}）
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' 不是绝对路径也不以 ~/ 开头，Claude Code 无法加载
+    tips_not_array: spinnerTipsOverride.tips 必须是数组（实际为 %{actual}）
+    tip_not_object: spinnerTipsOverride.tips 第 %{index} 项必须是字符串或对象（实际为 %{actual}）
+    tip_id: spinnerTipsOverride.tips 第 %{index} 项需要 'id'，最多 64 个字母、数字、'.'、'_' 或 '-'
+    tip_text: spinnerTipsOverride.tips 第 %{index} 项需要非空的 'text'，最多 %{max} 个字符
+    tip_range: spinnerTipsOverride.tips 第 %{index} 项的 '%{field}' 超出 %{min}..%{max}
+    tip_unknown_field: spinnerTipsOverride.tips 第 %{index} 项含有未知字段 '%{field}'
+  cc_pl_016:
+    message: 插件名称 '%{name}' 不是 kebab-case
+    suggestion: 只使用小写字母、数字和连字符。Claude Code 会拒绝包含控制字符或不可见字符的名称。
   error:
     file_read: '读取文件失败: %{path}'
     file_write: '写入文件失败: %{path}'

--- a/crates/agnix-cli/locales/zh-CN.yml
+++ b/crates/agnix-cli/locales/zh-CN.yml
@@ -840,7 +840,6 @@ rules:
 # ===========================================================================
 # Core - Library messages
 # ===========================================================================
-core:
   cc_set_028:
     message: feedbackDrafts 必须为 notify、quiet 或 off（实际为 %{actual}）
     suggestion: 将 feedbackDrafts 设置为 notify、quiet 或 off。它是字符串枚举，而不是布尔值。
@@ -862,6 +861,7 @@ core:
   cc_pl_016:
     message: 插件名称 '%{name}' 不是 kebab-case
     suggestion: 只使用小写字母、数字和连字符。Claude Code 会拒绝包含控制字符或不可见字符的名称。
+core:
   error:
     file_read: '读取文件失败: %{path}'
     file_write: '写入文件失败: %{path}'

--- a/crates/agnix-core/locales/en.yml
+++ b/crates/agnix-core/locales/en.yml
@@ -1382,6 +1382,27 @@ rules:
   cc_set_027:
     message: subagentPromptCacheTtl must be 5m or 1h (got %{actual})
     suggestion: Set subagentPromptCacheTtl to 5m or 1h.
+  cc_set_028:
+    message: feedbackDrafts must be notify, quiet, or off (got %{actual})
+    suggestion: Set feedbackDrafts to notify, quiet, or off. It is a string enum, not a boolean.
+  cc_set_029:
+    suggestion: Match the documented spinnerTipsOverride shape - Claude Code drops an invalid tip with a debug warning instead of reporting it.
+    not_object: spinnerTipsOverride must be an object with tips, tipsFile, label, or excludeDefault (got %{actual})
+    unknown_field: spinnerTipsOverride has unknown field '%{field}'
+    label_not_string: spinnerTipsOverride.label must be a string (got %{actual})
+    label_too_long: spinnerTipsOverride.label is %{len} characters, over the %{max} character limit
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault must be a boolean (got %{actual})
+    tips_file_not_string: spinnerTipsOverride.tipsFile must be a string path (got %{actual})
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' is not absolute or ~/-rooted, so Claude Code cannot load it
+    tips_not_array: spinnerTipsOverride.tips must be an array (got %{actual})
+    tip_not_object: spinnerTipsOverride.tips entry %{index} must be a string or an object (got %{actual})
+    tip_id: spinnerTipsOverride.tips entry %{index} needs an 'id' of up to 64 letters, digits, '.', '_', or '-'
+    tip_text: spinnerTipsOverride.tips entry %{index} needs a non-empty 'text' of at most %{max} characters
+    tip_range: spinnerTipsOverride.tips entry %{index} has '%{field}' outside %{min}..%{max}
+    tip_unknown_field: spinnerTipsOverride.tips entry %{index} has unknown field '%{field}'
+  cc_pl_016:
+    message: Plugin name '%{name}' is not kebab-case
+    suggestion: Use lowercase letters, digits, and hyphens only. Claude Code rejects names with control or invisible characters.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -894,6 +894,27 @@ rules:
 # Core - Library messages
 # ===========================================================================
 core:
+  cc_set_028:
+    message: feedbackDrafts debe ser notify, quiet u off (se recibió %{actual})
+    suggestion: Establece feedbackDrafts en notify, quiet u off. Es una cadena enumerada, no un booleano.
+  cc_set_029:
+    suggestion: Usa la forma documentada de spinnerTipsOverride - Claude Code descarta un consejo inválido con un aviso de depuración en lugar de informarlo.
+    not_object: spinnerTipsOverride debe ser un objeto con tips, tipsFile, label o excludeDefault (se recibió %{actual})
+    unknown_field: spinnerTipsOverride tiene el campo desconocido '%{field}'
+    label_not_string: spinnerTipsOverride.label debe ser una cadena (se recibió %{actual})
+    label_too_long: spinnerTipsOverride.label tiene %{len} caracteres, más del límite de %{max}
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault debe ser booleano (se recibió %{actual})
+    tips_file_not_string: spinnerTipsOverride.tipsFile debe ser una ruta en texto (se recibió %{actual})
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' no es absoluta ni empieza por ~/, así que Claude Code no puede cargarla
+    tips_not_array: spinnerTipsOverride.tips debe ser un arreglo (se recibió %{actual})
+    tip_not_object: la entrada %{index} de spinnerTipsOverride.tips debe ser una cadena o un objeto (se recibió %{actual})
+    tip_id: la entrada %{index} de spinnerTipsOverride.tips necesita un 'id' de hasta 64 letras, dígitos, '.', '_' o '-'
+    tip_text: la entrada %{index} de spinnerTipsOverride.tips necesita un 'text' no vacío de hasta %{max} caracteres
+    tip_range: la entrada %{index} de spinnerTipsOverride.tips tiene '%{field}' fuera de %{min}..%{max}
+    tip_unknown_field: la entrada %{index} de spinnerTipsOverride.tips tiene el campo desconocido '%{field}'
+  cc_pl_016:
+    message: El nombre de plugin '%{name}' no está en kebab-case
+    suggestion: Usa solo minúsculas, dígitos y guiones. Claude Code rechaza nombres con caracteres de control o invisibles.
   error:
     file_read: 'Error al leer archivo: %{path}'
     file_write: 'Error al escribir archivo: %{path}'

--- a/crates/agnix-core/locales/es.yml
+++ b/crates/agnix-core/locales/es.yml
@@ -893,7 +893,6 @@ rules:
 # ===========================================================================
 # Core - Library messages
 # ===========================================================================
-core:
   cc_set_028:
     message: feedbackDrafts debe ser notify, quiet u off (se recibió %{actual})
     suggestion: Establece feedbackDrafts en notify, quiet u off. Es una cadena enumerada, no un booleano.
@@ -915,6 +914,7 @@ core:
   cc_pl_016:
     message: El nombre de plugin '%{name}' no está en kebab-case
     suggestion: Usa solo minúsculas, dígitos y guiones. Claude Code rechaza nombres con caracteres de control o invisibles.
+core:
   error:
     file_read: 'Error al leer archivo: %{path}'
     file_write: 'Error al escribir archivo: %{path}'

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -841,6 +841,27 @@ rules:
 # Core - Library messages
 # ===========================================================================
 core:
+  cc_set_028:
+    message: feedbackDrafts 必须为 notify、quiet 或 off（实际为 %{actual}）
+    suggestion: 将 feedbackDrafts 设置为 notify、quiet 或 off。它是字符串枚举，而不是布尔值。
+  cc_set_029:
+    suggestion: 请遵循 spinnerTipsOverride 的文档结构 - Claude Code 会以调试警告丢弃无效提示，而不会报错。
+    not_object: spinnerTipsOverride 必须是包含 tips、tipsFile、label 或 excludeDefault 的对象（实际为 %{actual}）
+    unknown_field: spinnerTipsOverride 含有未知字段 '%{field}'
+    label_not_string: spinnerTipsOverride.label 必须是字符串（实际为 %{actual}）
+    label_too_long: spinnerTipsOverride.label 有 %{len} 个字符，超过 %{max} 个字符的限制
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault 必须是布尔值（实际为 %{actual}）
+    tips_file_not_string: spinnerTipsOverride.tipsFile 必须是字符串路径（实际为 %{actual}）
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' 不是绝对路径也不以 ~/ 开头，Claude Code 无法加载
+    tips_not_array: spinnerTipsOverride.tips 必须是数组（实际为 %{actual}）
+    tip_not_object: spinnerTipsOverride.tips 第 %{index} 项必须是字符串或对象（实际为 %{actual}）
+    tip_id: spinnerTipsOverride.tips 第 %{index} 项需要 'id'，最多 64 个字母、数字、'.'、'_' 或 '-'
+    tip_text: spinnerTipsOverride.tips 第 %{index} 项需要非空的 'text'，最多 %{max} 个字符
+    tip_range: spinnerTipsOverride.tips 第 %{index} 项的 '%{field}' 超出 %{min}..%{max}
+    tip_unknown_field: spinnerTipsOverride.tips 第 %{index} 项含有未知字段 '%{field}'
+  cc_pl_016:
+    message: 插件名称 '%{name}' 不是 kebab-case
+    suggestion: 只使用小写字母、数字和连字符。Claude Code 会拒绝包含控制字符或不可见字符的名称。
   error:
     file_read: '读取文件失败: %{path}'
     file_write: '写入文件失败: %{path}'

--- a/crates/agnix-core/locales/zh-CN.yml
+++ b/crates/agnix-core/locales/zh-CN.yml
@@ -840,7 +840,6 @@ rules:
 # ===========================================================================
 # Core - Library messages
 # ===========================================================================
-core:
   cc_set_028:
     message: feedbackDrafts 必须为 notify、quiet 或 off（实际为 %{actual}）
     suggestion: 将 feedbackDrafts 设置为 notify、quiet 或 off。它是字符串枚举，而不是布尔值。
@@ -862,6 +861,7 @@ core:
   cc_pl_016:
     message: 插件名称 '%{name}' 不是 kebab-case
     suggestion: 只使用小写字母、数字和连字符。Claude Code 会拒绝包含控制字符或不可见字符的名称。
+core:
   error:
     file_read: '读取文件失败: %{path}'
     file_write: '写入文件失败: %{path}'

--- a/crates/agnix-core/src/rules/agent.rs
+++ b/crates/agnix-core/src/rules/agent.rs
@@ -120,7 +120,7 @@ const KNOWN_AGENT_FIELDS: &[&str] = &[
 /// Known Claude Code tools for CC-AG-009 and CC-AG-010.
 ///
 /// Mirrors the built-in tools reference (code.claude.com/docs/en/tools,
-/// verified 2026-07-31) plus legacy/internal names kept for version
+/// verified 2026-08-27) plus legacy/internal names kept for version
 /// tolerance. Alphabetized.
 ///
 /// Tools that subagents never receive (`AskUserQuestion`, `Workflow`,
@@ -144,6 +144,7 @@ const KNOWN_AGENT_TOOLS: &[&str] = &[
     "Glob",
     "Grep",
     "LSP",
+    "ListAgents",
     "ListMcpResourcesTool",
     "Monitor",
     "MultiTool",
@@ -155,6 +156,7 @@ const KNOWN_AGENT_TOOLS: &[&str] = &[
     "RemoteTrigger",
     "ReportFindings",
     "ScheduleWakeup",
+    "SendFeedback",
     "SendMessage",
     "SendUserFile",
     "ShareOnboardingGuide",
@@ -2929,6 +2931,29 @@ Agent instructions"#;
         assert!(
             !cc_ag_008[0].has_fixes(),
             "CC-AG-008 should not auto-fix nonsense values"
+        );
+    }
+
+    #[test]
+    fn test_cc_ag_009_accepts_tools_added_in_recent_releases() {
+        // `SendFeedback` (Claude Code v2.1.238) and `ListAgents` (v2.1.224) were
+        // missing from KNOWN_AGENT_TOOLS, so agents that list them had a valid
+        // configuration reported as an unknown tool name.
+        let content = r#"---
+name: my-agent
+description: A test agent
+tools: Read, ListAgents, SendFeedback, SendMessage
+---
+Agent instructions"#;
+
+        let hits: Vec<_> = validate(content)
+            .into_iter()
+            .filter(|d| d.rule == "CC-AG-009" || d.rule == "CC-AG-010")
+            .collect();
+
+        assert!(
+            hits.is_empty(),
+            "documented built-in tools must not be flagged, got: {hits:?}"
         );
     }
 

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -32,6 +32,9 @@
 //! - `modelPicker` scope and shape (CC-SET-025, added in Claude Code v2.1.242).
 //! - `promptCacheTtl` enum (CC-SET-026, added in Claude Code v2.1.242).
 //! - `subagentPromptCacheTtl` enum (CC-SET-027, added in Claude Code v2.1.242).
+//! - `feedbackDrafts` enum (CC-SET-028, added in Claude Code v2.1.247).
+//! - `spinnerTipsOverride` shape (CC-SET-029, tip objects/`tipsFile`/`label`
+//!   added in Claude Code v2.1.247).
 //!
 //! Runs on FileType::Hooks (which covers `.claude/settings.json` -
 //! see `file_types/detection.rs`). Skips non-Claude Code settings paths
@@ -74,6 +77,8 @@ const RULE_IDS: &[&str] = &[
     "CC-SET-025",
     "CC-SET-026",
     "CC-SET-027",
+    "CC-SET-028",
+    "CC-SET-029",
 ];
 
 /// Allowed values for `worktree.baseRef` per Claude Code v2.1.133 release notes.
@@ -99,6 +104,22 @@ const DIALOG_EXPIRY_ALLOWED: &[&str] = &["60s", "5m", "10m", "never"];
 
 /// Allowed prompt-cache lifetimes documented for the main and subagent settings.
 const PROMPT_CACHE_TTL_ALLOWED: &[&str] = &["5m", "1h"];
+
+/// Allowed values for `feedbackDrafts` per the settings reference. `"off"`
+/// removes the SendFeedback tool entirely.
+const FEEDBACK_DRAFTS_ALLOWED: &[&str] = &["notify", "quiet", "off"];
+
+/// Documented `spinnerTipsOverride` fields, all optional.
+const SPINNER_TIPS_OVERRIDE_FIELDS: &[&str] = &["tips", "tipsFile", "label", "excludeDefault"];
+
+/// Documented limits for a `spinnerTipsOverride` tip object. Claude Code drops
+/// an invalid entry with a debug warning rather than rejecting the file, so a
+/// bad tip is silently never shown.
+const SPINNER_TIP_ID_MAX_LEN: usize = 64;
+const SPINNER_TIP_TEXT_MAX_LEN: usize = 500;
+const SPINNER_TIP_LABEL_MAX_LEN: usize = 40;
+const SPINNER_TIP_COOLDOWN_RANGE: (i64, i64) = (0, 1000);
+const SPINNER_TIP_PRIORITY_RANGE: (i64, i64) = (-10, 10);
 
 /// Placeholders documented for `prUrlTemplate` at
 /// <https://code.claude.com/docs/en/settings>.
@@ -239,6 +260,14 @@ impl Validator for ClaudeSettingsValidator {
 
         if config.is_rule_enabled("CC-SET-027") {
             validate_subagent_prompt_cache_ttl(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-028") {
+            validate_feedback_drafts(path, content, &value, &mut diagnostics);
+        }
+
+        if config.is_rule_enabled("CC-SET-029") {
+            validate_spinner_tips_override(path, content, &value, &mut diagnostics);
         }
 
         diagnostics
@@ -2539,6 +2568,240 @@ fn model_picker_shape_diagnostic(path: &Path, line: usize, reason: String) -> Di
         t!("rules.cc_set_025.shape_message", reason = reason),
     )
     .with_suggestion(t!("rules.cc_set_025.shape_suggestion"))
+}
+
+/// CC-SET-028: Validate `feedbackDrafts`.
+///
+/// A string enum, not a boolean: `"off"` removes the SendFeedback tool, while
+/// `"notify"` and `"quiet"` differ only in whether a card appears above the
+/// prompt. A boolean `false` is the natural wrong guess and silently leaves the
+/// default `"notify"` in place.
+fn validate_feedback_drafts(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(field_value) = value.get("feedbackDrafts") else {
+        return;
+    };
+    if field_value.is_null()
+        || field_value
+            .as_str()
+            .is_some_and(|mode| FEEDBACK_DRAFTS_ALLOWED.contains(&mode))
+    {
+        return;
+    }
+
+    let actual = field_value
+        .as_str()
+        .map(ToString::to_string)
+        .unwrap_or_else(|| describe_json_type(field_value).to_string());
+    diagnostics.push(
+        Diagnostic::warning(
+            path.to_path_buf(),
+            find_key_line(content, "feedbackDrafts").unwrap_or(1),
+            0,
+            "CC-SET-028",
+            t!("rules.cc_set_028.message", actual = actual),
+        )
+        .with_suggestion(t!("rules.cc_set_028.suggestion")),
+    );
+}
+
+/// CC-SET-029: Validate the `spinnerTipsOverride` object and its tip entries.
+///
+/// Claude Code drops an invalid tip entry with a debug warning instead of
+/// rejecting the settings file, so a malformed tip is simply never shown - the
+/// silent-failure class agnix exists to catch.
+fn validate_spinner_tips_override(
+    path: &Path,
+    content: &str,
+    value: &serde_json::Value,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let Some(field_value) = value.get("spinnerTipsOverride") else {
+        return;
+    };
+    if field_value.is_null() {
+        return;
+    }
+
+    let line = find_key_line(content, "spinnerTipsOverride").unwrap_or(1);
+    let mut push = |message: String| {
+        diagnostics.push(
+            Diagnostic::warning(path.to_path_buf(), line, 0, "CC-SET-029", message)
+                .with_suggestion(t!("rules.cc_set_029.suggestion")),
+        );
+    };
+
+    let Some(object) = field_value.as_object() else {
+        push(
+            t!(
+                "rules.cc_set_029.not_object",
+                actual = describe_json_type(field_value)
+            )
+            .to_string(),
+        );
+        return;
+    };
+
+    for key in object.keys() {
+        if !SPINNER_TIPS_OVERRIDE_FIELDS.contains(&key.as_str()) {
+            push(t!("rules.cc_set_029.unknown_field", field = key.as_str()).to_string());
+        }
+    }
+
+    if let Some(label) = object.get("label") {
+        match label.as_str() {
+            Some(text) if text.chars().count() <= SPINNER_TIP_LABEL_MAX_LEN => {}
+            Some(text) => push(
+                t!(
+                    "rules.cc_set_029.label_too_long",
+                    len = text.chars().count(),
+                    max = SPINNER_TIP_LABEL_MAX_LEN
+                )
+                .to_string(),
+            ),
+            None => push(
+                t!(
+                    "rules.cc_set_029.label_not_string",
+                    actual = describe_json_type(label)
+                )
+                .to_string(),
+            ),
+        }
+    }
+
+    if let Some(exclude) = object.get("excludeDefault")
+        && !exclude.is_boolean()
+    {
+        push(
+            t!(
+                "rules.cc_set_029.exclude_default_not_bool",
+                actual = describe_json_type(exclude)
+            )
+            .to_string(),
+        );
+    }
+
+    if let Some(tips_file) = object.get("tipsFile") {
+        match tips_file.as_str() {
+            // Documented as "an absolute or `~/` path": a relative path is
+            // resolved against nothing predictable, so the file never loads.
+            Some(text) if text.starts_with('/') || text.starts_with("~/") => {}
+            Some(text) if is_windows_absolute_path(text) => {}
+            Some(text) => push(t!("rules.cc_set_029.tips_file_relative", path = text).to_string()),
+            None => push(
+                t!(
+                    "rules.cc_set_029.tips_file_not_string",
+                    actual = describe_json_type(tips_file)
+                )
+                .to_string(),
+            ),
+        }
+    }
+
+    let Some(tips) = object.get("tips") else {
+        return;
+    };
+    let Some(entries) = tips.as_array() else {
+        push(
+            t!(
+                "rules.cc_set_029.tips_not_array",
+                actual = describe_json_type(tips)
+            )
+            .to_string(),
+        );
+        return;
+    };
+
+    for (index, entry) in entries.iter().enumerate() {
+        let position = index + 1;
+        // A plain string is a valid tip and takes the documented defaults.
+        if entry.is_string() {
+            continue;
+        }
+        let Some(tip) = entry.as_object() else {
+            push(
+                t!(
+                    "rules.cc_set_029.tip_not_object",
+                    index = position,
+                    actual = describe_json_type(entry)
+                )
+                .to_string(),
+            );
+            continue;
+        };
+
+        match tip.get("id").and_then(serde_json::Value::as_str) {
+            Some(id)
+                if !id.is_empty()
+                    && id.chars().count() <= SPINNER_TIP_ID_MAX_LEN
+                    && id
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')) => {}
+            _ => push(t!("rules.cc_set_029.tip_id", index = position).to_string()),
+        }
+
+        match tip.get("text").and_then(serde_json::Value::as_str) {
+            Some(text)
+                if !text.trim().is_empty() && text.chars().count() <= SPINNER_TIP_TEXT_MAX_LEN => {}
+            _ => push(
+                t!(
+                    "rules.cc_set_029.tip_text",
+                    index = position,
+                    max = SPINNER_TIP_TEXT_MAX_LEN
+                )
+                .to_string(),
+            ),
+        }
+
+        for (field, (min, max)) in [
+            ("cooldownSessions", SPINNER_TIP_COOLDOWN_RANGE),
+            ("priority", SPINNER_TIP_PRIORITY_RANGE),
+        ] {
+            if let Some(number) = tip.get(field) {
+                let in_range = number
+                    .as_i64()
+                    .is_some_and(|value| (min..=max).contains(&value));
+                if !in_range {
+                    push(
+                        t!(
+                            "rules.cc_set_029.tip_range",
+                            index = position,
+                            field = field,
+                            min = min,
+                            max = max
+                        )
+                        .to_string(),
+                    );
+                }
+            }
+        }
+
+        for key in tip.keys() {
+            if !["id", "text", "cooldownSessions", "priority"].contains(&key.as_str()) {
+                push(
+                    t!(
+                        "rules.cc_set_029.tip_unknown_field",
+                        index = position,
+                        field = key.as_str()
+                    )
+                    .to_string(),
+                );
+            }
+        }
+    }
+}
+
+/// `C:\path` or `C:/path`, which `tipsFile` accepts on Windows.
+fn is_windows_absolute_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'/' || bytes[2] == b'\\')
 }
 
 /// CC-SET-026: Validate the main-conversation prompt-cache TTL.
@@ -5571,6 +5834,173 @@ mod tests {
         );
         assert!(chinese.contains("必须是字符串"));
         assert!(!chinese.contains("must be"));
+    }
+
+    // ===== CC-SET-028: feedbackDrafts enum =====
+
+    #[test]
+    fn test_feedback_drafts_documented_values_are_valid() {
+        for mode in ["notify", "quiet", "off"] {
+            let content = format!(r#"{{"feedbackDrafts":"{mode}"}}"#);
+            assert!(
+                validate(&content)
+                    .iter()
+                    .all(|diagnostic| diagnostic.rule != "CC-SET-028"),
+                "{mode} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_feedback_drafts_boolean_is_flagged() {
+        // The natural wrong guess: it reads like an on/off switch but is a
+        // string enum, and a boolean silently leaves the default in place.
+        for invalid in ["false", "true", "0", r#""disabled""#, "[]"] {
+            let content = format!(r#"{{"feedbackDrafts":{invalid}}}"#);
+            assert_eq!(
+                validate(&content)
+                    .iter()
+                    .filter(|diagnostic| diagnostic.rule == "CC-SET-028")
+                    .count(),
+                1,
+                "expected CC-SET-028 for {content}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_feedback_drafts_null_and_absent_are_valid() {
+        for content in [r#"{"feedbackDrafts":null}"#, r#"{"model":"sonnet"}"#] {
+            assert!(
+                validate(content)
+                    .iter()
+                    .all(|diagnostic| diagnostic.rule != "CC-SET-028")
+            );
+        }
+    }
+
+    // ===== CC-SET-029: spinnerTipsOverride shape =====
+
+    #[test]
+    fn test_spinner_tips_override_documented_example_is_valid() {
+        // The settings-reference example, verbatim in shape.
+        let content = r#"{
+          "spinnerTipsOverride": {
+            "label": "Acme tip",
+            "excludeDefault": false,
+            "tips": [
+              "Run /review before opening a PR",
+              {
+                "id": "gateway-errors",
+                "text": "Seeing 5xx errors? Check the gateway status page first",
+                "cooldownSessions": 5,
+                "priority": 2
+              }
+            ]
+          }
+        }"#;
+        let diagnostics = validate(content);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.rule != "CC-SET-029"),
+            "documented example should be accepted, got {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn test_spinner_tips_override_tip_object_requires_id_and_text() {
+        for invalid_tip in [
+            r#"{"text":"Missing an id"}"#,
+            r#"{"id":"no-text"}"#,
+            r#"{"id":"","text":"Empty id"}"#,
+            r#"{"id":"bad id","text":"Space in id"}"#,
+            r#"{"id":"ok","text":"   "}"#,
+        ] {
+            let content = format!(r#"{{"spinnerTipsOverride":{{"tips":[{invalid_tip}]}}}}"#);
+            assert!(
+                validate(&content)
+                    .iter()
+                    .any(|diagnostic| diagnostic.rule == "CC-SET-029"),
+                "expected CC-SET-029 for {content}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_spinner_tips_override_numeric_ranges_are_enforced() {
+        for invalid in [
+            r#"{"id":"a","text":"t","cooldownSessions":1001}"#,
+            r#"{"id":"a","text":"t","cooldownSessions":-1}"#,
+            r#"{"id":"a","text":"t","priority":11}"#,
+            r#"{"id":"a","text":"t","priority":-11}"#,
+        ] {
+            let content = format!(r#"{{"spinnerTipsOverride":{{"tips":[{invalid}]}}}}"#);
+            assert!(
+                validate(&content)
+                    .iter()
+                    .any(|diagnostic| diagnostic.rule == "CC-SET-029"),
+                "expected CC-SET-029 for {content}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_spinner_tips_override_boundary_values_are_valid() {
+        let content = r#"{"spinnerTipsOverride":{"tips":[{"id":"a.b_c-d","text":"t","cooldownSessions":0,"priority":-10},{"id":"e","text":"t","cooldownSessions":1000,"priority":10}]}}"#;
+        assert!(
+            validate(content)
+                .iter()
+                .all(|diagnostic| diagnostic.rule != "CC-SET-029")
+        );
+    }
+
+    #[test]
+    fn test_spinner_tips_override_field_and_path_checks() {
+        let cases = [
+            (r#"{"spinnerTipsOverride":[]}"#, "non-object value"),
+            (
+                r#"{"spinnerTipsOverride":{"tips":{}}}"#,
+                "tips not an array",
+            ),
+            (
+                r#"{"spinnerTipsOverride":{"tipsFile":"tips.json"}}"#,
+                "relative tipsFile",
+            ),
+            (
+                r#"{"spinnerTipsOverride":{"excludeDefault":"yes"}}"#,
+                "non-boolean excludeDefault",
+            ),
+            (
+                r#"{"spinnerTipsOverride":{"label":42}}"#,
+                "non-string label",
+            ),
+            (
+                r#"{"spinnerTipsOverride":{"tipss":[]}}"#,
+                "misspelled field",
+            ),
+        ];
+        for (content, why) in cases {
+            assert!(
+                validate(content)
+                    .iter()
+                    .any(|diagnostic| diagnostic.rule == "CC-SET-029"),
+                "expected CC-SET-029 for {why}: {content}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_spinner_tips_override_accepts_absolute_and_home_tips_files() {
+        for tips_file in ["/etc/agnix/tips.json", "~/tips.json", "C:/tips.json"] {
+            let content = format!(r#"{{"spinnerTipsOverride":{{"tipsFile":"{tips_file}"}}}}"#);
+            assert!(
+                validate(&content)
+                    .iter()
+                    .all(|diagnostic| diagnostic.rule != "CC-SET-029"),
+                "{tips_file} should be accepted"
+            );
+        }
     }
 
     // ===== CC-SET-026/027: prompt cache TTL enums =====

--- a/crates/agnix-core/src/rules/claude_settings.rs
+++ b/crates/agnix-core/src/rules/claude_settings.rs
@@ -2718,8 +2718,20 @@ fn validate_spinner_tips_override(
 
     for (index, entry) in entries.iter().enumerate() {
         let position = index + 1;
-        // A plain string is a valid tip and takes the documented defaults.
-        if entry.is_string() {
+        // A plain string is a tip that takes the documented defaults, so the
+        // string *is* the tip's text and the same "one line of up to 500
+        // characters" limit applies to it as to an object's `text`.
+        if let Some(text) = entry.as_str() {
+            if !is_valid_spinner_tip_text(text) {
+                push(
+                    t!(
+                        "rules.cc_set_029.tip_text",
+                        index = position,
+                        max = SPINNER_TIP_TEXT_MAX_LEN
+                    )
+                    .to_string(),
+                );
+            }
             continue;
         }
         let Some(tip) = entry.as_object() else {
@@ -2745,8 +2757,7 @@ fn validate_spinner_tips_override(
         }
 
         match tip.get("text").and_then(serde_json::Value::as_str) {
-            Some(text)
-                if !text.trim().is_empty() && text.chars().count() <= SPINNER_TIP_TEXT_MAX_LEN => {}
+            Some(text) if is_valid_spinner_tip_text(text) => {}
             _ => push(
                 t!(
                     "rules.cc_set_029.tip_text",
@@ -2793,6 +2804,13 @@ fn validate_spinner_tips_override(
             }
         }
     }
+}
+
+/// Whether a tip's text is usable: non-empty after trimming and within the
+/// documented one-line, 500-character limit. Applies to both entry forms - a
+/// plain string tip is read as a tip whose text is the string itself.
+fn is_valid_spinner_tip_text(text: &str) -> bool {
+    !text.trim().is_empty() && text.chars().count() <= SPINNER_TIP_TEXT_MAX_LEN
 }
 
 /// `C:\path` or `C:/path`, which `tipsFile` accepts on Windows.
@@ -5906,6 +5924,42 @@ mod tests {
                 .all(|diagnostic| diagnostic.rule != "CC-SET-029"),
             "documented example should be accepted, got {diagnostics:?}"
         );
+    }
+
+    #[test]
+    fn test_spinner_tips_override_string_tips_share_the_text_limits() {
+        // A plain string is read as a tip whose text is the string, so an empty
+        // or over-long string is dropped just like a bad object `text`.
+        let long = "x".repeat(501);
+        for invalid in ["", "   ", long.as_str()] {
+            let content =
+                serde_json::json!({"spinnerTipsOverride": {"tips": [invalid]}}).to_string();
+            assert!(
+                validate(&content)
+                    .iter()
+                    .any(|diagnostic| diagnostic.rule == "CC-SET-029"),
+                "expected CC-SET-029 for string tip {invalid:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_spinner_tips_override_text_boundary_is_inclusive() {
+        // Exactly at the limit is valid, in both entry forms.
+        let string_form =
+            serde_json::json!({"spinnerTipsOverride": {"tips": ["x".repeat(500)]}}).to_string();
+        let object_form = serde_json::json!({
+            "spinnerTipsOverride": {"tips": [{"id": "a", "text": "x".repeat(500)}]}
+        })
+        .to_string();
+        for content in [string_form, object_form] {
+            assert!(
+                validate(&content)
+                    .iter()
+                    .all(|diagnostic| diagnostic.rule != "CC-SET-029"),
+                "500 characters should be accepted"
+            );
+        }
     }
 
     #[test]

--- a/crates/agnix-core/src/rules/plugin.rs
+++ b/crates/agnix-core/src/rules/plugin.rs
@@ -26,7 +26,22 @@ const RULE_IDS: &[&str] = &[
     "CC-PL-013",
     "CC-PL-014",
     "CC-PL-015",
+    "CC-PL-016",
 ];
+
+/// Whether a plugin `name` matches the documented kebab-case identifier form:
+/// lowercase letters, digits, and hyphens, not starting or ending with a hyphen.
+///
+/// Control and invisible characters fail this by construction, which is the
+/// case Claude Code v2.1.247 started rejecting on the marketplace side.
+fn is_kebab_case_plugin_name(name: &str) -> bool {
+    !name.starts_with('-')
+        && !name.ends_with('-')
+        && !name.contains("--")
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
 
 pub struct PluginValidator;
 
@@ -174,6 +189,28 @@ impl Validator for PluginValidator {
                     diagnostics.push(diagnostic);
                 }
             }
+        }
+
+        // CC-PL-016: Plugin name is not kebab-case. The manifest reference
+        // documents `name` as a kebab-case identifier with no spaces, and
+        // Claude Code v2.1.247 hardened marketplace handling to reject names
+        // containing control or invisible characters - which this catches as a
+        // subset, before the plugin reaches a marketplace.
+        if config.is_rule_enabled("CC-PL-016")
+            && let Some(name) = raw_value.get("name").and_then(|v| v.as_str())
+            && !name.trim().is_empty()
+            && !is_kebab_case_plugin_name(name)
+        {
+            diagnostics.push(
+                Diagnostic::error(
+                    path.to_path_buf(),
+                    1,
+                    0,
+                    "CC-PL-016",
+                    t!("rules.cc_pl_016.message", name = name),
+                )
+                .with_suggestion(t!("rules.cc_pl_016.suggestion")),
+            );
         }
 
         // CC-PL-007: Invalid component path / CC-PL-008: Component inside .claude-plugin
@@ -2957,5 +2994,72 @@ mod tests {
                 "{manifest} replaces the default `{default_dir}/` and must report CC-PL-015, got: {diagnostics:?}"
             );
         }
+    }
+    // ===== CC-PL-016: plugin name must be kebab-case =====
+
+    /// Validate a manifest at the documented `.claude-plugin/plugin.json`
+    /// location so CC-PL-001 does not fire and mask the name rules.
+    fn validate_manifest(content: &str) -> Vec<Diagnostic> {
+        let temp = TempDir::new().unwrap();
+        let plugin_path = temp.path().join(".claude-plugin").join("plugin.json");
+        write_plugin(&plugin_path, content);
+        PluginValidator.validate(&plugin_path, content, &LintConfig::default())
+    }
+
+    #[test]
+    fn test_cc_pl_016_kebab_case_names_are_valid() {
+        for name in ["my-plugin", "agnix", "a1", "tool-2-name"] {
+            let content = format!(r#"{{"name":"{name}","version":"1.0.0"}}"#);
+            let diagnostics = validate_manifest(&content);
+            assert!(
+                diagnostics.iter().all(|d| d.rule != "CC-PL-016"),
+                "{name} should be accepted, got {diagnostics:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cc_pl_016_flags_non_kebab_case_names() {
+        for name in [
+            "My Plugin",
+            "my_plugin",
+            "MyPlugin",
+            "-leading",
+            "trailing-",
+            "double--hyphen",
+        ] {
+            let content = format!(r#"{{"name":"{name}","version":"1.0.0"}}"#);
+            assert_eq!(
+                validate_manifest(&content)
+                    .iter()
+                    .filter(|d| d.rule == "CC-PL-016")
+                    .count(),
+                1,
+                "expected CC-PL-016 for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cc_pl_016_flags_control_and_invisible_characters() {
+        // Claude Code v2.1.247 rejects marketplace names containing these;
+        // kebab-case excludes them by construction.
+        for name in ["my\u{7}plugin", "my\u{200b}plugin", "my\u{a0}plugin"] {
+            let content = serde_json::json!({"name": name, "version": "1.0.0"}).to_string();
+            assert!(
+                validate_manifest(&content)
+                    .iter()
+                    .any(|d| d.rule == "CC-PL-016"),
+                "expected CC-PL-016 for {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cc_pl_016_empty_name_is_left_to_cc_pl_005() {
+        // CC-PL-005 owns the empty case; reporting both would double-report.
+        let diagnostics = validate_manifest(r#"{"name":"","version":"1.0.0"}"#);
+        assert!(diagnostics.iter().all(|d| d.rule != "CC-PL-016"));
+        assert!(diagnostics.iter().any(|d| d.rule == "CC-PL-005"));
     }
 }

--- a/crates/agnix-lsp/README.md
+++ b/crates/agnix-lsp/README.md
@@ -81,7 +81,7 @@ The extension automatically downloads the `agnix-lsp` binary. See `editors/zed/R
 
 - Real-time diagnostics as you type (via textDocument/didChange)
 - Real-time diagnostics on file open and save
-- Supports all agnix validation rules (451 rules)
+- Supports all agnix validation rules (454 rules)
 - Project-level validation for cross-file rules (AGM-006, XP-004/005/006, VER-001)
 
 - Maps diagnostic severity levels (Error, Warning, Info)

--- a/crates/agnix-lsp/locales/en.yml
+++ b/crates/agnix-lsp/locales/en.yml
@@ -1382,6 +1382,27 @@ rules:
   cc_set_027:
     message: subagentPromptCacheTtl must be 5m or 1h (got %{actual})
     suggestion: Set subagentPromptCacheTtl to 5m or 1h.
+  cc_set_028:
+    message: feedbackDrafts must be notify, quiet, or off (got %{actual})
+    suggestion: Set feedbackDrafts to notify, quiet, or off. It is a string enum, not a boolean.
+  cc_set_029:
+    suggestion: Match the documented spinnerTipsOverride shape - Claude Code drops an invalid tip with a debug warning instead of reporting it.
+    not_object: spinnerTipsOverride must be an object with tips, tipsFile, label, or excludeDefault (got %{actual})
+    unknown_field: spinnerTipsOverride has unknown field '%{field}'
+    label_not_string: spinnerTipsOverride.label must be a string (got %{actual})
+    label_too_long: spinnerTipsOverride.label is %{len} characters, over the %{max} character limit
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault must be a boolean (got %{actual})
+    tips_file_not_string: spinnerTipsOverride.tipsFile must be a string path (got %{actual})
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' is not absolute or ~/-rooted, so Claude Code cannot load it
+    tips_not_array: spinnerTipsOverride.tips must be an array (got %{actual})
+    tip_not_object: spinnerTipsOverride.tips entry %{index} must be a string or an object (got %{actual})
+    tip_id: spinnerTipsOverride.tips entry %{index} needs an 'id' of up to 64 letters, digits, '.', '_', or '-'
+    tip_text: spinnerTipsOverride.tips entry %{index} needs a non-empty 'text' of at most %{max} characters
+    tip_range: spinnerTipsOverride.tips entry %{index} has '%{field}' outside %{min}..%{max}
+    tip_unknown_field: spinnerTipsOverride.tips entry %{index} has unknown field '%{field}'
+  cc_pl_016:
+    message: Plugin name '%{name}' is not kebab-case
+    suggestion: Use lowercase letters, digits, and hyphens only. Claude Code rejects names with control or invisible characters.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -894,6 +894,27 @@ rules:
 # Core - Library messages
 # ===========================================================================
 core:
+  cc_set_028:
+    message: feedbackDrafts debe ser notify, quiet u off (se recibió %{actual})
+    suggestion: Establece feedbackDrafts en notify, quiet u off. Es una cadena enumerada, no un booleano.
+  cc_set_029:
+    suggestion: Usa la forma documentada de spinnerTipsOverride - Claude Code descarta un consejo inválido con un aviso de depuración en lugar de informarlo.
+    not_object: spinnerTipsOverride debe ser un objeto con tips, tipsFile, label o excludeDefault (se recibió %{actual})
+    unknown_field: spinnerTipsOverride tiene el campo desconocido '%{field}'
+    label_not_string: spinnerTipsOverride.label debe ser una cadena (se recibió %{actual})
+    label_too_long: spinnerTipsOverride.label tiene %{len} caracteres, más del límite de %{max}
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault debe ser booleano (se recibió %{actual})
+    tips_file_not_string: spinnerTipsOverride.tipsFile debe ser una ruta en texto (se recibió %{actual})
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' no es absoluta ni empieza por ~/, así que Claude Code no puede cargarla
+    tips_not_array: spinnerTipsOverride.tips debe ser un arreglo (se recibió %{actual})
+    tip_not_object: la entrada %{index} de spinnerTipsOverride.tips debe ser una cadena o un objeto (se recibió %{actual})
+    tip_id: la entrada %{index} de spinnerTipsOverride.tips necesita un 'id' de hasta 64 letras, dígitos, '.', '_' o '-'
+    tip_text: la entrada %{index} de spinnerTipsOverride.tips necesita un 'text' no vacío de hasta %{max} caracteres
+    tip_range: la entrada %{index} de spinnerTipsOverride.tips tiene '%{field}' fuera de %{min}..%{max}
+    tip_unknown_field: la entrada %{index} de spinnerTipsOverride.tips tiene el campo desconocido '%{field}'
+  cc_pl_016:
+    message: El nombre de plugin '%{name}' no está en kebab-case
+    suggestion: Usa solo minúsculas, dígitos y guiones. Claude Code rechaza nombres con caracteres de control o invisibles.
   error:
     file_read: 'Error al leer archivo: %{path}'
     file_write: 'Error al escribir archivo: %{path}'

--- a/crates/agnix-lsp/locales/es.yml
+++ b/crates/agnix-lsp/locales/es.yml
@@ -893,7 +893,6 @@ rules:
 # ===========================================================================
 # Core - Library messages
 # ===========================================================================
-core:
   cc_set_028:
     message: feedbackDrafts debe ser notify, quiet u off (se recibió %{actual})
     suggestion: Establece feedbackDrafts en notify, quiet u off. Es una cadena enumerada, no un booleano.
@@ -915,6 +914,7 @@ core:
   cc_pl_016:
     message: El nombre de plugin '%{name}' no está en kebab-case
     suggestion: Usa solo minúsculas, dígitos y guiones. Claude Code rechaza nombres con caracteres de control o invisibles.
+core:
   error:
     file_read: 'Error al leer archivo: %{path}'
     file_write: 'Error al escribir archivo: %{path}'

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -841,6 +841,27 @@ rules:
 # Core - Library messages
 # ===========================================================================
 core:
+  cc_set_028:
+    message: feedbackDrafts 必须为 notify、quiet 或 off（实际为 %{actual}）
+    suggestion: 将 feedbackDrafts 设置为 notify、quiet 或 off。它是字符串枚举，而不是布尔值。
+  cc_set_029:
+    suggestion: 请遵循 spinnerTipsOverride 的文档结构 - Claude Code 会以调试警告丢弃无效提示，而不会报错。
+    not_object: spinnerTipsOverride 必须是包含 tips、tipsFile、label 或 excludeDefault 的对象（实际为 %{actual}）
+    unknown_field: spinnerTipsOverride 含有未知字段 '%{field}'
+    label_not_string: spinnerTipsOverride.label 必须是字符串（实际为 %{actual}）
+    label_too_long: spinnerTipsOverride.label 有 %{len} 个字符，超过 %{max} 个字符的限制
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault 必须是布尔值（实际为 %{actual}）
+    tips_file_not_string: spinnerTipsOverride.tipsFile 必须是字符串路径（实际为 %{actual}）
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' 不是绝对路径也不以 ~/ 开头，Claude Code 无法加载
+    tips_not_array: spinnerTipsOverride.tips 必须是数组（实际为 %{actual}）
+    tip_not_object: spinnerTipsOverride.tips 第 %{index} 项必须是字符串或对象（实际为 %{actual}）
+    tip_id: spinnerTipsOverride.tips 第 %{index} 项需要 'id'，最多 64 个字母、数字、'.'、'_' 或 '-'
+    tip_text: spinnerTipsOverride.tips 第 %{index} 项需要非空的 'text'，最多 %{max} 个字符
+    tip_range: spinnerTipsOverride.tips 第 %{index} 项的 '%{field}' 超出 %{min}..%{max}
+    tip_unknown_field: spinnerTipsOverride.tips 第 %{index} 项含有未知字段 '%{field}'
+  cc_pl_016:
+    message: 插件名称 '%{name}' 不是 kebab-case
+    suggestion: 只使用小写字母、数字和连字符。Claude Code 会拒绝包含控制字符或不可见字符的名称。
   error:
     file_read: '读取文件失败: %{path}'
     file_write: '写入文件失败: %{path}'

--- a/crates/agnix-lsp/locales/zh-CN.yml
+++ b/crates/agnix-lsp/locales/zh-CN.yml
@@ -840,7 +840,6 @@ rules:
 # ===========================================================================
 # Core - Library messages
 # ===========================================================================
-core:
   cc_set_028:
     message: feedbackDrafts 必须为 notify、quiet 或 off（实际为 %{actual}）
     suggestion: 将 feedbackDrafts 设置为 notify、quiet 或 off。它是字符串枚举，而不是布尔值。
@@ -862,6 +861,7 @@ core:
   cc_pl_016:
     message: 插件名称 '%{name}' 不是 kebab-case
     suggestion: 只使用小写字母、数字和连字符。Claude Code 会拒绝包含控制字符或不可见字符的名称。
+core:
   error:
     file_read: '读取文件失败: %{path}'
     file_write: '写入文件失败: %{path}'

--- a/crates/agnix-rules/rules.json
+++ b/crates/agnix-rules/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 451,
-  "last_updated": "2026-08-25",
+  "total_rules": 454,
+  "last_updated": "2026-08-27",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3040,6 +3040,35 @@
       "bad_example": "{\n  \"commands\": \"./custom-commands\"\n}"
     },
     {
+      "id": "CC-PL-016",
+      "name": "Plugin Name Not Kebab-Case",
+      "severity": "HIGH",
+      "category": "claude-plugins",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://code.claude.com/docs/en/plugins-reference",
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.247"
+        ],
+        "verified_on": "2026-08-27",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.0"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"name\": \"my-plugin\"\n}",
+      "bad_example": "{\n  \"name\": \"My Plugin\"\n}"
+    },
+    {
       "id": "CC-SK-001",
       "name": "Invalid Model Value",
       "severity": "HIGH",
@@ -4405,6 +4434,64 @@
       },
       "good_example": "{\n  \"subagentPromptCacheTtl\": \"5m\"\n}",
       "bad_example": "{\n  \"subagentPromptCacheTtl\": 300\n}"
+    },
+    {
+      "id": "CC-SET-028",
+      "name": "Invalid feedbackDrafts Setting",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.247",
+          "https://code.claude.com/docs/en/settings-reference#feedbackdrafts"
+        ],
+        "verified_on": "2026-08-27",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.247"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"feedbackDrafts\": \"quiet\"\n}",
+      "bad_example": "{\n  \"feedbackDrafts\": false\n}"
+    },
+    {
+      "id": "CC-SET-029",
+      "name": "Invalid spinnerTipsOverride Shape",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.247",
+          "https://code.claude.com/docs/en/settings-reference#spinnertipsoverride"
+        ],
+        "verified_on": "2026-08-27",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.247"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"spinnerTipsOverride\": {\n    \"label\": \"Acme tip\",\n    \"tips\": [\n      \"Run /review before opening a PR\",\n      { \"id\": \"gateway-errors\", \"text\": \"Check the gateway status page first\", \"cooldownSessions\": 5, \"priority\": 2 }\n    ]\n  }\n}",
+      "bad_example": "{\n  \"spinnerTipsOverride\": {\n    \"tips\": [\n      { \"text\": \"Missing an id\", \"cooldownSessions\": 5000 }\n    ]\n  }\n}"
     },
     {
       "id": "CDX-000",
@@ -13090,7 +13177,7 @@
     },
     "claude-plugins": {
       "prefix": "CC-PL",
-      "count": 15,
+      "count": 16,
       "description": "Claude Code Plugins rules"
     },
     "mcp": {
@@ -13245,7 +13332,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 27,
+      "count": 29,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/docs/EDITOR-SETUP.md
+++ b/docs/EDITOR-SETUP.md
@@ -300,6 +300,6 @@ cargo install agnix-lsp
 - Real-time diagnostics as you type
 - Quick-fix code actions for auto-fixable issues
 - Hover documentation for frontmatter fields
-- 451 validation rules
+- 454 validation rules
 - Status bar indicator (VS Code)
 - Syntax highlighting for SKILL.md (VS Code)

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -3,7 +3,7 @@
 Real-time validation for AI agent configuration files in VS Code.
 Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=avifenesh.agnix).
 
-**451 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
+**454 rules** | **Real-time diagnostics** | **Auto-fix** | **Completion** | **Multi-tool support**
 
 
 ## Features
@@ -11,7 +11,7 @@ Install from the [VS Code Marketplace](https://marketplace.visualstudio.com/item
 - **Real-time validation** - Diagnostics as you type
 - **Context-aware completions** - Frontmatter keys, values, and snippets
 - **JSON Schema validation and autocomplete for `.agnix.toml` config files**
-- **Validates 451 rules** - From official specs and best practices
+- **Validates 454 rules** - From official specs and best practices
 
 - **Diagnostics panel** - Sidebar tree view of all issues by file
 - **CodeLens** - Rule info shown inline above problematic lines
@@ -45,7 +45,7 @@ Access via Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | `agnix: Fix All Issues in File` | `Ctrl+Shift+.` | Apply all available fixes |
 | `agnix: Preview Fixes` | - | Browse fixes with diff preview |
 | `agnix: Fix All Safe Issues` | `Ctrl+Alt+.` | Apply only safe fixes |
-| `agnix: Show All Rules` | - | Browse 451 rules by category |
+| `agnix: Show All Rules` | - | Browse 454 rules by category |
 
 | `agnix: Show Rule Documentation` | - | Open docs for a rule (via CodeLens) |
 | `agnix: Ignore Rule in Project` | - | Add rule to `.agnix.toml` disabled list |

--- a/knowledge-base/INDEX.md
+++ b/knowledge-base/INDEX.md
@@ -1,6 +1,6 @@
 # agnix Knowledge Base - Master Index
 
-> 451 validation rules across 40 categories, sourced from 75+ references
+> 454 validation rules across 40 categories, sourced from 75+ references
 
 
 ---
@@ -9,7 +9,7 @@
 
 | What You Need | Start Here |
 |---------------|------------|
-| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 451 rules with detection logic |
+| **Implement validator** | [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 454 rules with detection logic |
 
 | **Understand a standard** | [standards/](#standards) - HARD-RULES files |
 | **Learn best practices** | [standards/](#standards) - OPINIONS files |
@@ -28,7 +28,7 @@
 knowledge-base/
 ├── INDEX.md                        # This file
 ├── README.md                       # Detailed navigation guide
-├── VALIDATION-RULES.md             # Master validation reference (451 rules)
+├── VALIDATION-RULES.md             # Master validation reference (454 rules)
 
 ├── PATTERNS-CATALOG.md             # 70 production-tested patterns
 ├── RESEARCH-TRACKING.md            # Tool inventory and monitoring process
@@ -81,7 +81,7 @@ knowledge-base/
 | **AGENTS.md** | 5 | - | - | 6 rules |
 | **Cursor** | 2 | - | - | 9 rules |
 | **agentsys** | 12 | - | - | 70 patterns |
-| **Total** | **75+** | **117KB** | **160KB** | **451 rules** |
+| **Total** | **75+** | **117KB** | **160KB** | **454 rules** |
 
 
 ### Validation Rules by Category
@@ -96,8 +96,8 @@ knowledge-base/
 | Claude Hooks | 27 | 15 | 7 | 5 | 15 |
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
-| Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 27 | 0 | 26 | 1 | 0 |
+| Claude Plugins | 16 | 10 | 6 | 0 | 4 |
+| Claude Settings | 29 | 0 | 28 | 1 | 0 |
 | Claude Skills | 20 | 10 | 9 | 1 | 10 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -128,7 +128,7 @@ knowledge-base/
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **451** | **215** | **206** | **30** | **124** |
+| **TOTAL** | **454** | **216** | **208** | **30** | **124** |
 
 
 ---
@@ -166,7 +166,7 @@ knowledge-base/
 
 ### For Implementation
 
-**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 451 rules with rule IDs (AS-001, CC-HK-001, etc.)
+**Start here**: [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 454 rules with rule IDs (AS-001, CC-HK-001, etc.)
 
 - Detection pseudocode
 - Auto-fix implementations
@@ -292,7 +292,7 @@ Total Size:           650KB
 Standards Covered:     5 (Agent Skills, MCP, Claude Code, Multi-Platform, Prompt Eng)
 Sources Consulted:    75+ (specs, docs, research papers, repos)
 Research Agents:       5 (10+ sources each)
-Validation Rules:     451 rules
+Validation Rules:     454 rules
 Auto-Fixable Rules:   124 rules
 
 Test Fixtures:        116 files

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -5,7 +5,7 @@
 ## Start Here
 
 - [INDEX.md](./INDEX.md) - Master navigation and summaries
-- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 451 rules with detection logic
+- [VALIDATION-RULES.md](./VALIDATION-RULES.md) - 454 rules with detection logic
 
 - [PATTERNS-CATALOG.md](./PATTERNS-CATALOG.md) - 70 patterns from agentsys
 - [standards/](./standards/) - HARD-RULES and OPINIONS by topic

--- a/knowledge-base/RESEARCH-TRACKING.md
+++ b/knowledge-base/RESEARCH-TRACKING.md
@@ -17,7 +17,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | Claude Code | `CLAUDE.md`, `.claude/settings.json`, `.claude/settings.local.json`, `.claude/managed-settings.json`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `.claude/hooks configuration`, `.mcp.json`, `.claude-plugin/plugin.json`, `.claude/rules/**/*.md`, `.claude/output-styles/*.md` | https://code.claude.com/docs/en | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-27 | CC-SK, CC-HK, CC-MEM, CC-AG, CC-PL, CC-SET, CC-OS, MCP |
-| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex/skills/*/SKILL.md`, `.codex-plugin/plugin.json`, Agent Plugins root `plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-25 | AGM, XP, CDX, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ, CX-SK |
+| Codex CLI | `AGENTS.md`, `.codex/config.toml` (also `.codex/config.json`/`.yaml`), `.codex/skills/*/SKILL.md`, `.codex-plugin/plugin.json`, Agent Plugins root `plugin.json` | https://developers.openai.com/codex/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-27 | AGM, XP, CDX, CDX-AG, CDX-APP, CDX-CFG, CDX-PL, CDX-REQ, CX-SK |
 | OpenCode | `AGENTS.md`, `opencode.json`, `opencode.jsonc`, `.opencode/config.json`, `.opencode/skills/*/SKILL.md` | https://opencode.ai/docs/ | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-25 | AGM, XP, OC, OC-AG, OC-AGM, OC-CFG, OC-DEP, OC-LSP, OC-PM, OC-TUI, OC-SK |
 | Kiro CLI | `.kiro/steering/*.md`, `.kiro/agents/**/*.{json,md}`, `.kiro/hooks/*.kiro.hook`, `.kiro/settings/mcp.json`, `.kiro/settings.json`, `.kiro/powers/*/POWER.md`, `.kiro/skills/*/SKILL.md`, `AGENTS.md` (nested, loaded as steering since 2.18.0) | https://kiro.dev/changelog/cli/ | Automated (tool-release-watch.yml via HTML scrape) | Quarterly | 2026-08-21 | AGM, KIRO, KR-AG, KR-HK, KR-MCP, KR-PW, KR-SK, KR-SET |
 
@@ -26,7 +26,7 @@ Tools are organized by support tier (see [../CONTRIBUTING.md#tool-tier-system](.
 | Tool | Config Format | Documentation URL | Monitoring | Frequency | Last Reviewed | Rule Prefix |
 |------|---------------|-------------------|------------|-----------|---------------|-------------|
 | GitHub Copilot | `.github/copilot-instructions.md`, `.github/instructions/*.instructions.md` | https://docs.github.com/en/copilot/customizing-copilot | Automated (spec-drift.yml + tool-release-watch.yml via microsoft/vscode-copilot-chat) | Weekly | 2026-07-26 | COP |
-| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-24 | CLN, CL-SK |
+| Cline | `.clinerules` (file or dir), `.clinerules/workflows/*.md`, `.clinerules/hooks/*`, `.clinerules/skills/*/SKILL.md`, `.cline/skills/*/SKILL.md` | https://docs.cline.bot/features/cline-rules/overview | Automated (spec-drift.yml + tool-release-watch.yml) | Weekly | 2026-08-27 | CLN, CL-SK |
 | Cursor | `.cursor/rules/**/*.mdc`, `.cursorrules` (legacy), `.cursor/hooks.json`, `.cursor/agents/**/*.md`, `.cursor/environment.json`, `.cursor/mcp.json`, `.cursor/skills/*/SKILL.md` | https://cursor.com/docs/rules | Automated (spec-drift.yml + tool-release-watch.yml via api2.cursor.sh stable update endpoint) | Weekly | 2026-08-27 | CUR, MCP, CR-SK |
 
 ### B Tier (test on significant changes if time permits)
@@ -199,6 +199,8 @@ Tracking community input that influences rule development, tool support decision
 | 2026-08-27 | Claude Code v2.1.246 triage | `keybindings.json` now skips bindings whose action name is unknown and warns under `--debug` | agnix does not validate `keybindings.json` at all; candidate new file type |
 | 2026-08-27 | Cursor MCP doc revision | STDIO table now marks `type` as Required, and documents `envFile` as STDIO-only (remote HTTP/SSE servers do not support it) | agnix infers the transport when `type` is absent and has no rule for `envFile` on a remote server; candidate MCP rules |
 | 2026-08-27 | Cursor hooks doc revision | Per-script options table types `matcher` as `object` while every example in the same document uses a string | Upstream doc inconsistency; CUR-017 deliberately leaves `matcher` unvalidated until it is resolved |
+| 2026-08-27 | Codex CLI rust-v0.150.0 triage | New `Interrupt` hook event runs commands or MCP handlers when a top-level turn is interrupted | agnix validates Codex hook shape (CDX-PL-013) but has no hook event-name allowlist, so nothing false-positives and nothing catches a typo either; candidate rule |
+| 2026-08-27 | Claude Code v2.1.247 triage | `spinnerVerbs` takes an object with a `verbs` array and `mode` of `append` or `replace` | No rule covers it, same class as the new CC-SET-029; candidate CC-SET rule |
 
 ---
 

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -556,7 +556,7 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 <a id="cc-set-029"></a>
 
 ### CC-SET-029 [MEDIUM] Invalid spinnerTipsOverride Shape
-**Requirement**: `spinnerTipsOverride` MUST be an object limited to `tips`, `tipsFile`, `label`, and `excludeDefault`. Each `tips` entry is a plain string or an object with a required `id` (up to 64 letters, digits, `.`, `_`, `-`) and `text` (up to 500 characters), plus optional `cooldownSessions` (0-1000) and `priority` (-10-10). `tipsFile` MUST be absolute or `~/`-rooted, and `label` at most 40 characters.
+**Requirement**: `spinnerTipsOverride` MUST be an object limited to `tips`, `tipsFile`, `label`, and `excludeDefault`. Each `tips` entry is a plain string or an object with a required `id` (up to 64 letters, digits, `.`, `_`, `-`) and `text` (up to 500 characters), plus optional `cooldownSessions` (0-1000) and `priority` (-10-10). A plain string is read as a tip whose text is the string itself, so it MUST satisfy the same non-empty, 500-character limit. `tipsFile` MUST be absolute or `~/`-rooted, and `label` at most 40 characters.
 **Detection**: Parse settings JSON, then check the object's fields and each tip entry against the documented shape and limits.
 **Fix**: Manual - Claude Code drops an invalid tip with a debug warning instead of reporting it, so the tip is simply never shown.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.247, code.claude.com/docs/en/settings-reference#spinnertipsoverride

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -545,6 +545,18 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 **Fix**: Manual - choose `5m` or `1h`.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.243, code.claude.com/docs/en/settings-reference#subagentpromptcachettl
 
+### CC-SET-028 [MEDIUM] Invalid feedbackDrafts Setting
+**Requirement**: `feedbackDrafts` MUST be the string `notify`, `quiet`, or `off` when present in Claude Code 2.1.247+. It is a string enum, not a boolean; `off` removes the SendFeedback tool.
+**Detection**: Parse settings JSON and flag non-string values or strings outside the documented enum.
+**Fix**: Manual - choose `notify`, `quiet`, or `off`.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.247, code.claude.com/docs/en/settings-reference#feedbackdrafts
+
+### CC-SET-029 [MEDIUM] Invalid spinnerTipsOverride Shape
+**Requirement**: `spinnerTipsOverride` MUST be an object limited to `tips`, `tipsFile`, `label`, and `excludeDefault`. Each `tips` entry is a plain string or an object with a required `id` (up to 64 letters, digits, `.`, `_`, `-`) and `text` (up to 500 characters), plus optional `cooldownSessions` (0-1000) and `priority` (-10-10). `tipsFile` MUST be absolute or `~/`-rooted, and `label` at most 40 characters.
+**Detection**: Parse settings JSON, then check the object's fields and each tip entry against the documented shape and limits.
+**Fix**: Manual - Claude Code drops an invalid tip with a debug warning instead of reporting it, so the tip is simply never shown.
+**Source**: github.com/anthropics/claude-code/releases/tag/v2.1.247, code.claude.com/docs/en/settings-reference#spinnertipsoverride
+
 ---
 
 ## PER-CLIENT SKILL RULES
@@ -1392,6 +1404,13 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 ## MCP RULES
 
 <a id="mcp-001"></a>
+
+### CC-PL-016 [HIGH] Plugin Name Not Kebab-Case
+**Requirement**: A plugin manifest `name` MUST be a kebab-case identifier - lowercase letters, digits, and hyphens, with no spaces, no leading or trailing hyphen, and no doubled hyphen.
+**Detection**: Read `name` from `.claude-plugin/plugin.json` and flag any character outside the documented set. Control and invisible characters fail by construction, which is what Claude Code 2.1.247 hardened marketplace handling to reject.
+**Fix**: Manual - rename the plugin.
+**Source**: code.claude.com/docs/en/plugins-reference, github.com/anthropics/claude-code/releases/tag/v2.1.247
+
 ### MCP-001 [HIGH] Invalid JSON-RPC Version
 **Requirement**: MUST use JSON-RPC 2.0
 **Detection**: `message.jsonrpc != "2.0"`
@@ -3606,8 +3625,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Claude Hooks | 27 | 15 | 7 | 5 | 15 |
 | Claude Memory | 13 | 8 | 5 | 0 | 3 |
 | Claude Output Styles | 6 | 2 | 2 | 2 | 0 |
-| Claude Plugins | 15 | 9 | 6 | 0 | 4 |
-| Claude Settings | 27 | 0 | 26 | 1 | 0 |
+| Claude Plugins | 16 | 10 | 6 | 0 | 4 |
+| Claude Settings | 29 | 0 | 28 | 1 | 0 |
 | Claude Skills | 20 | 10 | 9 | 1 | 10 |
 | Cline | 7 | 4 | 3 | 0 | 3 |
 | Cline Skills | 3 | 2 | 1 | 0 | 2 |
@@ -3638,7 +3657,7 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 | Windsurf | 4 | 1 | 2 | 1 | 0 |
 | Windsurf Skills | 1 | 0 | 1 | 0 | 1 |
 | XML | 3 | 3 | 0 | 0 | 3 |
-| **TOTAL** | **451** | **215** | **206** | **30** | **124** |
+| **TOTAL** | **454** | **216** | **208** | **30** | **124** |
 
 
 ---
@@ -3668,8 +3687,8 @@ pub fn validate_skill(path: &Path, content: &str) -> Vec<Diagnostic> {
 
 ---
 
-**Total Coverage**: 451 validation rules across 40 categories
+**Total Coverage**: 454 validation rules across 40 categories
 
 **Knowledge Base**: 11,036 lines, 320KB, 75+ sources
-**Certainty**: 215 HIGH, 206 MEDIUM, 30 LOW
+**Certainty**: 216 HIGH, 208 MEDIUM, 30 LOW
 **Auto-Fixable**: 124 rules (27%)

--- a/knowledge-base/VALIDATION-RULES.md
+++ b/knowledge-base/VALIDATION-RULES.md
@@ -545,11 +545,15 @@ Rules are active by default. Deprecated rules should include `status`, `deprecat
 **Fix**: Manual - choose `5m` or `1h`.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.243, code.claude.com/docs/en/settings-reference#subagentpromptcachettl
 
+<a id="cc-set-028"></a>
+
 ### CC-SET-028 [MEDIUM] Invalid feedbackDrafts Setting
 **Requirement**: `feedbackDrafts` MUST be the string `notify`, `quiet`, or `off` when present in Claude Code 2.1.247+. It is a string enum, not a boolean; `off` removes the SendFeedback tool.
 **Detection**: Parse settings JSON and flag non-string values or strings outside the documented enum.
 **Fix**: Manual - choose `notify`, `quiet`, or `off`.
 **Source**: github.com/anthropics/claude-code/releases/tag/v2.1.247, code.claude.com/docs/en/settings-reference#feedbackdrafts
+
+<a id="cc-set-029"></a>
 
 ### CC-SET-029 [MEDIUM] Invalid spinnerTipsOverride Shape
 **Requirement**: `spinnerTipsOverride` MUST be an object limited to `tips`, `tipsFile`, `label`, and `excludeDefault`. Each `tips` entry is a plain string or an object with a required `id` (up to 64 letters, digits, `.`, `_`, `-`) and `text` (up to 500 characters), plus optional `cooldownSessions` (0-1000) and `priority` (-10-10). `tipsFile` MUST be absolute or `~/`-rooted, and `label` at most 40 characters.
@@ -1401,15 +1405,18 @@ Output-style files (`.claude/output-styles/*.md` or `~/.claude/output-styles/*.m
 
 ---
 
-## MCP RULES
-
-<a id="mcp-001"></a>
+<a id="cc-pl-016"></a>
 
 ### CC-PL-016 [HIGH] Plugin Name Not Kebab-Case
 **Requirement**: A plugin manifest `name` MUST be a kebab-case identifier - lowercase letters, digits, and hyphens, with no spaces, no leading or trailing hyphen, and no doubled hyphen.
 **Detection**: Read `name` from `.claude-plugin/plugin.json` and flag any character outside the documented set. Control and invisible characters fail by construction, which is what Claude Code 2.1.247 hardened marketplace handling to reject.
 **Fix**: Manual - rename the plugin.
 **Source**: code.claude.com/docs/en/plugins-reference, github.com/anthropics/claude-code/releases/tag/v2.1.247
+
+## MCP RULES
+
+<a id="mcp-001"></a>
+
 
 ### MCP-001 [HIGH] Invalid JSON-RPC Version
 **Requirement**: MUST use JSON-RPC 2.0

--- a/knowledge-base/rules.json
+++ b/knowledge-base/rules.json
@@ -1,8 +1,8 @@
 {
   "description": "Machine-readable source of truth for all validation rules. When adding a new rule, add it here AND in VALIDATION-RULES.md. CI parity tests enforce sync.",
   "version": "1.1.0",
-  "total_rules": 451,
-  "last_updated": "2026-08-25",
+  "total_rules": 454,
+  "last_updated": "2026-08-27",
   "schema": {
     "evidence": {
       "source_type": "spec|vendor_docs|vendor_code|paper|community",
@@ -3040,6 +3040,35 @@
       "bad_example": "{\n  \"commands\": \"./custom-commands\"\n}"
     },
     {
+      "id": "CC-PL-016",
+      "name": "Plugin Name Not Kebab-Case",
+      "severity": "HIGH",
+      "category": "claude-plugins",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://code.claude.com/docs/en/plugins-reference",
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.247"
+        ],
+        "verified_on": "2026-08-27",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.0"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"name\": \"my-plugin\"\n}",
+      "bad_example": "{\n  \"name\": \"My Plugin\"\n}"
+    },
+    {
       "id": "CC-SK-001",
       "name": "Invalid Model Value",
       "severity": "HIGH",
@@ -4405,6 +4434,64 @@
       },
       "good_example": "{\n  \"subagentPromptCacheTtl\": \"5m\"\n}",
       "bad_example": "{\n  \"subagentPromptCacheTtl\": 300\n}"
+    },
+    {
+      "id": "CC-SET-028",
+      "name": "Invalid feedbackDrafts Setting",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.247",
+          "https://code.claude.com/docs/en/settings-reference#feedbackdrafts"
+        ],
+        "verified_on": "2026-08-27",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.247"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"feedbackDrafts\": \"quiet\"\n}",
+      "bad_example": "{\n  \"feedbackDrafts\": false\n}"
+    },
+    {
+      "id": "CC-SET-029",
+      "name": "Invalid spinnerTipsOverride Shape",
+      "severity": "MEDIUM",
+      "category": "claude-settings",
+      "evidence": {
+        "source_type": "vendor_docs",
+        "source_urls": [
+          "https://github.com/anthropics/claude-code/releases/tag/v2.1.247",
+          "https://code.claude.com/docs/en/settings-reference#spinnertipsoverride"
+        ],
+        "verified_on": "2026-08-27",
+        "applies_to": {
+          "tool": "claude-code",
+          "version_range": ">=2.1.247"
+        },
+        "normative_level": "MUST",
+        "tests": {
+          "unit": true,
+          "fixtures": false,
+          "e2e": false
+        }
+      },
+      "fix": {
+        "autofix": false
+      },
+      "good_example": "{\n  \"spinnerTipsOverride\": {\n    \"label\": \"Acme tip\",\n    \"tips\": [\n      \"Run /review before opening a PR\",\n      { \"id\": \"gateway-errors\", \"text\": \"Check the gateway status page first\", \"cooldownSessions\": 5, \"priority\": 2 }\n    ]\n  }\n}",
+      "bad_example": "{\n  \"spinnerTipsOverride\": {\n    \"tips\": [\n      { \"text\": \"Missing an id\", \"cooldownSessions\": 5000 }\n    ]\n  }\n}"
     },
     {
       "id": "CDX-000",
@@ -13090,7 +13177,7 @@
     },
     "claude-plugins": {
       "prefix": "CC-PL",
-      "count": 15,
+      "count": 16,
       "description": "Claude Code Plugins rules"
     },
     "mcp": {
@@ -13245,7 +13332,7 @@
     },
     "claude-settings": {
       "prefix": "CC-SET",
-      "count": 27,
+      "count": 29,
       "description": "Claude Code settings (.claude/settings.json) rules"
     },
     "gemini-agents": {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1382,6 +1382,27 @@ rules:
   cc_set_027:
     message: subagentPromptCacheTtl must be 5m or 1h (got %{actual})
     suggestion: Set subagentPromptCacheTtl to 5m or 1h.
+  cc_set_028:
+    message: feedbackDrafts must be notify, quiet, or off (got %{actual})
+    suggestion: Set feedbackDrafts to notify, quiet, or off. It is a string enum, not a boolean.
+  cc_set_029:
+    suggestion: Match the documented spinnerTipsOverride shape - Claude Code drops an invalid tip with a debug warning instead of reporting it.
+    not_object: spinnerTipsOverride must be an object with tips, tipsFile, label, or excludeDefault (got %{actual})
+    unknown_field: spinnerTipsOverride has unknown field '%{field}'
+    label_not_string: spinnerTipsOverride.label must be a string (got %{actual})
+    label_too_long: spinnerTipsOverride.label is %{len} characters, over the %{max} character limit
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault must be a boolean (got %{actual})
+    tips_file_not_string: spinnerTipsOverride.tipsFile must be a string path (got %{actual})
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' is not absolute or ~/-rooted, so Claude Code cannot load it
+    tips_not_array: spinnerTipsOverride.tips must be an array (got %{actual})
+    tip_not_object: spinnerTipsOverride.tips entry %{index} must be a string or an object (got %{actual})
+    tip_id: spinnerTipsOverride.tips entry %{index} needs an 'id' of up to 64 letters, digits, '.', '_', or '-'
+    tip_text: spinnerTipsOverride.tips entry %{index} needs a non-empty 'text' of at most %{max} characters
+    tip_range: spinnerTipsOverride.tips entry %{index} has '%{field}' outside %{min}..%{max}
+    tip_unknown_field: spinnerTipsOverride.tips entry %{index} has unknown field '%{field}'
+  cc_pl_016:
+    message: Plugin name '%{name}' is not kebab-case
+    suggestion: Use lowercase letters, digits, and hyphens only. Claude Code rejects names with control or invisible characters.
   cc_hk_028:
     message: Command hook at %{location} uses '${user_config.*}' interpolation, which Claude Code 2.1.207+ rejects at
       load time as a shell-injection fix

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -894,6 +894,27 @@ rules:
 # Core - Library messages
 # ===========================================================================
 core:
+  cc_set_028:
+    message: feedbackDrafts debe ser notify, quiet u off (se recibió %{actual})
+    suggestion: Establece feedbackDrafts en notify, quiet u off. Es una cadena enumerada, no un booleano.
+  cc_set_029:
+    suggestion: Usa la forma documentada de spinnerTipsOverride - Claude Code descarta un consejo inválido con un aviso de depuración en lugar de informarlo.
+    not_object: spinnerTipsOverride debe ser un objeto con tips, tipsFile, label o excludeDefault (se recibió %{actual})
+    unknown_field: spinnerTipsOverride tiene el campo desconocido '%{field}'
+    label_not_string: spinnerTipsOverride.label debe ser una cadena (se recibió %{actual})
+    label_too_long: spinnerTipsOverride.label tiene %{len} caracteres, más del límite de %{max}
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault debe ser booleano (se recibió %{actual})
+    tips_file_not_string: spinnerTipsOverride.tipsFile debe ser una ruta en texto (se recibió %{actual})
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' no es absoluta ni empieza por ~/, así que Claude Code no puede cargarla
+    tips_not_array: spinnerTipsOverride.tips debe ser un arreglo (se recibió %{actual})
+    tip_not_object: la entrada %{index} de spinnerTipsOverride.tips debe ser una cadena o un objeto (se recibió %{actual})
+    tip_id: la entrada %{index} de spinnerTipsOverride.tips necesita un 'id' de hasta 64 letras, dígitos, '.', '_' o '-'
+    tip_text: la entrada %{index} de spinnerTipsOverride.tips necesita un 'text' no vacío de hasta %{max} caracteres
+    tip_range: la entrada %{index} de spinnerTipsOverride.tips tiene '%{field}' fuera de %{min}..%{max}
+    tip_unknown_field: la entrada %{index} de spinnerTipsOverride.tips tiene el campo desconocido '%{field}'
+  cc_pl_016:
+    message: El nombre de plugin '%{name}' no está en kebab-case
+    suggestion: Usa solo minúsculas, dígitos y guiones. Claude Code rechaza nombres con caracteres de control o invisibles.
   error:
     file_read: 'Error al leer archivo: %{path}'
     file_write: 'Error al escribir archivo: %{path}'

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -893,7 +893,6 @@ rules:
 # ===========================================================================
 # Core - Library messages
 # ===========================================================================
-core:
   cc_set_028:
     message: feedbackDrafts debe ser notify, quiet u off (se recibió %{actual})
     suggestion: Establece feedbackDrafts en notify, quiet u off. Es una cadena enumerada, no un booleano.
@@ -915,6 +914,7 @@ core:
   cc_pl_016:
     message: El nombre de plugin '%{name}' no está en kebab-case
     suggestion: Usa solo minúsculas, dígitos y guiones. Claude Code rechaza nombres con caracteres de control o invisibles.
+core:
   error:
     file_read: 'Error al leer archivo: %{path}'
     file_write: 'Error al escribir archivo: %{path}'

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -841,6 +841,27 @@ rules:
 # Core - Library messages
 # ===========================================================================
 core:
+  cc_set_028:
+    message: feedbackDrafts 必须为 notify、quiet 或 off（实际为 %{actual}）
+    suggestion: 将 feedbackDrafts 设置为 notify、quiet 或 off。它是字符串枚举，而不是布尔值。
+  cc_set_029:
+    suggestion: 请遵循 spinnerTipsOverride 的文档结构 - Claude Code 会以调试警告丢弃无效提示，而不会报错。
+    not_object: spinnerTipsOverride 必须是包含 tips、tipsFile、label 或 excludeDefault 的对象（实际为 %{actual}）
+    unknown_field: spinnerTipsOverride 含有未知字段 '%{field}'
+    label_not_string: spinnerTipsOverride.label 必须是字符串（实际为 %{actual}）
+    label_too_long: spinnerTipsOverride.label 有 %{len} 个字符，超过 %{max} 个字符的限制
+    exclude_default_not_bool: spinnerTipsOverride.excludeDefault 必须是布尔值（实际为 %{actual}）
+    tips_file_not_string: spinnerTipsOverride.tipsFile 必须是字符串路径（实际为 %{actual}）
+    tips_file_relative: spinnerTipsOverride.tipsFile '%{path}' 不是绝对路径也不以 ~/ 开头，Claude Code 无法加载
+    tips_not_array: spinnerTipsOverride.tips 必须是数组（实际为 %{actual}）
+    tip_not_object: spinnerTipsOverride.tips 第 %{index} 项必须是字符串或对象（实际为 %{actual}）
+    tip_id: spinnerTipsOverride.tips 第 %{index} 项需要 'id'，最多 64 个字母、数字、'.'、'_' 或 '-'
+    tip_text: spinnerTipsOverride.tips 第 %{index} 项需要非空的 'text'，最多 %{max} 个字符
+    tip_range: spinnerTipsOverride.tips 第 %{index} 项的 '%{field}' 超出 %{min}..%{max}
+    tip_unknown_field: spinnerTipsOverride.tips 第 %{index} 项含有未知字段 '%{field}'
+  cc_pl_016:
+    message: 插件名称 '%{name}' 不是 kebab-case
+    suggestion: 只使用小写字母、数字和连字符。Claude Code 会拒绝包含控制字符或不可见字符的名称。
   error:
     file_read: '读取文件失败: %{path}'
     file_write: '写入文件失败: %{path}'

--- a/locales/zh-CN.yml
+++ b/locales/zh-CN.yml
@@ -840,7 +840,6 @@ rules:
 # ===========================================================================
 # Core - Library messages
 # ===========================================================================
-core:
   cc_set_028:
     message: feedbackDrafts 必须为 notify、quiet 或 off（实际为 %{actual}）
     suggestion: 将 feedbackDrafts 设置为 notify、quiet 或 off。它是字符串枚举，而不是布尔值。
@@ -862,6 +861,7 @@ core:
   cc_pl_016:
     message: 插件名称 '%{name}' 不是 kebab-case
     suggestion: 只使用小写字母、数字和连字符。Claude Code 会拒绝包含控制字符或不可见字符的名称。
+core:
   error:
     file_read: '读取文件失败: %{path}'
     file_write: '写入文件失败: %{path}'

--- a/npm/README.md
+++ b/npm/README.md
@@ -2,7 +2,7 @@
 
 Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.
 
-**451 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
+**454 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
 
 ## Installation
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agnix",
   "version": "0.51.0",
-  "description": "Lint agent configurations before they break your workflow. 451 rules for Skills, Hooks, MCP, Memory, Plugins.",
+  "description": "Lint agent configurations before they break your workflow. 454 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",
     "email": "aviarchi1994@gmail.com",

--- a/plugin/commands/agnix.md
+++ b/plugin/commands/agnix.md
@@ -1,6 +1,6 @@
 ---
 description: Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP', or mentions 'agent config issues', 'skill validation'.
-codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 451 rules across 10+ AI tools.'
+codex-description: 'Use when user asks to "lint agent configs", "validate skills", "check CLAUDE.md", "validate hooks", "lint MCP". Validates agent configuration files against 454 rules across 10+ AI tools.'
 argument-hint: "[path] [--fix] [--strict] [--target [target]]"
 allowed-tools: Task, Read
 ---

--- a/plugin/skills/agnix/SKILL.md
+++ b/plugin/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 451 rules across 10+ AI tools."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 454 rules across 10+ AI tools."
 argument-hint: "[path] [--fix] [--strict] [--target=claude-code|cursor|codex]"
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---

--- a/pypi/README.md
+++ b/pypi/README.md
@@ -2,7 +2,7 @@
 
 Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.
 
-**451 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
+**454 rules** | **Real-time validation** | **Auto-fix** | **Multi-tool support**
 
 ## Installation
 

--- a/skills/agnix/SKILL.md
+++ b/skills/agnix/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agnix
-description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 451 rules."
+description: "Use when user asks to 'lint agent configs', 'validate skills', 'check CLAUDE.md', 'validate hooks', 'lint MCP'. Validates agent configuration files against 454 rules."
 allowed-tools: Bash(agnix:*), Bash(cargo:*), Read, Glob, Grep
 ---
 

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -9,7 +9,7 @@ Contributions are welcome and appreciated.
 
 ## Found something off?
 
-agnix validates against 451 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
+agnix validates against 454 rules, but the agent config ecosystem moves fast. If a rule is wrong, missing, or too noisy, I want to know.
 
 - [Report a bug](https://github.com/agent-sh/agnix/issues/new)
 - [Request a rule](https://github.com/agent-sh/agnix/issues/new)

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -73,6 +73,6 @@ GitHub Copilot validation is enabled by default and can be targeted in config wi
 ## Next steps
 
 - [Configuration](./configuration.md) - customize rules with `.agnix.toml`
-- [Rules Reference](./rules/index.md) - browse all 451 rules
+- [Rules Reference](./rules/index.md) - browse all 454 rules
 - [Editor Integration](./editor-integration.md) - get diagnostics in your editor
 - [Troubleshooting](./troubleshooting.md) - common issues and fixes

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 title: Introduction
 slug: /
-description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 451 rules, auto-fix, and editor integration."
+description: "agnix validates AI agent configuration files across Claude Code, Cursor, Copilot, MCP, and AGENTS.md. 454 rules, auto-fix, and editor integration."
 ---
 
 # agnix
@@ -14,7 +14,7 @@ npx agnix .
 
 ## What it does
 
-- **Validates** configuration files against 451 rules derived from official specs and real-world testing
+- **Validates** configuration files against 454 rules derived from official specs and real-world testing
 - **Auto-fixes** common issues with `--fix`
 - **Integrates** with VS Code, Neovim, JetBrains, and Zed via the LSP server
 - **Runs in your browser** - [try the playground](/playground) with zero install
@@ -24,6 +24,6 @@ npx agnix .
 
 - [Playground](/playground) - try it now, no install needed
 - [Getting Started](./getting-started.md) - install and run in 60 seconds
-- [Rules Reference](./rules/index.md) - browse all 451 validation rules
+- [Rules Reference](./rules/index.md) - browse all 454 validation rules
 - [Configuration](./configuration.md) - customize with `.agnix.toml`
 - [Editor Integration](./editor-integration.md) - set up real-time diagnostics

--- a/website/docs/rules/generated/cc-pl-016.md
+++ b/website/docs/rules/generated/cc-pl-016.md
@@ -1,0 +1,53 @@
+---
+id: cc-pl-016
+title: "CC-PL-016: Plugin Name Not Kebab-Case - Claude Plugins"
+sidebar_label: "CC-PL-016"
+description: "agnix rule CC-PL-016 checks for plugin name not kebab-case in claude plugins files. Severity: HIGH. See examples and fix guidance."
+keywords: ["CC-PL-016", "plugin name not kebab-case", "claude plugins", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-PL-016`
+- **Severity**: `HIGH`
+- **Category**: `Claude Plugins`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-08-27`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.0`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://code.claude.com/docs/en/plugins-reference
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.247
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "name": "My Plugin"
+}
+```
+
+### Valid
+
+```json
+{
+  "name": "my-plugin"
+}
+```

--- a/website/docs/rules/generated/cc-set-028.md
+++ b/website/docs/rules/generated/cc-set-028.md
@@ -1,0 +1,53 @@
+---
+id: cc-set-028
+title: "CC-SET-028: Invalid feedbackDrafts Setting - Claude Settings"
+sidebar_label: "CC-SET-028"
+description: "agnix rule CC-SET-028 checks for invalid feedbackdrafts setting in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-028", "invalid feedbackdrafts setting", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-028`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-08-27`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.247`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.247
+- https://code.claude.com/docs/en/settings-reference#feedbackdrafts
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "feedbackDrafts": false
+}
+```
+
+### Valid
+
+```json
+{
+  "feedbackDrafts": "quiet"
+}
+```

--- a/website/docs/rules/generated/cc-set-029.md
+++ b/website/docs/rules/generated/cc-set-029.md
@@ -1,0 +1,63 @@
+---
+id: cc-set-029
+title: "CC-SET-029: Invalid spinnerTipsOverride Shape"
+sidebar_label: "CC-SET-029"
+description: "agnix rule CC-SET-029 checks for invalid spinnertipsoverride shape in claude settings files. Severity: MEDIUM. See examples and fix guidance."
+keywords: ["CC-SET-029", "invalid spinnertipsoverride shape", "claude settings", "validation", "agnix", "linter"]
+---
+
+## Summary
+
+- **Rule ID**: `CC-SET-029`
+- **Severity**: `MEDIUM`
+- **Category**: `Claude Settings`
+- **Normative Level**: `MUST`
+- **Auto-Fix**: `No`
+- **Verified On**: `2026-08-27`
+
+## Applicability
+
+- **Tool**: `claude-code`
+- **Version Range**: `>=2.1.247`
+- **Spec Revision**: `unspecified`
+
+## Evidence Sources
+
+- https://github.com/anthropics/claude-code/releases/tag/v2.1.247
+- https://code.claude.com/docs/en/settings-reference#spinnertipsoverride
+
+## Test Coverage Metadata
+
+- Unit tests: `true`
+- Fixture tests: `false`
+- E2E tests: `false`
+
+## Examples
+
+The following examples demonstrate what triggers this rule and how to fix it.
+
+### Invalid
+
+```json
+{
+  "spinnerTipsOverride": {
+    "tips": [
+      { "text": "Missing an id", "cooldownSessions": 5000 }
+    ]
+  }
+}
+```
+
+### Valid
+
+```json
+{
+  "spinnerTipsOverride": {
+    "label": "Acme tip",
+    "tips": [
+      "Run /review before opening a PR",
+      { "id": "gateway-errors", "text": "Check the gateway status page first", "cooldownSessions": 5, "priority": 2 }
+    ]
+  }
+}
+```

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -1,6 +1,6 @@
 # Rules Reference
 
-This section contains all `451` validation rules generated from `knowledge-base/rules.json`.
+This section contains all `454` validation rules generated from `knowledge-base/rules.json`.
 `124` rules have automatic fixes.
 
 | Rule | Name | Severity | Category | Auto-Fix |
@@ -109,6 +109,7 @@ This section contains all `451` validation rules generated from `knowledge-base/
 | [CC-PL-013](./generated/cc-pl-013.md) | Channel Missing Server Reference | MEDIUM | Claude Plugins | No |
 | [CC-PL-014](./generated/cc-pl-014.md) | Plugin Agent Unsupported Field | MEDIUM | Claude Plugins | Yes (safe) |
 | [CC-PL-015](./generated/cc-pl-015.md) | Default Component Folder Shadowed by Manifest | MEDIUM | Claude Plugins | No |
+| [CC-PL-016](./generated/cc-pl-016.md) | Plugin Name Not Kebab-Case | HIGH | Claude Plugins | No |
 | [CC-SK-001](./generated/cc-sk-001.md) | Invalid Model Value | HIGH | Claude Skills | Yes (unsafe) |
 | [CC-SK-002](./generated/cc-sk-002.md) | Invalid Context Value | HIGH | Claude Skills | Yes (unsafe) |
 | [CC-SK-004](./generated/cc-sk-004.md) | Agent Without Context | HIGH | Claude Skills | Yes (unsafe) |
@@ -156,6 +157,8 @@ This section contains all `451` validation rules generated from `knowledge-base/
 | [CC-SET-025](./generated/cc-set-025.md) | Invalid modelPicker Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-026](./generated/cc-set-026.md) | Invalid promptCacheTtl Setting | MEDIUM | Claude Settings | No |
 | [CC-SET-027](./generated/cc-set-027.md) | Invalid subagentPromptCacheTtl Setting | MEDIUM | Claude Settings | No |
+| [CC-SET-028](./generated/cc-set-028.md) | Invalid feedbackDrafts Setting | MEDIUM | Claude Settings | No |
+| [CC-SET-029](./generated/cc-set-029.md) | Invalid spinnerTipsOverride Shape | MEDIUM | Claude Settings | No |
 | [CDX-000](./generated/cdx-000.md) | TOML Parse Error | HIGH | Codex CLI | No |
 | [CDX-001](./generated/cdx-001.md) | Invalid Approval Mode | HIGH | Codex CLI | Yes (unsafe) |
 | [CDX-002](./generated/cdx-002.md) | Invalid Full Auto Error Mode | HIGH | Codex CLI | Yes (unsafe) |

--- a/website/src/data/siteData.json
+++ b/website/src/data/siteData.json
@@ -1,5 +1,5 @@
 {
-  "totalRules": 451,
+  "totalRules": 454,
   "categoryCount": 40,
   "autofixCount": 124,
   "uniqueTools": [


### PR DESCRIPTION
Closes #1435, closes #1436, closes #1437.

Triaged all three against their upstream sources. Claude Code v2.1.247 needed real work; the other two are baseline-only with the reasoning recorded rather than assumed.

## Fixed: two documented tools reported as invalid

`KNOWN_AGENT_TOOLS` had not been refreshed since 2026-07-31, so **CC-AG-009/010 flagged valid configs**:

| Tool | Added upstream |
|---|---|
| `ListAgents` | Claude Code v2.1.224 |
| `SendFeedback` | Claude Code v2.1.238 |

An agent listing either in `tools:` or `disallowedTools:` got "invalid tool name". Diffed the entire list against the live tools reference - these were the only two missing. Regression test added.

## Added: three rules for this release's contracts

**CC-SET-028 - `feedbackDrafts`.** Governs the new SendFeedback tool. It is a string enum (`notify`, `quiet`, `off`), and `off` removes the tool entirely. A boolean is the natural wrong guess and silently leaves the default `notify` in place.

> Worth flagging: the watcher's own GLM triage proposed *"non-boolean `feedbackDrafts`"*. The settings reference says string enum. The contract here came from the doc, not the summary - the triage output is a lead, not a spec.

**CC-SET-029 - `spinnerTipsOverride`.** v2.1.247 added tip objects (`id`, `text`, `cooldownSessions`, `priority`), `tipsFile`, and `label`. The doc is explicit that Claude Code *"drops an invalid entry with a debug warning instead of rejecting the settings file"* - so a malformed tip is simply never shown, which is precisely the silent-failure class agnix exists to catch. Validates the object's fields, each entry (string or object), the documented `id`/`text` limits, the `0`-`1000` and `-10`-`10` ranges, the 40-char `label` cap, and that `tipsFile` is absolute or `~/`-rooted.

**CC-PL-016 - plugin name kebab-case.** The plugin reference documents `name` as "kebab-case, no spaces". v2.1.247 hardened marketplace handling to reject names with control or invisible characters; those fail kebab-case by construction, so this catches them before a plugin reaches a marketplace. CC-PL-005 keeps the empty-name case, so the two never double-report (test asserts this).

Rule count 451 -> 454.

## Baselines

| Tool | From | To |
|---|---|---|
| Claude Code | `v2.1.246` | `v2.1.247` |
| Cline | `v4.1.15` | `v4.1.16` |
| Codex CLI | `rust-v0.149.1` | `rust-v0.150.0` |

- **Cline** moves hook workspace resolution from shared global state in `~/.cline` to the VS Code window. Runtime behaviour, not a validated file contract.
- **Codex** adds an `Interrupt` hook event. CDX-PL-013 validates hook *shape* with no event-name allowlist, so nothing false-positives - and nothing catches a typo either. Recorded in RESEARCH-TRACKING, along with the still-uncovered `spinnerVerbs` setting.

## Verification

- `cargo test --workspace` - 4171 core + all suites green
- `cargo test -p agnix-cli --test rule_parity` - 20 passed
- Kiro S-tier gate - 5 passed
- `agnix eval tests/eval.yaml` - **61/61**
- `agnix .` self-lint - no issues
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` - clean
- `cargo fmt --check --all` - clean
- `sync-rule-bookkeeping --check`, `check-rule-counts.py`, `check-locale-sync.sh` - all in sync (locales updated in all 3 languages across all 3 crates)