### PR TITLE
release: v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-08-27
+
 ### Changed
 - **pre-commit hooks install agnix themselves**
   ([#1439](https://github.com/agent-sh/agnix/issues/1439)). The three hooks in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -99,14 +99,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -33,8 +33,8 @@ categories = ["development-tools", "command-line-utilities"]
 [workspace.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.51.0" }
-agnix-core = { path = "crates/agnix-core", version = "0.51.0" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.52.0" }
+agnix-core = { path = "crates/agnix-core", version = "0.52.0" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.agnix
 pluginName = agnix
 pluginRepositoryUrl = https://github.com/agent-sh/agnix
 # SemVer format -> https://semver.org
-pluginVersion = 0.51.0
+pluginVersion = 0.52.0
 
 # Supported build number ranges and IntelliJ Platform Versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.51.0"
+version = "0.52.0"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "Lint agent configurations before they break your workflow. 454 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",

--- a/pypi/agnix/__init__.py
+++ b/pypi/agnix/__init__.py
@@ -13,7 +13,7 @@ import sysconfig
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-__version__ = "0.51.0"
+__version__ = "0.52.0"
 
 __all__ = ["AgnixError", "binary_path", "lint", "run", "version", "__version__"]
 

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnix"
-version = "0.51.0"
+version = "0.52.0"
 description = "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@
 # name is deliberately different so the two can never collide on PyPI.
 [project]
 name = "agnix-pre-commit"
-version = "0.51.0"
+version = "0.52.0"
 description = "pre-commit shim that installs the agnix wheel. Not published to PyPI."
 requires-python = ">=3.9"
-dependencies = ["agnix==0.51.0"]
+dependencies = ["agnix==0.52.0"]
 
 [build-system]
 requires = ["setuptools>=61"]


### PR DESCRIPTION
Cuts v0.52.0. Tag after merge to trigger the release workflow.

## Contents

**Added** - rule count 451 -> 454, all from the Claude Code v2.1.247 triage (#1435)
- `CC-SET-028` - `feedbackDrafts` is a string enum (`notify`/`quiet`/`off`), not the boolean it reads like
- `CC-SET-029` - `spinnerTipsOverride` shape; Claude Code drops an invalid tip with only a debug warning, so a malformed tip is silently never shown
- `CC-PL-016` - plugin `name` must be kebab-case, which also covers the control/invisible characters v2.1.247 started rejecting

**Fixed**
- `ListAgents` and `SendFeedback` were flagged as unknown tools by CC-AG-009/010 - `KNOWN_AGENT_TOOLS` had not been refreshed since 2026-07-31 (#1435)
- Tool-release triage posted raw changelogs instead of summaries: an expired `GLM_API_KEY` and, behind it, reasoning tokens sharing the 4096-token output budget with the answer (#1438)

**Changed**
- pre-commit hooks use `language: python`, so `rev: v0.52.0` installs the matching wheel with nothing on PATH (#1439). **This is the first tag where the documented snippet works as written** - v0.51.0 and earlier ship `language: system`, which is why the docs pin v0.52.0.
- Tool baselines: Claude Code `v2.1.247`, Cline `v4.1.16`, Codex CLI `rust-v0.150.0`, plus Cursor and amp from the earlier batch (#1426, #1427, #1428, #1429, #1436, #1437)

## Version sync

`scripts/sync-versions.sh` propagated `0.52.0` to npm, PyPI, the pre-commit shim, VS Code (+lock), JetBrains, Zed, and the plugin manifest. The shim's `agnix==0.52.0` pin moved with its version - confirmed by the CI guard added in #1441, which fails if the two ever drift.

## Local verification

- `cargo check --workspace` - clean
- `cargo fmt --check --all` - clean
- `python3 -m unittest discover -s pypi/test` - 26 passed, including the shim pin guard now reading `agnix==0.52.0`
- `sync-rule-bookkeeping --check` and `check-rule-counts.py` - in sync at 454

Full matrix, clippy, eval, and self-lint run in CI here and again in the release workflow before anything publishes.

## Post-merge

Tag `v0.52.0` -> build (5 targets) -> release -> crates.io / npm / PyPI / VS Code / JetBrains / Zed. PyPI's second run; the first (v0.51.0) published five wheels cleanly.