### PR TITLE
fix(pre-commit): match every path agnix itself validates

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,12 +17,47 @@
       plugin\.json|
       mcp\.json|
       [^/]+\.mcp\.json|
-      \.claude/settings\.json|
-      \.claude/settings\.local\.json|
+      mcp-[^/]+\.json|
+      opencode\.jsonc?|
+      gemini-extension\.json|
+      \.geminiignore|
+      \.cursorrules(\.md)?|
+      \.clinerules(/.+)?|
+      \.roorules|
+      \.roomodes|
+      \.rooignore|
+      \.windsurfrules|
+      \.claude/settings(\.local)?\.json|
+      \.claude/managed-settings\.json|
       \.claude/agents/.+\.md|
+      \.claude/rules/.+\.md|
+      \.claude/output-styles/[^/]+\.md|
       \.github/copilot-instructions\.md|
       \.github/instructions/.+\.instructions\.md|
-      \.cursor/rules/.+\.mdc?
+      \.github/agents/[^/]+\.agent\.md|
+      \.github/prompts/[^/]+\.prompt\.md|
+      \.github/hooks/hooks\.json|
+      \.github/workflows/copilot-setup-steps\.ya?ml|
+      \.cursor/rules/.+\.mdc?|
+      \.cursor/agents/.+\.md|
+      \.cursor/(.+/)?hooks\.json|
+      \.cursor/environment\.json|
+      \.cursor/[^/]+\.mdc?|
+      \.codex/config\.(toml|json|ya?ml)|
+      \.codex/requirements\.toml|
+      \.gemini/settings(\.local)?\.json|
+      \.gemini/agents/[^/]+\.md|
+      \.amp/settings(\.local)?\.json|
+      \.agents/(checks|skills)/.+\.md|
+      \.roo/rules[^/]*/.+\.md|
+      \.windsurf/(rules|workflows)/.+\.md|
+      \.windsurf/[^/]+\.md|
+      \.kiro/steering/.+\.md|
+      \.kiro/[^/]+\.md|
+      \.kiro/agents/.+|
+      \.kiro/hooks/[^/]+\.kiro\.hook|
+      \.kiro/settings/[^/]+\.json|
+      \.kiro/powers/.+/POWER\.md
     )$
   args: [--strict]
 
@@ -45,12 +80,47 @@
       plugin\.json|
       mcp\.json|
       [^/]+\.mcp\.json|
-      \.claude/settings\.json|
-      \.claude/settings\.local\.json|
+      mcp-[^/]+\.json|
+      opencode\.jsonc?|
+      gemini-extension\.json|
+      \.geminiignore|
+      \.cursorrules(\.md)?|
+      \.clinerules(/.+)?|
+      \.roorules|
+      \.roomodes|
+      \.rooignore|
+      \.windsurfrules|
+      \.claude/settings(\.local)?\.json|
+      \.claude/managed-settings\.json|
       \.claude/agents/.+\.md|
+      \.claude/rules/.+\.md|
+      \.claude/output-styles/[^/]+\.md|
       \.github/copilot-instructions\.md|
       \.github/instructions/.+\.instructions\.md|
-      \.cursor/rules/.+\.mdc?
+      \.github/agents/[^/]+\.agent\.md|
+      \.github/prompts/[^/]+\.prompt\.md|
+      \.github/hooks/hooks\.json|
+      \.github/workflows/copilot-setup-steps\.ya?ml|
+      \.cursor/rules/.+\.mdc?|
+      \.cursor/agents/.+\.md|
+      \.cursor/(.+/)?hooks\.json|
+      \.cursor/environment\.json|
+      \.cursor/[^/]+\.mdc?|
+      \.codex/config\.(toml|json|ya?ml)|
+      \.codex/requirements\.toml|
+      \.gemini/settings(\.local)?\.json|
+      \.gemini/agents/[^/]+\.md|
+      \.amp/settings(\.local)?\.json|
+      \.agents/(checks|skills)/.+\.md|
+      \.roo/rules[^/]*/.+\.md|
+      \.windsurf/(rules|workflows)/.+\.md|
+      \.windsurf/[^/]+\.md|
+      \.kiro/steering/.+\.md|
+      \.kiro/[^/]+\.md|
+      \.kiro/agents/.+|
+      \.kiro/hooks/[^/]+\.kiro\.hook|
+      \.kiro/settings/[^/]+\.json|
+      \.kiro/powers/.+/POWER\.md
     )$
   args: [--fix]
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,19 +5,24 @@
   language: python
   types: [file]
   files: |
