### PR TITLE
fix(action): make the documented @v0 ref exist and track releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -249,7 +249,10 @@ jobs:
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           MAJOR="v${VERSION%%.*}"
-          git tag -f "$MAJOR" "$GITHUB_SHA"
+          # Peel to the commit: on an annotated tag push GITHUB_SHA is the tag
+          # object, and tagging it directly would nest v0 -> tag -> commit.
+          COMMIT="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          git tag -f "$MAJOR" "$COMMIT"
           git push -f origin "refs/tags/$MAJOR"
 
       - name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Keep the floating major tag on the latest release so the documented
+      # `uses: agent-sh/agnix@v0` keeps resolving. The tag did not exist at all
+      # until 2026-08-27 - every user who copied the README's GitHub Action
+      # snippet got "unable to resolve action agent-sh/agnix@v0" - and nothing
+      # here moved it, so it would have gone stale immediately once created.
+      - name: Update floating major tag
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR="v${VERSION%%.*}"
+          git tag -f "$MAJOR" "$GITHUB_SHA"
+          git push -f origin "refs/tags/$MAJOR"
+
       - name: Publish release
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,9 @@ jobs:
       # snippet got "unable to resolve action agent-sh/agnix@v0" - and nothing
       # here moved it, so it would have gone stale immediately once created.
       - name: Update floating major tag
+        # Skip prereleases, like every publisher job: a v0.53.0-beta.1 tag
+        # must not move @v0 onto beta code for action users.
+        if: ${{ !contains(github.ref, '-') }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`uses: agent-sh/agnix@v0` did not resolve**. The README, configuration
+  guide, and marketplace snippet all instruct `agent-sh/agnix@v0`, but no `v0`
+  tag or branch has ever existed - every user who copied the documented GitHub
+  Action snippet got "unable to resolve action". The repo's own CI never
+  noticed because it exercises the action as `uses: ./`. The floating tag now
+  exists (pointing at v0.52.1) and the release workflow force-moves it to each
+  new release commit, so the documented ref tracks the latest release the way
+  major-version action tags are expected to.
+
+### Fixed
 - **Homebrew tap was 34 releases behind**. `brew install agnix` built v0.18.0
   from source because nothing told the tap about new releases: the tap's
   `update-formula.yml` listens for a `release-published` dispatch that the main


### PR DESCRIPTION
Found in the same finalization sweep as #1449.

**`uses: agent-sh/agnix@v0` has never resolved.** The README's GitHub Action snippet, four examples in `docs/CONFIGURATION.md`, and the marketplace listing all instruct `@v0` - but no `v0` tag or branch exists in the repo's history. Every user who copied the documented snippet got:

```
Error: Unable to resolve action agent-sh/agnix@v0, unable to find version v0
```

The repo's own CI never caught it because the `agnix` job exercises the action as `uses: ./`.

## Fix, in two parts

1. **Already live:** created the floating `v0` tag at the v0.52.1 release commit and verified it resolves with a fresh `git fetch origin v0` from an empty clone. The documented snippet works as of now.
2. **This PR:** the `release` job force-moves the floating major tag (`v${major}`) to each release commit before publishing, so the ref tracks the latest release the way major-version action tags are expected to. Shell derivation tested for both `v0.52.1 -> v0` and a future `v1.2.3 -> v1`. The job already has `contents: write` and a full checkout - no new permissions, no new secrets.