### PR TITLE
feat(pre-commit): let pre-commit install agnix itself

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   name: agnix
   description: Lint AI agent configuration files
   entry: agnix
-  language: system
+  language: python
   types: [file]
   files: |
     (?x)^(
@@ -25,7 +25,7 @@
   name: agnix (with auto-fix)
   description: Lint and auto-fix AI agent configuration files
   entry: agnix
-  language: system
+  language: python
   types: [file]
   files: |
     (?x)^(
@@ -53,7 +53,7 @@
     fails the commit if the working tree is dirty afterward. Override the
     target path with `args: [--output=<path>, --fix]`.
   entry: agnix schema
-  language: system
+  language: python
   pass_filenames: false
   always_run: true
   args: [--fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **pre-commit hooks install agnix themselves**
+  ([#1439](https://github.com/agent-sh/agnix/issues/1439)). The three hooks in
+  `.pre-commit-hooks.yaml` move from `language: system` to `language: python`,
+  so `pre-commit` and `prek` create a virtualenv and pull the `agnix` wheel that
+  matches the pinned `rev` instead of requiring a manual `cargo install` on
+  PATH. This is what the new PyPI distribution makes possible. A root
+  `pyproject.toml` exists solely for that install: pre-commit clones the repo
+  and `pip install .`s it, so the clone has to be pip-installable, and this shim
+  declares the matching `agnix==<version>` as its only dependency.
+  `scripts/sync-versions.sh` moves the shim's version and its pin together, so a
+  hook pinned at `rev: vX.Y.Z` always runs agnix X.Y.Z. Platforms without a
+  wheel can still pin `language: system` in their own config, which the
+  configuration guide now documents.
+
 ### Added
 - **CC-SET-028: invalid `feedbackDrafts` setting**
   ([#1435](https://github.com/agent-sh/agnix/issues/1435)). Claude Code v2.1.247

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -462,10 +462,14 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/agent-sh/agnix
-    rev: v0.37.5
+    rev: v0.51.0
     hooks:
       - id: agnix
 ```
+
+pre-commit installs agnix itself: the hooks use `language: python`, so it
+creates a virtualenv and pulls the `agnix` wheel matching the `rev` you pinned.
+Nothing needs to be on your PATH.
 
 ### Available Hooks
 
@@ -479,15 +483,30 @@ repos:
 ```yaml
 repos:
   - repo: https://github.com/agent-sh/agnix
-    rev: v0.37.5
+    rev: v0.51.0
     hooks:
       - id: agnix-fix
 ```
 
 ### Requirements
 
-The `agnix` binary must be installed and available in PATH:
+Python 3.9 or newer, which pre-commit already needs. The hook environment
+installs the `agnix` wheel for your platform, so there is nothing to install by
+hand.
+
+Wheels cover Linux x86_64 (glibc and musl), Linux aarch64, macOS Apple silicon,
+and Windows x86_64. On any other platform, pin the binary yourself and switch
+the hook to a locally installed agnix:
 
 ```bash
 cargo install agnix-cli
+```
+
+```yaml
+repos:
+  - repo: https://github.com/agent-sh/agnix
+    rev: v0.51.0
+    hooks:
+      - id: agnix
+        language: system
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -462,7 +462,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/agent-sh/agnix
-    rev: v0.51.0
+    rev: v0.52.0
     hooks:
       - id: agnix
 ```
@@ -470,6 +470,9 @@ repos:
 pre-commit installs agnix itself: the hooks use `language: python`, so it
 creates a virtualenv and pulls the `agnix` wheel matching the `rev` you pinned.
 Nothing needs to be on your PATH.
+
+This needs `rev: v0.52.0` or later. Earlier tags ship `language: system` hooks,
+which require an `agnix` already on your PATH.
 
 ### Available Hooks
 
@@ -483,7 +486,7 @@ Nothing needs to be on your PATH.
 ```yaml
 repos:
   - repo: https://github.com/agent-sh/agnix
-    rev: v0.51.0
+    rev: v0.52.0
     hooks:
       - id: agnix-fix
 ```
@@ -505,7 +508,7 @@ cargo install agnix-cli
 ```yaml
 repos:
   - repo: https://github.com/agent-sh/agnix
-    rev: v0.51.0
+    rev: v0.52.0
     hooks:
       - id: agnix
         language: system

--- a/pypi/test/test_build_wheels.py
+++ b/pypi/test/test_build_wheels.py
@@ -211,20 +211,45 @@ class WheelTests(unittest.TestCase):
             self.assertEqual(first, second)
 
 
+def workspace_version() -> str:
+    cargo = (bw.REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    section = cargo.split("[workspace.package]", 1)[1]
+    return next(
+        line.split('"')[1]
+        for line in section.splitlines()
+        if line.startswith("version = ")
+    )
+
+
 class VersionTests(unittest.TestCase):
     def test_pyproject_matches_workspace_version(self):
-        cargo = (bw.REPO_ROOT / "Cargo.toml").read_text(encoding="utf-8")
-        section = cargo.split("[workspace.package]", 1)[1]
-        workspace_version = next(
-            line.split('"')[1]
-            for line in section.splitlines()
-            if line.startswith("version = ")
-        )
+        workspace_version_local = workspace_version()
         meta = bw.read_metadata(bw.PYPI_DIR / "pyproject.toml")
-        self.assertEqual(meta["version"], workspace_version)
+        self.assertEqual(meta["version"], workspace_version_local)
 
         init = (bw.PYPI_DIR / "agnix" / "__init__.py").read_text(encoding="utf-8")
-        self.assertIn(f'__version__ = "{workspace_version}"', init)
+        self.assertIn(f'__version__ = "{workspace_version_local}"', init)
+
+    def test_precommit_shim_pins_the_workspace_version(self):
+        # The root pyproject.toml exists only so `pre-commit`'s `language: python`
+        # hooks can pip-install the clone. Its contract is that a hook pinned at
+        # `rev: vX.Y.Z` runs agnix X.Y.Z, which holds only while both its own
+        # version and its `agnix==` pin track the workspace version. Every other
+        # manifest in the repo has a drift guard; this is that guard.
+        expected = workspace_version()
+        shim = bw.read_metadata(bw.REPO_ROOT / "pyproject.toml")
+
+        self.assertEqual(shim["version"], expected)
+        self.assertEqual(
+            shim["dependencies"],
+            [f"agnix=={expected}"],
+            "the pre-commit shim must pin exactly the agnix version it ships with",
+        )
+        self.assertNotEqual(
+            shim["name"],
+            "agnix",
+            "the shim must not share the published package's name",
+        )
 
     def test_version_mismatch_is_rejected(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+# Installed by `pre-commit`, not published to PyPI.
+#
+# A `language: python` hook makes pre-commit clone this repository at the
+# pinned rev, create a virtualenv, and `pip install .` from this directory.
+# That is the only reason a Rust project has a root pyproject.toml: it turns
+# the clone into something pip can install, whose single dependency is the
+# real `agnix` wheel from PyPI. pre-commit then finds the `agnix` binary the
+# wheel puts in the venv's scripts directory, so `entry: agnix` resolves
+# without the user installing anything by hand.
+#
+# The dependency is pinned exactly to this repository's version so a hook
+# pinned at `rev: vX.Y.Z` always runs agnix X.Y.Z. `scripts/sync-versions.sh`
+# keeps both numbers in step.
+#
+# The package under `pypi/` is the published one. This is a shim, and its
+# name is deliberately different so the two can never collide on PyPI.
+[project]
+name = "agnix-pre-commit"
+version = "0.51.0"
+description = "pre-commit shim that installs the agnix wheel. Not published to PyPI."
+requires-python = ">=3.9"
+dependencies = ["agnix==0.51.0"]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+# No Python code of its own: the dependency provides the binary.
+[tool.setuptools]
+py-modules = []

--- a/scripts/sync-versions.sh
+++ b/scripts/sync-versions.sh
@@ -60,6 +60,15 @@ if [ -f npm/package.json ]; then
   echo "  npm/package.json -> $VERSION"
 fi
 
+# pre-commit shim at the repo root. Both the version and the pinned dependency
+# must move together: a hook pinned at rev vX.Y.Z installs agnix X.Y.Z.
+if [ -f pyproject.toml ]; then
+  sed -i.bak "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" pyproject.toml
+  sed -i.bak "s/^dependencies = \[\"agnix==[^\"]*\"\]/dependencies = [\"agnix==$VERSION\"]/" pyproject.toml
+  rm -f pyproject.toml.bak
+  echo "  pyproject.toml -> $VERSION"
+fi
+
 # PyPI wrapper
 if [ -f pypi/pyproject.toml ]; then
   sed -i.bak "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" pypi/pyproject.toml


### PR DESCRIPTION
Closes #1439.

The three hooks move from `language: system` to `language: python`, so `pre-commit` and `prek` create a virtualenv and install the `agnix` wheel matching the pinned `rev` - instead of failing unless the user already ran `cargo install agnix-cli`. Publishing to PyPI (#1431) is what made this possible, and @pygarap filed this the same day.

## Why a Rust repo now has a root `pyproject.toml`

A `language: python` hook makes pre-commit clone the repo and `pip install .` from its **root**, so the clone has to be pip-installable. The root `pyproject.toml` is a shim with no Python code of its own:

```toml
[project]
name = "agnix-pre-commit"
version = "0.51.0"
dependencies = ["agnix==0.51.0"]
```

Named differently from the published `agnix` so the two can never collide, and never published itself. The wheel puts the binary in the venv's scripts directory, which is exactly where `entry: agnix` resolves. This mirrors how other Rust tools do it (ruff's mirror repo), just in-repo rather than as a separate mirror.

`scripts/sync-versions.sh` moves the shim's version **and** its `agnix==` pin together, so `rev: vX.Y.Z` always runs agnix X.Y.Z rather than drifting to latest. Verified both lines move by syncing to a throwaway version and back.

## Verified end to end, not just by inspection

Scratch repo, `pre-commit 4.6.2`, hook repo pinned at this commit:

```
agnix ....................... Failed   # 2 warnings under --strict, correctly non-zero
agnix (with auto-fix) ....... Passed
agnix-schema ................ Passed
```

This machine already has `agnix` on PATH at `~/.cargo/bin/agnix`, so "it ran" alone would prove nothing. Checking the hook environment:

```
$ .../py_env-python3.12/bin/pip list | grep agnix
agnix            0.51.0
agnix-pre-commit 0.51.0

$ readlink -f .../py_env-python3.12/bin/agnix
/home/.../py_env-python3.12/bin/agnix        # a real 9.6MB binary, not the cargo one
```

The venv holds its own binary from the PyPI wheel; PATH was not consulted.

## Platform caveat, documented

Wheels cover Linux x86_64 (glibc + musl), Linux aarch64, macOS Apple silicon, and Windows x86_64. Intel macOS has no release binary, so `docs/CONFIGURATION.md` now documents pinning `language: system` in your own config as the fallback - and drops the stale `rev: v0.37.5` examples while it is there.