-    (?x)^(
+    (?x)^(?:.*/)?(
       SKILL\.md|
       CLAUDE\.md|
       CLAUDE\.local\.md|
       AGENTS\.md|
       AGENTS\.local\.md|
       AGENTS\.override\.md|
+      GEMINI\.md|
+      GEMINI\.local\.md|
+      plugin\.json|
+      mcp\.json|
+      [^/]+\.mcp\.json|
       \.claude/settings\.json|
       \.claude/settings\.local\.json|
-      \.claude/agents/.*\.md|
-      .*\.mcp\.json|
+      \.claude/agents/[^/]+\.md|
       \.github/copilot-instructions\.md|
-      \.cursor/rules/.*\.mdc
+      \.github/instructions/.+\.instructions\.md|
+      \.cursor/rules/.+\.mdc
     )$
   args: [--strict]
 
@@ -28,19 +33,24 @@
   language: python
   types: [file]
   files: |
-    (?x)^(
+    (?x)^(?:.*/)?(
       SKILL\.md|
       CLAUDE\.md|
       CLAUDE\.local\.md|
       AGENTS\.md|
       AGENTS\.local\.md|
       AGENTS\.override\.md|
+      GEMINI\.md|
+      GEMINI\.local\.md|
+      plugin\.json|
+      mcp\.json|
+      [^/]+\.mcp\.json|
       \.claude/settings\.json|
       \.claude/settings\.local\.json|
-      \.claude/agents/.*\.md|
-      .*\.mcp\.json|
+      \.claude/agents/[^/]+\.md|
       \.github/copilot-instructions\.md|
-      \.cursor/rules/.*\.mdc
+      \.github/instructions/.+\.instructions\.md|
+      \.cursor/rules/.+\.mdc
     )$
   args: [--fix]
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -30,13 +30,14 @@
       \.claude/settings(\.local)?\.json|
       \.claude/managed-settings\.json|
       \.claude/agents/.+\.md|
+      agents/[^/]+(/[^/]+)?\.md|
       \.claude/rules/.+\.md|
       \.claude/output-styles/[^/]+\.md|
       \.github/copilot-instructions\.md|
       \.github/instructions/.+\.instructions\.md|
       \.github/agents/[^/]+\.agent\.md|
       \.github/prompts/[^/]+\.prompt\.md|
-      \.github/hooks/hooks\.json|
+      hooks/hooks\.json|
       \.github/workflows/copilot-setup-steps\.ya?ml|
       \.cursor/rules/.+\.mdc?|
       \.cursor/agents/.+\.md|
@@ -44,7 +45,7 @@
       \.cursor/environment\.json|
       \.cursor/[^/]+\.mdc?|
       \.codex/config\.(toml|json|ya?ml)|
-      \.codex/requirements\.toml|
+      [Cc]odex/requirements\.toml|
       \.gemini/settings(\.local)?\.json|
       \.gemini/agents/[^/]+\.md|
       \.amp/settings(\.local)?\.json|
@@ -57,6 +58,7 @@
       \.kiro/agents/.+|
       \.kiro/hooks/[^/]+\.kiro\.hook|
       \.kiro/settings/[^/]+\.json|
+      \.kiro/settings\.json|
       \.kiro/powers/.+/POWER\.md
     )$
   args: [--strict]
@@ -93,13 +95,14 @@
       \.claude/settings(\.local)?\.json|
       \.claude/managed-settings\.json|
       \.claude/agents/.+\.md|
+      agents/[^/]+(/[^/]+)?\.md|
       \.claude/rules/.+\.md|
       \.claude/output-styles/[^/]+\.md|
       \.github/copilot-instructions\.md|
       \.github/instructions/.+\.instructions\.md|
       \.github/agents/[^/]+\.agent\.md|
       \.github/prompts/[^/]+\.prompt\.md|
-      \.github/hooks/hooks\.json|
+      hooks/hooks\.json|
       \.github/workflows/copilot-setup-steps\.ya?ml|
       \.cursor/rules/.+\.mdc?|
       \.cursor/agents/.+\.md|
@@ -107,7 +110,7 @@
       \.cursor/environment\.json|
       \.cursor/[^/]+\.mdc?|
       \.codex/config\.(toml|json|ya?ml)|
-      \.codex/requirements\.toml|
+      [Cc]odex/requirements\.toml|
       \.gemini/settings(\.local)?\.json|
       \.gemini/agents/[^/]+\.md|
       \.amp/settings(\.local)?\.json|
@@ -120,6 +123,7 @@
       \.kiro/agents/.+|
       \.kiro/hooks/[^/]+\.kiro\.hook|
       \.kiro/settings/[^/]+\.json|
+      \.kiro/settings\.json|
       \.kiro/powers/.+/POWER\.md
     )$
   args: [--fix]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -19,10 +19,10 @@
       [^/]+\.mcp\.json|
       \.claude/settings\.json|
       \.claude/settings\.local\.json|
