### PR TITLE
fix(release): only semver-shaped tags trigger the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,13 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Semver-shaped tags only. The floating major tag (v0, moved by the
+      # release job itself for `uses: agent-sh/agnix@v0`) must not trigger a
+      # release: a manual v0 push on 2026-08-27 ran the whole pipeline with
+      # version "0" - the semver guards stopped crates.io/npm/PyPI/VS Code,
+      # but a junk GitHub release, a junk Zed PR, and a version-"0" JetBrains
+      # marketplace upload all went through before cleanup.
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Floating `v0` tag pushes no longer trigger the release pipeline**. The
+  release workflow matched every `v*` tag, so the manually pushed floating
+  action tag ran the entire pipeline with version "0": the semver verification
+  guards stopped crates.io, npm, PyPI, and VS Code, but a junk GitHub release
+  was created, a junk Zed update PR was opened, and a version-"0" plugin update
+  reached the JetBrains marketplace (all three cleaned up the same day; the
+  marketplace update was deleted via the vendor API). The trigger now matches
+  only semver-shaped tags (`v[0-9]*.[0-9]*.[0-9]*`), which the automated
+  floating-tag move never produces - and that move uses `GITHUB_TOKEN`, whose
+  events do not start workflows anyway.
+
+### Fixed
 - **`uses: agent-sh/agnix@v0` did not resolve**. The README, configuration
   guide, and marketplace snippet all instruct `agent-sh/agnix@v0`, but no `v0`
   tag or branch has ever existed - every user who copied the documented GitHub


### PR DESCRIPTION
Incident follow-up from today: pushing the floating `v0` action tag (created in #1450 for `uses: agent-sh/agnix@v0`) matched the `v*` trigger and ran the whole release pipeline with version "0".

**What the guards caught:** crates.io, npm, PyPI, VS Code, and version-docs all failed on their semver checks.
**What got through (all cleaned up today):**
- a junk `v0` GitHub release with 33 assets - deleted, tag kept
- a junk "Update agnix to v0" PR in the Zed fork - closed
- a **version-"0" plugin update on the JetBrains marketplace** - deleted via the vendor API (update id 1154056); marketplace now lists 0.52.1 as latest

**The fix:** the trigger becomes `v[0-9]*.[0-9]*.[0-9]*` - two dots required, so `v0`/`v1` never match while `v0.52.1` and `v0.53.0-beta.1` still do. The automated floating-tag move from #1450 is doubly safe: it pushes with `GITHUB_TOKEN`, whose events never start workflow runs; this guard covers any future *manual* push.