### PR TITLE
release: v0.52.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.1] - 2026-08-27
+
 ### Fixed
 - **pre-commit hooks skipped nearly every file agnix validates**
   ([#1444](https://github.com/agent-sh/agnix/issues/1444),

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agnix-cli"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -35,7 +35,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-core"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-lsp"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "agnix-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agnix-mcp"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "agnix-core",
  "agnix-rules",
@@ -99,14 +99,14 @@ dependencies = [
 
 [[package]]
 name = "agnix-rules"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "agnix-wasm"
-version = "0.52.0"
+version = "0.52.1"
 dependencies = [
  "agnix-core",
  "console_error_panic_hook",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.52.0"
+version = "0.52.1"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -33,8 +33,8 @@ categories = ["development-tools", "command-line-utilities"]
 [workspace.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 # Internal crates - path for local dev, version for crates.io
-agnix-rules = { path = "crates/agnix-rules", version = "0.52.0" }
-agnix-core = { path = "crates/agnix-core", version = "0.52.0" }
+agnix-rules = { path = "crates/agnix-rules", version = "0.52.1" }
+agnix-core = { path = "crates/agnix-core", version = "0.52.1" }
 
 # Core dependencies
 serde = { version = "1", features = ["derive"] }

--- a/editors/jetbrains/gradle.properties
+++ b/editors/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.agnix
 pluginName = agnix
 pluginRepositoryUrl = https://github.com/agent-sh/agnix
 # SemVer format -> https://semver.org
-pluginVersion = 0.52.0
+pluginVersion = 0.52.1
 
 # Supported build number ranges and IntelliJ Platform Versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agnix",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agnix",
-      "version": "0.52.0",
+      "version": "0.52.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "agnix",
   "displayName": "agnix - Agent Config Linter",
   "description": "Real-time validation for AI agent configuration files. Validates SKILL.md, CLAUDE.md, AGENTS.md, MCP configs, hooks, and more.",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "publisher": "avifenesh",
   "repository": {
     "type": "git",

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "agnix"
 name = "Agnix"
-version = "0.52.0"
+version = "0.52.1"
 schema_version = 1
 authors = ["Avi Fenesh <avifenesh@gmail.com>"]
 description = "Linter for agent configurations (skills, hooks, memory, plugins, MCP)"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more.",
   "keywords": [
     "agent",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agnix",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "Lint agent configurations before they break your workflow. 454 rules for Skills, Hooks, MCP, Memory, Plugins.",
   "author": {
     "name": "Avi Fenesh",

--- a/pypi/agnix/__init__.py
+++ b/pypi/agnix/__init__.py
@@ -13,7 +13,7 @@ import sysconfig
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-__version__ = "0.52.0"
+__version__ = "0.52.1"
 
 __all__ = ["AgnixError", "binary_path", "lint", "run", "version", "__version__"]
 

--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agnix"
-version = "0.52.0"
+version = "0.52.1"
 description = "Linter for AI agent configurations. Validates SKILL.md, CLAUDE.md, hooks, MCP, and more."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@
 # name is deliberately different so the two can never collide on PyPI.
 [project]
 name = "agnix-pre-commit"
-version = "0.52.0"
+version = "0.52.1"
 description = "pre-commit shim that installs the agnix wheel. Not published to PyPI."
 requires-python = ">=3.9"
-dependencies = ["agnix==0.52.0"]
+dependencies = ["agnix==0.52.1"]
 
 [build-system]
 requires = ["setuptools>=61"]


### PR DESCRIPTION
Patch release. Tag `v0.52.1` after merge.

**Only change: the pre-commit file-pattern fix (#1446, closes #1444 + #1445).** The hooks now pass every tool-scoped config path agnix validates - nested skills, plugin manifests, `.cursorrules`, `.claude/rules`, `.codex/config.*`, `opencode.json`, the `.cursor`/`.kiro`/`.roo`/`.windsurf`/`.gemini`/`.amp` surfaces - instead of a root-anchored subset that silently skipped nearly everything. Verified against the 149 concrete paths in detection.rs's own tests.

No rule changes, no binary changes; the tag exists so pre-commit users can pin a rev that carries the pattern (`docs/CONFIGURATION.md` examples already point at v0.52.1).

`sync-versions.sh` propagated 0.52.1 to all manifests including the shim's `agnix==` pin (CI-guarded). 26 pypi tests green, `cargo check` clean, bookkeeping in sync.