-      \.claude/agents/[^/]+\.md|
+      \.claude/agents/.+\.md|
       \.github/copilot-instructions\.md|
       \.github/instructions/.+\.instructions\.md|
-      \.cursor/rules/.+\.mdc
+      \.cursor/rules/.+\.mdc?
     )$
   args: [--strict]
 
@@ -47,10 +47,10 @@
       [^/]+\.mcp\.json|
       \.claude/settings\.json|
       \.claude/settings\.local\.json|
-      \.claude/agents/[^/]+\.md|
+      \.claude/agents/.+\.md|
       \.github/copilot-instructions\.md|
       \.github/instructions/.+\.instructions\.md|
-      \.cursor/rules/.+\.mdc
+      \.cursor/rules/.+\.mdc?
     )$
   args: [--fix]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SKILL\.md` matched only a repository-root SKILL.md - a skill at its normal
   `.claude/skills/<name>/SKILL.md` location, a nested `AGENTS.md`, a plugin
   manifest, or a scoped Copilot instruction file never reached agnix, and the
-  hook reported Passed with nothing validated. The pattern now mirrors
-  `file_types/detection.rs`: filename-based entries (`SKILL.md`, the
-  `CLAUDE.md`/`AGENTS.md` variants, `GEMINI.md`/`GEMINI.local.md`,
-  `plugin.json`, `mcp.json`, `*.mcp.json`) match at any depth via a shared
-  `(?:.*/)?` prefix, and `.github/instructions/**/*.instructions.md` joins the
-  path-scoped entries. `.cursor/rules/**/*.md` is now passed alongside `.mdc`
-  so CUR-020 can flag plain-markdown rules Cursor silently ignores, and nested
-  subagent files under `.claude/agents/` keep their coverage. Verified end to end: a repo with a nested skill, a
+  hook reported Passed with nothing validated. The pattern now covers
+  every tool-scoped path shape `file_types/detection.rs` recognizes: the
+  filename-based entries (`SKILL.md`, the `CLAUDE.md`/`AGENTS.md` variants,
+  `GEMINI.md`, `plugin.json`, `mcp.json`, `*.mcp.json`, `mcp-*.json`,
+  `opencode.json{,c}`, `gemini-extension.json`, the `.cursorrules`,
+  `.clinerules`, `.roorules`/`.roomodes`/`.rooignore`, and `.windsurfrules`
+  legacy files) match at any depth via a shared `(?:.*/)?` prefix, and the
+  `.claude`, `.github`, `.cursor`, `.codex`, `.gemini`, `.amp`, `.agents`,
+  `.roo`, `.windsurf`, and `.kiro` directory surfaces are enumerated -
+  including `.cursor/rules/**/*.md` so CUR-020 can flag plain-markdown rules
+  Cursor silently ignores. Verified against the 150 concrete paths in
+  `detection.rs`'s own tests; the only remaining exclusions are deliberate:
+  detection's loose fallback arms outside a tool directory (a bare
+  `settings.json`, `hooks.json`, `environment.json`, `POWER.md`, or
+  `requirements.toml` anywhere), uppercase directory spellings, and generic
+  markdown. Verified end to end: a repo with a nested skill, a
   package-level AGENTS.md, GEMINI.md, and a scoped instruction file - all
   invisible to the old pattern - now produces their diagnostics through the
   hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CLAUDE.md`/`AGENTS.md` variants, `GEMINI.md`/`GEMINI.local.md`,
   `plugin.json`, `mcp.json`, `*.mcp.json`) match at any depth via a shared
   `(?:.*/)?` prefix, and `.github/instructions/**/*.instructions.md` joins the
-  path-scoped entries. Verified end to end: a repo with a nested skill, a
+  path-scoped entries. `.cursor/rules/**/*.md` is now passed alongside `.mdc`
+  so CUR-020 can flag plain-markdown rules Cursor silently ignores, and nested
+  subagent files under `.claude/agents/` keep their coverage. Verified end to end: a repo with a nested skill, a
   package-level AGENTS.md, GEMINI.md, and a scoped instruction file - all
   invisible to the old pattern - now produces their diagnostics through the
   hook.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **pre-commit hooks skipped nearly every file agnix validates**
+  ([#1444](https://github.com/agent-sh/agnix/issues/1444),
+  [#1445](https://github.com/agent-sh/agnix/issues/1445)). The `files:` pattern
+  in `.pre-commit-hooks.yaml` was `^(...)$`-anchored with root-level entries, so
+  `SKILL\.md` matched only a repository-root SKILL.md - a skill at its normal
+  `.claude/skills/<name>/SKILL.md` location, a nested `AGENTS.md`, a plugin
+  manifest, or a scoped Copilot instruction file never reached agnix, and the
+  hook reported Passed with nothing validated. The pattern now mirrors
+  `file_types/detection.rs`: filename-based entries (`SKILL.md`, the
+  `CLAUDE.md`/`AGENTS.md` variants, `GEMINI.md`/`GEMINI.local.md`,
+  `plugin.json`, `mcp.json`, `*.mcp.json`) match at any depth via a shared
+  `(?:.*/)?` prefix, and `.github/instructions/**/*.instructions.md` joins the
+  path-scoped entries. Verified end to end: a repo with a nested skill, a
+  package-level AGENTS.md, GEMINI.md, and a scoped instruction file - all
+  invisible to the old pattern - now produces their diagnostics through the
+  hook.
+
 ## [0.52.0] - 2026-08-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.claude`, `.github`, `.cursor`, `.codex`, `.gemini`, `.amp`, `.agents`,
   `.roo`, `.windsurf`, and `.kiro` directory surfaces are enumerated -
   including `.cursor/rules/**/*.md` so CUR-020 can flag plain-markdown rules
-  Cursor silently ignores. Verified against the 150 concrete paths in
-  `detection.rs`'s own tests; the only remaining exclusions are deliberate:
-  detection's loose fallback arms outside a tool directory (a bare
-  `settings.json`, `hooks.json`, `environment.json`, `POWER.md`, or
-  `requirements.toml` anywhere), uppercase directory spellings, and generic
-  markdown. Verified end to end: a repo with a nested skill, a
+  Cursor silently ignores. Also covers plugin
+  `hooks/hooks.json` at any root, bare `agents/` directories (which detection
+  validates as agent configs, `agents/README.md` included), `.kiro/settings.json`,
+  and the undotted `codex/requirements.toml` system surface - while deliberately
+  not matching `.codex/requirements.toml`, which Codex does not read. Verified
+  against the 149 concrete paths in `detection.rs`'s own tests; the only
+  remaining exclusions are deliberate: detection's loose fallback arms outside a
+  tool directory (a bare `settings.json`, `hooks.json`, `environment.json`,
+  `POWER.md`, or `requirements.toml` anywhere), uppercase directory spellings,
+  and generic markdown. Verified end to end: a repo with a nested skill, a
   package-level AGENTS.md, GEMINI.md, and a scoped instruction file - all
   invisible to the old pattern - now produces their diagnostics through the
   hook.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -462,7 +462,7 @@ Add to `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/agent-sh/agnix
-    rev: v0.52.0
+    rev: v0.52.1
     hooks:
       - id: agnix
 ```
@@ -471,7 +471,7 @@ pre-commit installs agnix itself: the hooks use `language: python`, so it
 creates a virtualenv and pulls the `agnix` wheel matching the `rev` you pinned.
 Nothing needs to be on your PATH.
 
-This needs `rev: v0.52.0` or later. Earlier tags ship `language: system` hooks,
+This needs `rev: v0.52.0` or later for the self-installing hooks, and `rev: v0.52.1` or later for full file coverage. Earlier tags ship `language: system` hooks,
 which require an `agnix` already on your PATH.
 
 ### Available Hooks
@@ -486,7 +486,7 @@ which require an `agnix` already on your PATH.
 ```yaml
 repos:
   - repo: https://github.com/agent-sh/agnix
-    rev: v0.52.0
+    rev: v0.52.1
     hooks:
       - id: agnix-fix
 ```
@@ -508,7 +508,7 @@ cargo install agnix-cli
 ```yaml
 repos:
   - repo: https://github.com/agent-sh/agnix
-    rev: v0.52.0
+    rev: v0.52.1
     hooks:
       - id: agnix
         language: system

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -471,7 +471,7 @@ pre-commit installs agnix itself: the hooks use `language: python`, so it
 creates a virtualenv and pulls the `agnix` wheel matching the `rev` you pinned.
 Nothing needs to be on your PATH.
 
-This needs `rev: v0.52.0` or later for the self-installing hooks, and `rev: v0.52.1` or later for full file coverage. Earlier tags ship `language: system` hooks,
+This needs `rev: v0.52.0` or later for the self-installing hooks, and `rev: v0.52.1` or later to cover every tool-scoped config path (see the hook file list). Earlier tags ship `language: system` hooks,
 which require an `agnix` already on your PATH.
 
 ### Available Hooks


### PR DESCRIPTION
Closes #1444, closes #1445.

Both issues are the same underlying gap. The hooks' `files:` pattern was `^(...)$`-anchored with root-level entries, so `SKILL\.md` matched only a repository-root SKILL.md. A skill at its normal `.claude/skills/<name>/SKILL.md` location, a nested `AGENTS.md`, a plugin manifest, a client-path `mcp.json`, or a scoped Copilot instruction file **never reached agnix - the hook reported Passed while validating nothing.**

## The fix mirrors agnix's own detector

`file_types/detection.rs` recognizes these filenames at any depth, so the hook now does too via a shared `(?:.*/)?` prefix:

| Entry | Status |
|---|---|
| `SKILL.md`, `CLAUDE[.local].md`, `AGENTS[.local/.override].md` | now any depth |
| `GEMINI.md`, `GEMINI.local.md` | **new** (#1445) |
| `plugin.json` | **new** (#1444) |
| `mcp.json` | **new** - previously only `*.mcp.json` matched (#1444) |
| `.github/instructions/**/*.instructions.md` | **new** (#1445) |
| `.github/copilot-instructions.md`, `.claude/settings*`, `.claude/agents/*.md`, `.cursor/rules/*.mdc` | kept; depth-crossing `.*` tightened to `[^/]+`/`.+` |

Matching `plugin.json` anywhere is deliberate: agnix's own directory walk treats any `plugin.json` as a plugin manifest, so the hook now agrees with `agnix .` rather than being quieter than it.

## Verified two ways

**Pattern semantics** - evaluated exactly as pre-commit does (Python `re.search` on the relative path): 29 representative paths match, 10 near-misses stay excluded (`README.md`, bare `settings.json`, `SKILL.md.bak`, `.cursor/rules/style.md`, `.github/instructions/notes.md`, ...).

**End to end** - pre-commit 4.6.2 against a repo holding a nested skill with a bad name, a package-level `AGENTS.md`, `GEMINI.md`, and a scoped instruction file missing frontmatter. All four were invisible to the old pattern; the hook now fails with their real diagnostics:

```
.github/instructions/api.instructions.md:1:0 error: Scoped Copilot instruction file missing required frontmatter
.claude/skills/review/SKILL.md:2:1 error: Name 'Review-Code' must be ...
GEMINI.md:1:0 warning: Missing project context section
packages/web/AGENTS.md:1:0 warning: Missing project context section
Found 2 errors, 2 warnings
```

Docs examples move to `rev: v0.52.1`, the first tag that will carry this pattern; the version note now distinguishes v0.52.0 (self-installing hooks) from v0.52.1 (full file coverage).